### PR TITLE
Use dynamic museum link path

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -82,7 +82,12 @@ export default function Home({ musea }) {
             <div className="card-head">
               <div>
                 <h2 className="card-title">
-                  <Link className="link-accent" href={`/museum/${m.id}`}>{m.title}</Link>
+                  <Link
+                    className="link-accent"
+                    href={{ pathname: '/museum/[id]', query: { id: m.id } }}
+                  >
+                    {m.title}
+                  </Link>
                 </h2>
                 <p className="card-sub">{m.city}</p>
               </div>


### PR DESCRIPTION
## Summary
- update home page links to reference `/museum/[id]`

## Testing
- `npm install` *(fails: Unexpected non-whitespace character after JSON at position 277 while parsing package.json)*
- `npm run build` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5960a466c832689d682ef84515d2e