### PR TITLE
feat: add museum listing card component

### DIFF
--- a/components/MuseumListingCard.jsx
+++ b/components/MuseumListingCard.jsx
@@ -1,0 +1,42 @@
+import Image from 'next/image';
+import styles from './MuseumListingCard.module.css';
+
+/**
+ * Card component for displaying a single museum.
+ * Renders a photo with share and favorite actions and a text section.
+ */
+export default function MuseumListingCard({ title, location, image }) {
+  return (
+    <div className={styles.card}>
+      <div className={styles.imageWrapper}>
+        <Image src={image} alt={title} fill sizes="(max-width: 600px) 100vw, 400px" className={styles.image} />
+        <div className={styles.actions}>
+          <button className={styles.iconButton} aria-label="Deel">
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="18" cy="5" r="3" />
+              <circle cx="6" cy="12" r="3" />
+              <circle cx="18" cy="19" r="3" />
+              <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+              <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+            </svg>
+          </button>
+          <button className={styles.iconButton} aria-label="Favoriet">
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div className={styles.content}>
+        <h3 className={styles.title}>{title}</h3>
+        <div className={styles.location}>
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={styles.pin}>
+            <path d="M21 10c0 5.25-9 13-9 13s-9-7.75-9-13a9 9 0 1 1 18 0z" />
+            <circle cx="12" cy="10" r="3" />
+          </svg>
+          <span className={styles.locationText}>{location}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/MuseumListingCard.module.css
+++ b/components/MuseumListingCard.module.css
@@ -1,0 +1,66 @@
+.card {
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+  background: #fff;
+  width: 320px;
+}
+
+.imageWrapper {
+  position: relative;
+  aspect-ratio: 3 / 2;
+}
+
+.image {
+  object-fit: cover;
+}
+
+.actions {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: flex;
+  gap: 8px;
+}
+
+.iconButton {
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255,255,255,0.7);
+  backdrop-filter: blur(4px);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.15);
+  cursor: pointer;
+}
+
+.content {
+  padding: 20px;
+  background: #f9f9f9;
+}
+
+.title {
+  margin: 0 0 16px;
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.location {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #666;
+  font-size: 16px;
+}
+
+.locationText {
+  display: block;
+}
+
+.pin {
+  flex-shrink: 0;
+}

--- a/pages/card-demo.js
+++ b/pages/card-demo.js
@@ -1,0 +1,13 @@
+import MuseumListingCard from '../components/MuseumListingCard';
+
+export default function CardDemo() {
+  return (
+    <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', background:'#f0f0f0' }}>
+      <MuseumListingCard
+        title="1646 Experimental Art Space"
+        location="1646 Experimental Art Space, Den Haag"
+        image="/images/Amsterdam Museum.webp"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add MuseumListingCard component with image, share, and favorite actions
- style card with glassmorphic icon buttons and location row
- include demo page to showcase card

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch font `Quicksand`)*

------
https://chatgpt.com/codex/tasks/task_e_68b83f13d6748326b25151813b971cda