### PR TITLE
Use photo as card with overlay info

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -69,55 +69,45 @@ export default function Home({ musea }) {
 
       {/* Grid met kaarten */}
       <ul className="grid" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-        {filtered.map(m => (
-          <li key={m.id} className="card">
-          {m.image && (
-            <div className="card-img">
-              <Image
-                src={m.image.startsWith('/') ? m.image : `/${m.image}`}
-                alt={m.title}
-                fill
-                sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                style={{ objectFit: 'cover' }}
-              />
-            </div>
-          )}
-
-            <div className="card-head">
-              <div>
+          {filtered.map(m => (
+            <li key={m.id} className="card">
+              {m.image && (
+                <Image
+                  src={m.image.startsWith('/') ? m.image : `/${m.image}`}
+                  alt={m.title}
+                  fill
+                  sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                  style={{ objectFit: 'cover' }}
+                />
+              )}
+              <div className="card-info">
                 <h2 className="card-title">
                   <Link
-                    className="link-accent"
                     href={{ pathname: '/museum/[id]', query: { id: m.id } }}
                   >
                     {m.title}
                   </Link>
                 </h2>
                 <p className="card-sub">{m.city}</p>
+                <div className="chips">
+                  {m.free && <span className="chip">Gratis</span>}
+                  {m.kidFriendly && <span className="chip">Kindvriendelijk</span>}
+                  {m.temporary && <span className="chip">Tijdelijk</span>}
+                </div>
+                {m.description && (
+                  <p className="description" style={{ marginTop: 10 }}>
+                    {m.description}
+                  </p>
+                )}
+                {Array.isArray(m.tags) && m.tags.length > 0 && (
+                  <p style={{ marginTop: 8 }}>
+                    {m.tags.map(t => <span key={t} className="tag">#{t}</span>)}
+                  </p>
+                )}
               </div>
-              <div className="chips">
-                {m.free && <span className="chip">Gratis</span>}
-                {m.kidFriendly && <span className="chip">Kindvriendelijk</span>}
-                {m.temporary && <span className="chip">Tijdelijk</span>}
-              </div>
-            </div>
-
-            {m.description && (
-              <p className="description" style={{ marginTop: 10 }}>
-                {m.description}
-              </p>
-            )}
-              
-
-
-            {Array.isArray(m.tags) && m.tags.length > 0 && (
-              <p style={{ marginTop: 8 }}>
-                {m.tags.map(t => <span key={t} className="tag">#{t}</span>)}
-              </p>
-            )}
-          </li>
-        ))}
-      </ul>
+            </li>
+          ))}
+        </ul>
     </>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -78,16 +78,36 @@ img { max-width: 100%; height: auto; display: block; }
 @media (min-width: 1024px){ .grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
 
 .card {
-  border: 1px solid var(--border);
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
   border-radius: 16px;
-  padding: 24px;
-  transition: box-shadow .15s ease, transform .15s ease;
-  background:#fff;
+  overflow: hidden;
+  transition: transform .15s ease;
+  background: #f3f4f6;
 }
-.card:hover { box-shadow: 0 4px 20px rgba(0,0,0,.06); transform: translateY(-1px); }
-.card-head { display:flex; justify-content:space-between; align-items:baseline; gap:12px; flex-wrap:wrap; }
-.card-title { margin:0; font-size:18px; font-weight:600; }
+.card:hover { transform: translateY(-1px); }
+.card-title { margin:0; font-size:18px; font-weight:600; color:inherit; }
 .card-sub { margin:6px 0 0; color:var(--muted); }
+.card-info {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  padding: 16px;
+  color: #fff;
+  background: linear-gradient(to top, rgba(0,0,0,0.7), rgba(0,0,0,0));
+}
+.card-info .card-sub,
+.card-info .description,
+.card-info .tag {
+  color: #fff;
+}
+.card-info .chip {
+  border: 1px solid #fff;
+  background: rgba(0,0,0,0.4);
+  color: #fff;
+}
 
 /* Detail */
 .backlink { color: var(--accent); }
@@ -100,15 +120,6 @@ img { max-width: 100%; height: auto; display: block; }
 .link-accent { color: var(--accent); }
 
 /* Afbeeldingen */
-.card-img {
-  position: relative;
-  width: 100%;
-  aspect-ratio: 4 / 3;
-  border-radius: 12px;
-  overflow: hidden;
-  margin-bottom: 12px;
-  background: #f3f4f6;
-}
 
 .hero {
   position: relative;
@@ -120,7 +131,6 @@ img { max-width: 100%; height: auto; display: block; }
   background: #f3f4f6;
 }
 
-.card-img img,
 .hero img {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary
- Replace card layout so that each museum listing uses the photo as the frame and overlays information directly on it
- Style overlay text and chips in white for contrast on images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch `Quicksand` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b829c14234832682f114411d0d235b