### PR TITLE
refactor: remove TypeScript syntax from MuseumCard

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -1,17 +1,13 @@
-interface Props {
-  name: string;
-  image: string;
-  description: string;
-}
-
-const MuseumCard: React.FC<Props> = ({ name, image, description }) => (
-  <div className="border rounded overflow-hidden shadow">
-    <img src={image} alt={name} className="w-full h-48 object-cover" />
-    <div className="p-4">
-      <h2 className="text-lg font-semibold mb-2">{name}</h2>
-      <p className="text-sm text-gray-700">{description}</p>
+function MuseumCard({ name, image, description }) {
+  return (
+    <div className="border rounded overflow-hidden shadow">
+      <img src={image} alt={name} className="w-full h-48 object-cover" />
+      <div className="p-4">
+        <h2 className="text-lg font-semibold mb-2">{name}</h2>
+        <p className="text-sm text-gray-700">{description}</p>
+      </div>
     </div>
-  </div>
-);
+  );
+}
 
 export default MuseumCard;


### PR DESCRIPTION
## Summary
- convert `MuseumCard` to plain JavaScript by removing interface and React.FC typing

## Testing
- `npm test` *(fails: JSON.parse Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5960b7c008326a73e54658bba1e2c