### PR TITLE
feat: add cross-platform components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 Test
 # MuseumBuddyApp
-
 ![CI](https://github.com/<user>/MuseumBuddyApp/actions/workflows/ci.yml/badge.svg)
-
 Deze CI-workflow voert de tests van het project uit zodat de badge de status van de build weergeeft.
+
+## Cross-platform structuur
+
+- `lib/` bevat pure JavaScript-logica. Deze modules kunnen zonder wijzigingen in React Native worden gebruikt.
+- `components/` bevat presentatiecomponenten. Ze zijn opgebouwd uit React Native-primitieven (`View`, `Text`) en hebben hun styling in aparte modules zoals `MuseumCard.styles.js`. Daardoor kunnen ze direct naar React Native worden overgezet.
+- Componenten vermijden HTML-specifieke tags, wat het hergebruik in React Native vereenvoudigt.

--- a/components/MuseumCard.jsx
+++ b/components/MuseumCard.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { formatMuseum } from '../lib/museums';
+import { styles } from './MuseumCard.styles';
+
+/**
+ * Presentation component that displays museum information.
+ * Uses React Native primitives so it can be ported to React Native without changes.
+ */
+export default function MuseumCard({ museum }) {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>{formatMuseum(museum)}</Text>
+    </View>
+  );
+}

--- a/components/MuseumCard.styles.js
+++ b/components/MuseumCard.styles.js
@@ -1,0 +1,22 @@
+import { StyleSheet } from 'react-native';
+
+/**
+ * Styles for MuseumCard component.
+ * Using React Native's StyleSheet for cross-platform compatibility.
+ */
+export const styles = StyleSheet.create({
+  card: {
+    padding: 16,
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+});

--- a/lib/museums.js
+++ b/lib/museums.js
@@ -1,0 +1,22 @@
+/**
+ * Logic functions for museum data.
+ * This module contains pure JavaScript that can be shared with React Native.
+ */
+
+/**
+ * Format a museum object for display.
+ * @param {{name: string, city: string}} museum
+ * @returns {string}
+ */
+export function formatMuseum(museum) {
+  return `${museum.name} – ${museum.city}`;
+}
+
+/**
+ * Example list of museums.
+ * Can be reused in React Native environments without modification.
+ */
+export const sampleMuseums = [
+  { name: 'Rijksmuseum', city: 'Amsterdam' },
+  { name: 'Louvre', city: 'Paris' },
+];


### PR DESCRIPTION
## Summary
- add reusable MuseumCard component with separated styling
- add shared museum logic module
- document cross-platform structure for React Native reuse

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b02451c1c083269cb01ad502b10a20