### PR TITLE
Add CI workflow badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-Test 
+Test
 # MuseumBuddyApp
+
+![CI](https://github.com/<user>/MuseumBuddyApp/actions/workflows/ci.yml/badge.svg)
+
+Deze CI-workflow voert de tests van het project uit zodat de badge de status van de build weergeeft.


### PR DESCRIPTION
## Summary
- add CI status badge for `ci.yml` workflow
- mention workflow runs project tests

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b018a761b08326bc3d488710042dbb