### PR TITLE
Add basic page layout with header and placeholder

### DIFF
--- a/museum-buddy-app/app/page.tsx
+++ b/museum-buddy-app/app/page.tsx
@@ -1,7 +1,19 @@
 export default function Home() {
   return (
-    <main className="p-4">
-      Welcome to Museum Buddy App
-    </main>
+    <>
+      <header className="bg-blue-100 p-4">
+        <h1 className="text-2xl font-bold">Museum Buddy App</h1>
+        <nav className="mt-2 flex space-x-4">
+          <a href="#" className="text-blue-700 hover:underline">Home</a>
+          <a href="#" className="text-blue-700 hover:underline">About</a>
+          <a href="#" className="text-blue-700 hover:underline">Contact</a>
+        </nav>
+      </header>
+      <main className="p-4">
+        <section className="mt-8 rounded border-2 border-dashed border-gray-300 p-8 text-gray-500">
+          Placeholder content goes here.
+        </section>
+      </main>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- add header with navigation to the home page
- include placeholder content section styled with Tailwind CSS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b031ad4efc8326a8613fe8ebdb55bc