### PR TITLE
Remove free, kid-friendly and temporary filters

### DIFF
--- a/musea.json
+++ b/musea.json
@@ -3,9 +3,6 @@
     "id": "rijksmuseum",
     "title": "Rijksmuseum",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": true,
     "tags": [
       "kunst",
       "nationale collectie"
@@ -18,9 +15,6 @@
     "id": "van-gogh-museum",
     "title": "Van Gogh Museum",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": true,
     "tags": [
       "kunst",
       "Van Gogh"
@@ -33,9 +27,6 @@
     "id": "stedelijk-museum",
     "title": "Stedelijk Museum",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": false,
-    "temporary": true,
     "tags": [
       "moderne kunst",
       "design"
@@ -48,9 +39,6 @@
     "id": "nemo-science-museum",
     "title": "NEMO Science Museum",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": true,
     "tags": [
       "science",
       "techniek",
@@ -64,9 +52,6 @@
     "id": "anne-frank-huis",
     "title": "Anne Frank Huis",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": false,
-    "temporary": false,
     "tags": [
       "geschiedenis",
       "oorlog"
@@ -79,9 +64,6 @@
     "id": "amsterdam-museum",
     "title": "Amsterdam Museum",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": false,
     "tags": [
       "geschiedenis",
       "Amsterdam"
@@ -94,9 +76,6 @@
     "id": "hart-museum",
     "title": "H’ART Museum",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": true,
     "tags": [
       "kunst",
       "culture"
@@ -109,9 +88,6 @@
     "id": "rembrandthuis",
     "title": "Museum Het Rembrandthuis",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": false,
     "tags": [
       "kunst",
       "Rembrandt"
@@ -124,9 +100,6 @@
     "id": "ons-lieve-heer-op-solder",
     "title": "Museum Ons' Lieve Heer op Solder",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": false,
-    "temporary": false,
     "tags": [
       "geschiedenis",
       "religie"
@@ -139,9 +112,6 @@
     "id": "wereldmuseum",
     "title": "Wereldmuseum",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": false,
     "tags": [
       "wereldculturen",
       "volkenkunde"
@@ -154,9 +124,6 @@
     "id": "eye-filmmuseum",
     "title": "Eye Filmmuseum",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": false,
     "tags": [
       "film",
       "media"
@@ -169,9 +136,6 @@
     "id": "scheepvaartmuseum",
     "title": "Het Scheepvaartmuseum",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": false,
     "tags": [
       "maritiem",
       "geschiedenis"
@@ -184,9 +148,6 @@
     "id": "foam",
     "title": "Foam Fotografiemuseum",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": true,
     "tags": [
       "fotografie",
       "kunst"
@@ -199,9 +160,6 @@
     "id": "moco-museum",
     "title": "Moco Museum",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": true,
     "tags": [
       "moderne kunst"
     ],
@@ -213,9 +171,6 @@
     "id": "joods-historisch-museum",
     "title": "Joods Historisch Museum",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": false,
     "tags": [
       "geschiedenis",
       "joods"
@@ -228,9 +183,6 @@
     "id": "allard-pierson",
     "title": "Allard Pierson Museum",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": false,
     "tags": [
       "archeologie",
       "geschiedenis"
@@ -243,9 +195,6 @@
     "id": "micropia",
     "title": "Micropia",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": false,
     "tags": [
       "science",
       "microben"
@@ -258,9 +207,6 @@
     "id": "museum-van-loon",
     "title": "Museum Van Loon",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": false,
-    "temporary": false,
     "tags": [
       "historisch huis",
       "grachten"
@@ -273,9 +219,6 @@
     "id": "museum-het-schip",
     "title": "Museum Het Schip",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": false,
     "tags": [
       "architectuur",
       "Amsterdamse School"
@@ -288,9 +231,6 @@
     "id": "straat-museum",
     "title": "STRAAT Museum",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": true,
     "tags": [
       "street art"
     ],
@@ -302,9 +242,6 @@
     "id": "nxt-museum",
     "title": "Nxt Museum",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": true,
     "tags": [
       "digitale kunst"
     ],
@@ -316,9 +253,6 @@
     "id": "kattenkabinet",
     "title": "KattenKabinet",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": false,
     "tags": [
       "kunst",
       "katten"
@@ -331,9 +265,6 @@
     "id": "grachtenmuseum",
     "title": "Het Grachtenmuseum",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": false,
     "tags": [
       "geschiedenis",
       "grachten"
@@ -346,9 +277,6 @@
     "id": "woonbootmuseum",
     "title": "Woonbootmuseum",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": false,
     "tags": [
       "woonboot",
       "grachten"
@@ -361,9 +289,6 @@
     "id": "amsterdam-tulip-museum",
     "title": "Amsterdam Tulip Museum",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": false,
     "tags": [
       "bloemen",
       "geschiedenis"
@@ -376,9 +301,6 @@
     "id": "body-worlds",
     "title": "Body Worlds",
     "city": "Amsterdam",
-    "free": false,
-    "kidFriendly": true,
-    "temporary": true,
     "tags": [
       "anatomie",
       "lichaam"

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,9 +11,6 @@ export async function getStaticProps() {
 
 export default function Home({ musea }) {
   const [query, setQuery] = useState('');
-  const [onlyFree, setOnlyFree] = useState(false);
-  const [onlyKids, setOnlyKids] = useState(false);
-  const [onlyTemporary, setOnlyTemporary] = useState(false);
   const cities = useMemo(() => Array.from(new Set(musea.map(m => m.city))).sort(), [musea]);
   const [city, setCity] = useState('');
 
@@ -26,14 +23,11 @@ export default function Home({ musea }) {
         (m.city && m.city.toLowerCase().includes(q)) ||
         (Array.isArray(m.tags) && m.tags.join(' ').toLowerCase().includes(q));
 
-      const matchesFree = !onlyFree || Boolean(m.free);
-      const matchesKids = !onlyKids || Boolean(m.kidFriendly);
-      const matchesTemp = !onlyTemporary || Boolean(m.temporary);
       const matchesCity = !city || m.city === city;
 
-      return matchesQuery && matchesFree && matchesKids && matchesTemp && matchesCity;
+      return matchesQuery && matchesCity;
     });
-  }, [musea, query, onlyFree, onlyKids, onlyTemporary, city]);
+  }, [musea, query, city]);
 
   return (
     <>
@@ -49,12 +43,6 @@ export default function Home({ musea }) {
           placeholder="Zoek op naam, stad of tag…"
           type="search"
         />
-
-        <div className="control-row">
-          <label className="checkbox"><input type="checkbox" checked={onlyFree} onChange={(e) => setOnlyFree(e.target.checked)} /> Gratis toegankelijk</label>
-          <label className="checkbox"><input type="checkbox" checked={onlyKids} onChange={(e) => setOnlyKids(e.target.checked)} /> Kindvriendelijk</label>
-          <label className="checkbox"><input type="checkbox" checked={onlyTemporary} onChange={(e) => setOnlyTemporary(e.target.checked)} /> Tijdelijke exposities</label>
-        </div>
 
         <div className="control-row">
           <select className="select" value={city} onChange={(e) => setCity(e.target.value)} style={{ maxWidth: 260 }}>
@@ -89,11 +77,6 @@ export default function Home({ musea }) {
                   </Link>
                 </h2>
                 <p className="card-sub">{m.city}</p>
-                <div className="chips">
-                  {m.free && <span className="chip">Gratis</span>}
-                  {m.kidFriendly && <span className="chip">Kindvriendelijk</span>}
-                  {m.temporary && <span className="chip">Tijdelijk</span>}
-                </div>
                 {m.description && (
                   <p className="description" style={{ marginTop: 10 }}>
                     {m.description}

--- a/pages/museum/[id].js
+++ b/pages/museum/[id].js
@@ -30,13 +30,6 @@ export default function MuseumPage({ museum }) {
         />
       </div>
     )}
-
-      <div className="chips" style={{ marginTop: 8 }}>
-        {museum.free && <span className="chip">Gratis</span>}
-        {museum.kidFriendly && <span className="chip">Kindvriendelijk</span>}
-        {museum.temporary && <span className="chip">Tijdelijk</span>}
-      </div>
-
       {museum.description && (
         <p className="description" style={{ marginTop: 16 }}>
           {museum.description}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,7 +5,6 @@
   --border:#e5e7eb;      /* subtiele randen */
   --accent:#000000;      /* warme accentkleur */
   --accent-ink:#ffffff;
-  --chip-bg:#f0f0f0;     /* lichte achtergrond voor chips/badges */
 }
 
 *{ box-sizing:border-box }
@@ -56,12 +55,7 @@ img { max-width: 100%; height: auto; display: block; }
   background:#f8fafc; cursor:pointer; font-size:14px;
 }
 
-/* Chips/badges */
-.chips { display:flex; gap:8px; flex-wrap:wrap; }
-.chip {
-  font-size: 12px; padding: 4px 10px; border-radius: 999px;
-  border: 1px solid var(--accent); background: var(--chip-bg); color: var(--accent);
-}
+/* Tags */
 .tag {
   color: var(--muted);
   margin-right: 8px;
@@ -101,11 +95,6 @@ img { max-width: 100%; height: auto; display: block; }
 .card-info .card-sub,
 .card-info .description,
 .card-info .tag {
-  color: #fff;
-}
-.card-info .chip {
-  border: 1px solid #fff;
-  background: rgba(0,0,0,0.4);
   color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- drop `free`, `kidFriendly`, and `temporary` properties from museum data
- remove related filter controls and chips from the UI
- clean up unused chip styling

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b82debf278832695f7fe9b7c3d8132