### PR TITLE
feat: add Playfair and Roboto fonts

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,21 +1,27 @@
-import Head from 'next/head';
 import '../styles/globals.css';
 import Layout from '../components/Layout';
+import { Playfair_Display, Roboto } from 'next/font/google';
+
+const headingFont = Playfair_Display({
+  subsets: ['latin'],
+  variable: '--font-heading',
+  weight: ['400', '700'],
+  display: 'swap',
+});
+
+const bodyFont = Roboto({
+  subsets: ['latin'],
+  variable: '--font-body',
+  weight: ['400', '500', '700'],
+  display: 'swap',
+});
 
 export default function MyApp({ Component, pageProps }) {
   return (
-    <>
-      <Head>
-        <link rel="preconnect" href="https://fonts.googleapis.com"/>
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous"/>
-        <link
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
-          rel="stylesheet"
-        />
-      </Head>
+    <div className={`${headingFont.variable} ${bodyFont.variable}`}>
       <Layout>
         <Component {...pageProps} />
       </Layout>
-    </>
+    </div>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -11,7 +11,14 @@
 *{ box-sizing:border-box }
 html, body { padding:0; margin:0; background:var(--bg); color:var(--text); }
 body {
-  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  font-family: var(--font-body), system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  font-weight: 400;
+  line-height: 1.6;
+}
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading), serif;
+  font-weight: 700;
+  line-height: 1.3;
 }
 a { color: inherit; text-decoration: none; }
 img { max-width: 100%; height: auto; display: block; }


### PR DESCRIPTION
## Summary
- switch to Playfair Display and Roboto via `next/font`
- expose fonts as CSS variables and apply globally

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Failed to fetch Google Fonts; network unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ac435a108326ba6ceaa41841c352