### PR TITLE
Use Quicksand font globally

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,23 +2,17 @@ import '../styles/globals.css';
 import Layout from '../components/Layout';
 import { Quicksand } from 'next/font/google';
 
-const headingFont = Quicksand({
+// Load Quicksand and expose it as a CSS variable so it can be used globally
+const quicksand = Quicksand({
   subsets: ['latin'],
-  variable: '--font-heading',
-  weight: ['400', '500', '700'],
-  display: 'swap',
-});
-
-const bodyFont = Quicksand({
-  subsets: ['latin'],
-  variable: '--font-body',
+  variable: '--font-quicksand',
   weight: ['400', '500', '700'],
   display: 'swap',
 });
 
 export default function MyApp({ Component, pageProps }) {
   return (
-    <div className={`${headingFont.variable} ${bodyFont.variable}`}>
+    <div className={quicksand.variable}>
       <Layout>
         <Component {...pageProps} />
       </Layout>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -11,12 +11,12 @@
 *{ box-sizing:border-box }
 html, body { padding:0; margin:0; background:var(--bg); color:var(--text); }
 body {
-  font-family: var(--font-body), system-ui, -apple-system, Segoe UI, Ubuntu, Cantarell, Noto Sans, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  font-family: var(--font-quicksand), system-ui, -apple-system, Segoe UI, Ubuntu, Cantarell, Noto Sans, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
   font-weight: 400;
   line-height: 1.6;
 }
 h1, h2, h3, h4, h5, h6 {
-  font-family: var(--font-heading), sans-serif;
+  font-family: var(--font-quicksand), sans-serif;
   font-weight: 700;
   line-height: 1.3;
 }


### PR DESCRIPTION
## Summary
- load Quicksand once and expose as CSS variable
- apply Quicksand to body and headings for consistent typography

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch font `Quicksand`)*

------
https://chatgpt.com/codex/tasks/task_e_68b8130e761c8326b5653d6893a1f602