### PR TITLE
feat: use Quicksand font across app

### DIFF
--- a/components/MuseumCard.styles.js
+++ b/components/MuseumCard.styles.js
@@ -18,5 +18,6 @@ export const styles = StyleSheet.create({
   title: {
     fontSize: 16,
     fontWeight: 'bold',
+    fontFamily: 'Quicksand',
   },
 });

--- a/museum-buddy-app/app/layout.js
+++ b/museum-buddy-app/app/layout.js
@@ -1,8 +1,8 @@
 import './globals.css'
-import { Inter } from 'next/font/google'
+import { Quicksand } from 'next/font/google'
 import type { Metadata } from 'next'
 
-const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
+const quicksand = Quicksand({ subsets: ['latin'], variable: '--font-quicksand', weight: ['400','500','700'], display: 'swap' })
 
 export const metadata: Metadata = {
   title: 'Museum Buddy App',
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className={inter.variable}>{children}</body>
+      <body className={quicksand.variable}>{children}</body>
     </html>
   )
 }

--- a/museum-buddy-app/tailwind.config.js
+++ b/museum-buddy-app/tailwind.config.js
@@ -14,7 +14,7 @@ module.exports = {
         },
       },
       fontFamily: {
-        sans: ['var(--font-inter)', ...defaultTheme.fontFamily.sans],
+        sans: ['var(--font-quicksand)', ...defaultTheme.fontFamily.sans],
       },
     },
   },

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,15 +1,15 @@
 import '../styles/globals.css';
 import Layout from '../components/Layout';
-import { Playfair_Display, Roboto } from 'next/font/google';
+import { Quicksand } from 'next/font/google';
 
-const headingFont = Playfair_Display({
+const headingFont = Quicksand({
   subsets: ['latin'],
   variable: '--font-heading',
-  weight: ['400', '700'],
+  weight: ['400', '500', '700'],
   display: 'swap',
 });
 
-const bodyFont = Roboto({
+const bodyFont = Quicksand({
   subsets: ['latin'],
   variable: '--font-body',
   weight: ['400', '500', '700'],

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 :root {
   --color-warm-yellow: #FFC107;
   --color-deep-blue: #1976D2;
-  --font-sans: 'Roboto', 'Helvetica', 'Arial', sans-serif;
+  --font-sans: 'Quicksand', sans-serif;
 }
 
 body {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -11,12 +11,12 @@
 *{ box-sizing:border-box }
 html, body { padding:0; margin:0; background:var(--bg); color:var(--text); }
 body {
-  font-family: var(--font-body), system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  font-family: var(--font-body), system-ui, -apple-system, Segoe UI, Ubuntu, Cantarell, Noto Sans, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
   font-weight: 400;
   line-height: 1.6;
 }
 h1, h2, h3, h4, h5, h6 {
-  font-family: var(--font-heading), serif;
+  font-family: var(--font-heading), sans-serif;
   font-weight: 700;
   line-height: 1.3;
 }

--- a/z_parked/index.html
+++ b/z_parked/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/style.css" />
   <title>MuseumBuddyApp</title>
 </head>


### PR DESCRIPTION
## Summary
- use Quicksand as global font via Next.js and Tailwind config
- update legacy styles and static HTML to load Quicksand
- remove references to Roboto, Inter and Playfair

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build` *(fails: Failed to fetch font `Quicksand`)*
- `(cd museum-buddy-app && npm test)` *(fails: Missing script "test" )*
- `(cd museum-buddy-app && npm run build)` *(fails: Expected ',' got '{')*


------
https://chatgpt.com/codex/tasks/task_e_68b80e518844832693a4c977df4bef45