### PR TITLE
fix: guard museum card return

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -2,6 +2,11 @@ import Link from 'next/link';
 import Image from 'next/image';
 
 export default function MuseumCard({ museum }) {
+  // Guard against undefined museum data which previously caused build issues
+  if (!museum) {
+    return null;
+  }
+
   return (
     <article className="museum-card">
       <div className="museum-card-image">


### PR DESCRIPTION
## Summary
- avoid returning outside component by guarding undefined museum

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Error [NextFontError]: Failed to fetch font `Quicksand`)*

------
https://chatgpt.com/codex/tasks/task_e_68b8488d7af88326853576ba133d30b5