### PR TITLE
Add Supabase env example and usage docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Deze CI-workflow voert de tests van het project uit zodat de badge de status van
 
 ## Environment Variables
 
-Add the following variables in your Vercel project settings for both build and runtime:
+To run the app locally:
 
-- `NEXT_PUBLIC_SUPABASE_URL`
-- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+1. Copy `.env.example` to `.env.local`.
+2. Fill in the values for `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`.
 
-These are required for the application to connect to Supabase.
+These variables are required for the application to connect to Supabase and should also be added to your Vercel project settings for both build and runtime.


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholders for Supabase credentials
- document copying `.env.example` to `.env.local` for local setup

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9976214308326b71a5c7f88a364a9