### PR TITLE
Enable sharing and favorites on museum cards

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -1,11 +1,66 @@
 import Link from 'next/link';
 import Image from 'next/image';
+import { useEffect, useState } from 'react';
 
 export default function MuseumCard({ museum }) {
   // Guard against undefined museum data which previously caused build issues
   if (!museum) {
     return null;
   }
+
+  const [isFavorite, setIsFavorite] = useState(false);
+
+  // Load favorite state from localStorage on mount
+  useEffect(() => {
+    try {
+      const stored = JSON.parse(localStorage.getItem('favorites') || '[]');
+      setIsFavorite(stored.includes(museum.id));
+    } catch {
+      // ignore JSON parse errors
+    }
+  }, [museum.id]);
+
+  const toggleFavorite = () => {
+    try {
+      const stored = JSON.parse(localStorage.getItem('favorites') || '[]');
+      let updated;
+      if (stored.includes(museum.id)) {
+        updated = stored.filter(id => id !== museum.id);
+      } else {
+        updated = [...stored, museum.id];
+      }
+      localStorage.setItem('favorites', JSON.stringify(updated));
+      setIsFavorite(!isFavorite);
+    } catch {
+      // localStorage might be unavailable
+    }
+  };
+
+  const shareMuseum = async () => {
+    const url = `${window.location.origin}/museum/${museum.id}`;
+    const shareData = {
+      title: museum.title,
+      text: `Bekijk ${museum.title}`,
+      url,
+    };
+
+    if (navigator.share) {
+      try {
+        await navigator.share(shareData);
+      } catch {
+        // ignore share cancellation or failure
+      }
+    } else if (navigator.clipboard) {
+      try {
+        await navigator.clipboard.writeText(url);
+        alert('Link gekopieerd naar klembord');
+      } catch {
+        window.open(url, '_blank');
+      }
+    } else {
+      window.open(url, '_blank');
+    }
+  };
 
   return (
     <article className="museum-card">
@@ -26,15 +81,27 @@ export default function MuseumCard({ museum }) {
           )}
         </Link>
         <div className="museum-card-actions">
-          <button className="icon-button" aria-label="Deel">
+          <button className="icon-button" aria-label="Deel" onClick={shareMuseum}>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
               <path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7" />
               <path d="M16 6l-4-4-4 4" />
               <path d="M12 2v14" />
             </svg>
           </button>
-          <button className="icon-button" aria-label="Bewaar">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+          <button
+            className={`icon-button${isFavorite ? ' favorited' : ''}`}
+            aria-label="Bewaar"
+            aria-pressed={isFavorite}
+            onClick={toggleFavorite}
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill={isFavorite ? 'currentColor' : 'none'}
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
               <path d="M21 8.25c0 4.556-9 11.25-9 11.25S3 12.806 3 8.25a5.25 5.25 0 0 1 9-3.676A5.25 5.25 0 0 1 21 8.25Z" />
             </svg>
           </button>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -164,6 +164,9 @@ img { max-width: 100%; height: auto; display: block; }
   width: 18px;
   height: 18px;
 }
+.icon-button.favorited {
+  color: var(--accent);
+}
 .museum-card-info {
   padding: 16px;
 }


### PR DESCRIPTION
## Summary
- add localStorage-based favorite toggle to museum cards
- use Web Share API or clipboard fallback for share button
- highlight favorited cards with accent color

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch `Quicksand` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b96c04f0a08326bea32a15db9e9b3d