### PR TITLE
Fix invalid musea data causing deployment failures

### DIFF
--- a/musea.json
+++ b/musea.json
@@ -8,7 +8,7 @@
     "temporary": true,
     "tags": ["kunst", "nationale collectie"],
     "description": "Het nationale museum van Nederland met meesterwerken uit de Gouden Eeuw.",
-    "url": "https://www.rijksmuseum.nl"
+    "url": "https://www.rijksmuseum.nl",
     "image": "rijksmuseum.png"
   },
   {
@@ -20,8 +20,8 @@
     "temporary": true,
     "tags": ["kunst", "Van Gogh"],
     "description": "Grootste collectie werken van Vincent van Gogh.",
-    "url": "https://www.vangoghmuseum.nl"
-    "image": "public/vangogh.jpg"
+    "url": "https://www.vangoghmuseum.nl",
+    "image": "vangogh.jpg"
   },
   {
     "id": "stedelijk-museum",


### PR DESCRIPTION
## Summary
- fix JSON syntax errors in `musea.json`
- correct Van Gogh museum image path

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b596ee333c8326bbd4e55dbd71a210