### PR TITLE
Use Quicksand font for descriptions and tags

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -102,7 +102,11 @@ export default function Home({ musea }) {
               </div>
             </div>
 
-            {m.description && <p style={{ marginTop: 10 }}>{m.description}</p>}
+            {m.description && (
+              <p className="description" style={{ marginTop: 10 }}>
+                {m.description}
+              </p>
+            )}
               
 
 

--- a/pages/museum/[id].js
+++ b/pages/museum/[id].js
@@ -37,7 +37,11 @@ export default function MuseumPage({ museum }) {
         {museum.temporary && <span className="chip">Tijdelijk</span>}
       </div>
 
-      {museum.description && <p style={{ marginTop: 16 }}>{museum.description}</p>}
+      {museum.description && (
+        <p className="description" style={{ marginTop: 16 }}>
+          {museum.description}
+        </p>
+      )}
 
       {museum.url && (
         <p style={{ marginTop: 16 }}>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -62,7 +62,15 @@ img { max-width: 100%; height: auto; display: block; }
   font-size: 12px; padding: 4px 10px; border-radius: 999px;
   border: 1px solid var(--accent); background: var(--chip-bg); color: var(--accent);
 }
-.tag { color: var(--muted); margin-right: 8px; }
+.tag {
+  color: var(--muted);
+  margin-right: 8px;
+  font-family: var(--font-quicksand), sans-serif;
+}
+
+.description {
+  font-family: var(--font-quicksand), sans-serif;
+}
 
 /* Cards grid */
 .grid { display:grid; gap: 16px; }


### PR DESCRIPTION
## Summary
- ensure tag elements use the Quicksand typeface
- apply Quicksand font to museum descriptions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch font `Quicksand`)*

------
https://chatgpt.com/codex/tasks/task_e_68b826d9ed94832689b1bf3633fe7f2f