### PR TITLE
Rename Hermitage Amsterdam to H’ART Museum

### DIFF
--- a/musea.json
+++ b/musea.json
@@ -84,15 +84,15 @@
     "image": "/images/amsterdammuseum.jpg"
   },
   {
-    "id": "hermitage-amsterdam",
-    "title": "Hermitage Amsterdam",
+    "id": "hart-museum",
+    "title": "H’ART Museum",
     "city": "Amsterdam",
     "free": false,
     "kidFriendly": true,
     "temporary": true,
     "tags": ["kunst", "culture"],
-    "description": "Dependance van de Hermitage met wisselende exposities.",
-    "url": "https://www.hermitage.nl",
+    "description": "Museum met wisselende exposities in het voormalige Hermitage-gebouw.",
+    "url": "https://www.hartmuseum.nl",
     "image": "/images/hermitage.jpg"
   },
   {


### PR DESCRIPTION
## Summary
- rename "Hermitage Amsterdam" entry to "H’ART Museum"
- update description and URL for the renamed museum

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch font `Quicksand`, build aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68b815ed03ac8326929725d5d8347ee0