### PR TITLE
Improve crawl URL handling

### DIFF
--- a/scripts/crawl.mjs
+++ b/scripts/crawl.mjs
@@ -141,10 +141,15 @@ async function fetchFirstOk(urls, retries = 1) {
 // ---------- CRAWL ----------
 async function crawlTarget(target) {
   const { slug, item } = target;
-  const urlCandidates = target.urls || target.url;
+  let urlCandidates = target.urls || target.url;
   if (!slug || !urlCandidates || !item) {
     console.warn('⚠️ Ongeldig target, overslaan:', target);
     return { slug, found: 0, inserted: 0, skippedDup: 0, ok: false };
+  }
+
+  // Zorg dat we altijd met een array van URL-kandidaten werken
+  if (!Array.isArray(urlCandidates)) {
+    urlCandidates = [urlCandidates];
   }
 
   const museum = await getMuseumBySlug(slug);

--- a/scripts/targets.json
+++ b/scripts/targets.json
@@ -1,7 +1,10 @@
 [
   {
     "slug": "rijksmuseum-amsterdam",
-    "url": "https://www.rijksmuseum.nl",
+    "urls": [
+      "https://www.rijksmuseum.nl/nl/tentoonstellingen",
+      "https://www.rijksmuseum.nl/en/whats-on/exhibitions"
+    ],
     "item": ".teaser, .tile, .grid__item, article, .card, a:has(h2), a:has(h3)",
     "maxItems": 15
   },


### PR DESCRIPTION
## Summary
- normalize URL candidates to arrays before fetching
- add explicit exhibition pages for Rijksmuseum targets

## Testing
- `SUPABASE_URL=https://example.com SUPABASE_SERVICE_ROLE_KEY=dummy node scripts/crawl.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68bad0de2f208326a2a8e6fbbde05fba