### PR TITLE
Handle optional Supabase client

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,12 @@ Deze CI-workflow voert de tests van het project uit zodat de badge de status van
 - `lib/` bevat pure JavaScript-logica. Deze modules kunnen zonder wijzigingen in React Native worden gebruikt.
 - `components/` bevat presentatiecomponenten. Ze zijn opgebouwd uit React Native-primitieven (`View`, `Text`) en hebben hun styling in aparte modules zoals `MuseumCard.styles.js`. Daardoor kunnen ze direct naar React Native worden overgezet.
 - Componenten vermijden HTML-specifieke tags, wat het hergebruik in React Native vereenvoudigt.
+
+## Environment Variables
+
+Add the following variables in your Vercel project settings for both build and runtime:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+
+These are required for the application to connect to Supabase.

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-);
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+export const supabase =
+  url && anonKey ? createClient(url, anonKey) : null;

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,6 +7,13 @@ import MuseumCard from '../components/MuseumCard';
 
 // We halen data server-side op, zodat je live DB gebruikt
 export async function getServerSideProps() {
+  if (!supabase) {
+    const errorMsg =
+      'Supabase client not configured. Please set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.';
+    console.error('[Supabase] index client error:', errorMsg);
+    return { props: { musea: [], error: errorMsg } };
+  }
+
   // Haal alle musea op (je kunt hier filters toevoegen als je wilt)
   const { data, error } = await supabase
     .from('musea')
@@ -33,10 +40,10 @@ export async function getServerSideProps() {
     // voeg eventueel andere props toe die MuseumCard gebruikt
   }));
 
-  return { props: { musea } };
+  return { props: { musea, error: error ? error.message : null } };
 }
 
-export default function Home({ musea }) {
+export default function Home({ musea, error }) {
   const [query, setQuery] = useState('');
   const cities = useMemo(
     () => Array.from(new Set(musea.map((m) => m.city).filter(Boolean))).sort(),
@@ -58,6 +65,17 @@ export default function Home({ musea }) {
       return matchesQuery && matchesCity;
     });
   }, [musea, query, city]);
+
+  if (error) {
+    return (
+      <>
+        <Head>
+          <title>MuseumBuddy</title>
+        </Head>
+        <p>{error}</p>
+      </>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary
- Instantiate Supabase client only when required env vars are present
- Guard homepage against missing Supabase configuration
- Document required Supabase environment variables for deployment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch fonts and module not found '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_e_68b99522fe58832685d5e490778c679e