### PR TITLE
List museums on home page

### DIFF
--- a/musea.json
+++ b/musea.json
@@ -4,6 +4,7 @@
     "title": "Van Gogh Museum",
     "description": "Museum dedicated to the works of Vincent van Gogh.",
     "openingHours": "Daily 9:00-18:00",
+    "url": "https://www.vangoghmuseum.nl/",
     "images": [
       "https://via.placeholder.com/300x200?text=Van+Gogh+1",
       "https://via.placeholder.com/300x200?text=Van+Gogh+2"
@@ -14,6 +15,7 @@
     "title": "Rijksmuseum",
     "description": "National museum dedicated to arts and history in Amsterdam.",
     "openingHours": "Daily 9:00-17:00",
+    "url": "https://www.rijksmuseum.nl/",
     "images": [
       "https://via.placeholder.com/300x200?text=Rijksmuseum+1",
       "https://via.placeholder.com/300x200?text=Rijksmuseum+2"

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,8 +1,22 @@
-export default function Home() {
+import Link from 'next/link';
+import museaData from '../musea.json';
+
+export default function Home({ musea }) {
   return (
-    <main style={{ padding: 24, fontFamily: "system-ui, sans-serif" }}>
-      <h1>MuseumBuddy – het werkt!</h1>
-      <p>Build zonder TypeScript.</p>
+    <main style={{ padding: 24, fontFamily: 'system-ui, sans-serif' }}>
+      <h1>MuseumBuddy</h1>
+      <ul style={{ marginTop: 16 }}>
+        {musea.map(m => (
+          <li key={m.id} style={{ marginBottom: 8 }}>
+            <Link href={`/museum/${m.id}`}>{m.title}</Link>
+          </li>
+        ))}
+      </ul>
     </main>
   );
+}
+
+export async function getStaticProps() {
+  const musea = Array.isArray(museaData) ? museaData : (museaData.musea || []);
+  return { props: { musea } };
 }

--- a/pages/museum/[id].js
+++ b/pages/museum/[id].js
@@ -12,18 +12,25 @@ export default function MuseumPage({ museum }) {
     );
   }
 
+  const image = museum.image || (museum.images && museum.images[0]);
+
   return (
     <main style={{ padding: 24 }}>
       <p><Link href="/">&larr; Terug</Link></p>
       <h1>{museum.title}</h1>
-      {museum.image && (
+      {image && (
         <img
           alt={museum.title}
-          src={museum.image.startsWith('/') ? museum.image : `/` + museum.image}
+          src={image}
           style={{ maxWidth: 600, width: '100%', height: 'auto', display: 'block', marginTop: 16 }}
         />
       )}
       <p style={{ marginTop: 16 }}>{museum.description}</p>
+      {museum.openingHours && (
+        <p style={{ marginTop: 16 }}>
+          <strong>Openingstijden:</strong> {museum.openingHours}
+        </p>
+      )}
       {museum.url && (
         <p style={{ marginTop: 16 }}>
           <a href={museum.url} target="_blank" rel="noreferrer">Website</a>


### PR DESCRIPTION
## Summary
- List museums on the landing page with links to detail pages
- Enhance museum detail page to show image, opening hours, and website link
- Add website URLs to sample museum data

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: sh: 1: next: not found)
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/next)


------
https://chatgpt.com/codex/tasks/task_e_68b06a1a69f883269c5295e624c7e773