### PR TITLE
feat: add redesigned museum card

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -1,13 +1,51 @@
-function MuseumCard({ name, image, description }) {
+import Link from 'next/link';
+import Image from 'next/image';
+
+export default function MuseumCard({ museum }) {
   return (
-    <div className="border rounded overflow-hidden shadow">
-      <img src={image} alt={name} className="w-full h-48 object-cover" />
-      <div className="p-4">
-        <h2 className="text-lg font-semibold mb-2">{name}</h2>
-        <p className="text-sm text-gray-700">{description}</p>
+    <article className="museum-card">
+      <div className="museum-card-image">
+        <Link
+          href={{ pathname: '/museum/[id]', query: { id: museum.id } }}
+          style={{ display: 'block', width: '100%', height: '100%', position: 'relative' }}
+          aria-label={`Bekijk ${museum.title}`}
+        >
+          {museum.image && (
+            <Image
+              src={museum.image.startsWith('/') ? museum.image : `/${museum.image}`}
+              alt={museum.title}
+              fill
+              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+              style={{ objectFit: 'cover' }}
+            />
+          )}
+        </Link>
+        <div className="museum-card-actions">
+          <button className="icon-button" aria-label="Deel">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7" />
+              <path d="M16 6l-4-4-4 4" />
+              <path d="M12 2v14" />
+            </svg>
+          </button>
+          <button className="icon-button" aria-label="Bewaar">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M21 8.25c0 4.556-9 11.25-9 11.25S3 12.806 3 8.25a5.25 5.25 0 0 1 9-3.676A5.25 5.25 0 0 1 21 8.25Z" />
+            </svg>
+          </button>
+        </div>
       </div>
-    </div>
+      <div className="museum-card-info">
+        <h3 className="museum-card-title">{museum.title}</h3>
+        <p className="museum-card-location">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 11.25a2.25 2.25 0 1 0 0-4.5 2.25 2.25 0 0 0 0 4.5Z" />
+            <path d="M12 21s-7.5-7.048-7.5-11.25a7.5 7.5 0 1 1 15 0C19.5 13.952 12 21 12 21Z" />
+          </svg>
+          {museum.title}, {museum.city}
+        </p>
+      </div>
+    </article>
   );
 }
 
-export default MuseumCard;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,8 +1,7 @@
    // vercel ping
 import { useMemo, useState } from 'react';
-import Link from 'next/link';
-import Image from 'next/image';
 import museaData from '../musea.json';
+import MuseumCard from '../components/MuseumCard';
 
 export async function getStaticProps() {
   const musea = Array.isArray(museaData) ? museaData : (museaData.musea || []);
@@ -58,44 +57,8 @@ export default function Home({ musea }) {
         {/* Grid met kaarten */}
         <ul className="grid" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
           {filtered.map(m => (
-            <li key={m.id} className="card">
-              <Link
-                href={{ pathname: '/museum/[id]', query: { id: m.id } }}
-                aria-label={`Bekijk ${m.title}`}
-                className="card-link"
-                style={{ display: 'block', width: '100%', height: '100%', position: 'relative' }}
-              >
-                {m.image && (
-                  <Image
-                    src={m.image.startsWith('/') ? m.image : `/${m.image}`}
-                    alt={m.title}
-                    fill
-                    sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                    style={{ objectFit: 'cover' }}
-                  />
-                )}
-                <div className="card-info">
-                  <h2 className="card-title">{m.title}</h2>
-                  <p className="card-sub">{m.city}</p>
-                  <div className="chips">
-                    {m.free && <span className="chip">Gratis</span>}
-                    {m.kidFriendly && <span className="chip">Kindvriendelijk</span>}
-                    {m.temporary && <span className="chip">Tijdelijk</span>}
-                  </div>
-                  {m.description && (
-                    <p className="description" style={{ marginTop: 10 }}>
-                      {m.description}
-                    </p>
-                  )}
-                  {Array.isArray(m.tags) && m.tags.length > 0 && (
-                    <p style={{ marginTop: 8 }}>
-                      {m.tags.map(t => (
-                        <span key={t} className="tag">#{t}</span>
-                      ))}
-                    </p>
-                  )}
-                </div>
-              </Link>
+            <li key={m.id}>
+              <MuseumCard museum={m} />
             </li>
           ))}
         </ul>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -126,3 +126,61 @@ img { max-width: 100%; height: auto; display: block; }
   object-fit: cover;
   display: block;
 }
+
+/* MuseumCard component */
+.museum-card {
+  background: #f3f4f6;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+.museum-card-image {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+}
+.museum-card-actions {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: flex;
+  gap: 8px;
+}
+.icon-button {
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+.icon-button svg {
+  width: 18px;
+  height: 18px;
+}
+.museum-card-info {
+  padding: 16px;
+}
+.museum-card-title {
+  margin: 0 0 8px;
+  font-size: 20px;
+  font-weight: 600;
+}
+.museum-card-location {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  color: var(--muted);
+}
+.museum-card-location svg {
+  width: 16px;
+  height: 16px;
+  margin-right: 4px;
+}


### PR DESCRIPTION
## Summary
- add standalone museum card component with image, actions and location
- integrate card in home page
- style card with new CSS rules

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Failed to fetch font `Quicksand`)*

------
https://chatgpt.com/codex/tasks/task_e_68b8420baf9c83268c55443648335a37