### PR TITLE
Use black on white color scheme

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 :root {
-  --color-warm-yellow: #FFC107;
-  --color-deep-blue: #1976D2;
+  --color-warm-yellow: #FFFFFF;
+  --color-deep-blue: #000000;
   --font-sans: 'Quicksand', sans-serif;
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,11 +1,11 @@
 :root{
-  --bg:#fdfbf7;          /* zachte achtergrondkleur */
-  --text:#111111;
+  --bg:#ffffff;          /* zachte achtergrondkleur */
+  --text:#000000;
   --muted:#6b7280;       /* grijs voor subtitels */
   --border:#e5e7eb;      /* subtiele randen */
-  --accent:#b85c28;      /* warme accentkleur */
+  --accent:#000000;      /* warme accentkleur */
   --accent-ink:#ffffff;
-  --chip-bg:#fff4ed;     /* lichte achtergrond voor chips/badges */
+  --chip-bg:#f0f0f0;     /* lichte achtergrond voor chips/badges */
 }
 
 *{ box-sizing:border-box }


### PR DESCRIPTION
## Summary
- replace warm yellow and blue theme variables with black text on white background
- set global accent color to black and neutral chip background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch Quicksand font)*

------
https://chatgpt.com/codex/tasks/task_e_68b81215f1408326ac456ccfe2d008d3