### PR TITLE
fix: merge package fields in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,20 +4,13 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "export": "next build && next export"
   },
   "engines": { "node": "20.x" },
   "dependencies": {
     "next": "14.2.3",
     "react": "18.2.0",
     "react-dom": "18.2.0"
-  }
-}
-{
-  "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "export": "next build && next export"
   }
 }


### PR DESCRIPTION
## Summary
- merge duplicate package.json objects into a single one
- include the `export` command in the scripts block

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@swc%2fcounter)*

------
https://chatgpt.com/codex/tasks/task_e_68b59605e95483268e21cbde5051a5d2