### PR TITLE
Add responsive museum grid with mock data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+dist

--- a/components/MuseumCard.tsx
+++ b/components/MuseumCard.tsx
@@ -1,0 +1,17 @@
+interface Props {
+  name: string;
+  image: string;
+  description: string;
+}
+
+const MuseumCard: React.FC<Props> = ({ name, image, description }) => (
+  <div className="border rounded overflow-hidden shadow">
+    <img src={image} alt={name} className="w-full h-48 object-cover" />
+    <div className="p-4">
+      <h2 className="text-lg font-semibold mb-2">{name}</h2>
+      <p className="text-sm text-gray-700">{description}</p>
+    </div>
+  </div>
+);
+
+export default MuseumCard;

--- a/data/musea.json
+++ b/data/musea.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": 1,
+    "name": "Rijksmuseum",
+    "image": "/images/rijksmuseum.jpg",
+    "description": "Nationaal museum in Amsterdam met kunst en geschiedenis."
+  },
+  {
+    "id": 2,
+    "name": "Van Gogh Museum",
+    "image": "/images/vangogh.jpg",
+    "description": "Collectie schilderijen van Vincent van Gogh."
+  },
+  {
+    "id": 3,
+    "name": "Mauritshuis",
+    "image": "/images/mauritshuis.jpg",
+    "description": "Museum in Den Haag met Nederlandse meesterwerken."
+  }
+]

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "museum-buddy-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "echo \"No tests specified\""
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import MuseumCard from '../components/MuseumCard';
+import musea from '../data/musea.json';
+
+interface Museum {
+  id: number;
+  name: string;
+  image: string;
+  description: string;
+}
+
+export default function Home() {
+  const [query, setQuery] = useState('');
+
+  const filteredMusea = (musea as Museum[]).filter((m) =>
+    m.name.toLowerCase().includes(query.toLowerCase())
+  );
+
+  return (
+    <main className="p-4">
+      <header className="mb-4">
+        <h1 className="text-2xl font-bold mb-2">Musea</h1>
+        <input
+          type="text"
+          placeholder="Zoek museum..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="w-full p-2 border rounded"
+        />
+      </header>
+      <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {filteredMusea.map((museum) => (
+          <MuseumCard key={museum.id} {...museum} />
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx", "**/*.json"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold basic TypeScript project
- add museum card component and mock data
- create index page with header, search bar, and responsive grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0244cfd6c8326a92d0078b4e633c9