### PR TITLE
Fix crawler script syntax

### DIFF
--- a/scripts/crawl.mjs
+++ b/scripts/crawl.mjs
@@ -75,16 +75,18 @@ async function crawlTarget(target) {
   // Items selecteren
   // was: const maxItems = 5;
   const maxItems = typeof target.maxItems === 'number' ? target.maxItems : 12;
+  let nodes = $(item).slice(0, maxItems);
   if (nodes.length === 0) {
-  console.warn(`⚠️  Selector matched 0 nodes for ${slug}. Tried: ${item}`);
+    console.warn(`⚠️  Selector matched 0 nodes for ${slug}. Tried: ${item}`);
 
-  // brede fallback: betekenisvolle links binnen main/content
-  nodes = $('main a, .content a, article a, li a')
-    .filter((_, el) => {
-      const t = $(el).text().trim();
-      return t.length > 3 && /tentoon|exhib|expo|present|te zien|exhibition|exhibitions|expositie/i.test(t);
-    })
-    .slice(0, maxItems);
+    // brede fallback: betekenisvolle links binnen main/content
+    nodes = $('main a, .content a, article a, li a')
+      .filter((_, el) => {
+        const t = $(el).text().trim();
+        return t.length > 3 && /tentoon|exhib|expo|present|te zien|exhibition|exhibitions|expositie/i.test(t);
+      })
+      .slice(0, maxItems);
+  }
   const existing = await existingTitlesForMuseum(museum.id);
 
   const rows = [];


### PR DESCRIPTION
## Summary
- ensure crawler initializes item selector and closes fallback block
- prevent syntax errors when running `npm run crawl`

## Testing
- `npm run crawl`

------
https://chatgpt.com/codex/tasks/task_e_68bac609c7cc83269c119dd6b8724252