### PR TITLE
Redesign museum listing page

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -121,8 +121,14 @@ export default function MuseumCard({ museum }) {
             <path d="M12 11.25a2.25 2.25 0 1 0 0-4.5 2.25 2.25 0 0 0 0 4.5Z" />
             <path d="M12 21s-7.5-7.048-7.5-11.25a7.5 7.5 0 1 1 15 0C19.5 13.952 12 21 12 21Z" />
           </svg>
-          {museum.title}, {museum.city}
+          {[museum.city, museum.province].filter(Boolean).join(', ')}
         </p>
+        {(museum.free || museum.kids) && (
+          <div className="museum-card-tags">
+            {museum.free && <span className="tag">Gratis</span>}
+            {museum.kids && <span className="tag">Kids</span>}
+          </div>
+        )}
       </div>
     </article>
   );

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,70 +1,80 @@
 import Head from 'next/head';
-import Link from 'next/link';
+import { useState } from 'react';
 import { createClient } from '@supabase/supabase-js';
+import MuseumCard from '../components/MuseumCard';
 
 export default function Home({ items, q, gratis, kids }) {
+  const [showFilters, setShowFilters] = useState(false);
+
   return (
     <>
       <Head>
-        <title>MuseumBuddy — Musea</title>
-        <meta name="description" content="Zoek en filter musea in Nederland." />
+        <title>MuseumBuddy — Museums</title>
+        <meta name="description" content="Search and filter museums in the Netherlands." />
       </Head>
 
-      <main style={{ maxWidth: 900, margin: '2rem auto', padding: '0 1rem' }}>
-        <h1 style={{ marginTop: 0 }}>Musea</h1>
-
-        <form method="get" style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap', marginBottom: '1rem' }}>
+      <form method="get" className="controls">
+        <div className="control-row">
+          <select name="type" className="select" defaultValue="musea">
+            <option value="musea">Museums</option>
+          </select>
+          <button
+            type="button"
+            className="btn-reset"
+            onClick={() => setShowFilters((v) => !v)}
+          >
+            Filters
+          </button>
           <input
             type="text"
             name="q"
-            placeholder="Zoek op naam…"
+            className="input"
+            placeholder="Search"
             defaultValue={q || ''}
-            style={{ flex: '1 1 260px', padding: '0.5rem 0.75rem', borderRadius: 8, border: '1px solid #ddd' }}
           />
-          <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-            <input type="checkbox" name="gratis" value="1" defaultChecked={!!gratis} />
-            Gratis
-          </label>
-          <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-            <input type="checkbox" name="kids" value="1" defaultChecked={!!kids} />
-            Kindvriendelijk
-          </label>
-          <button type="submit" style={{ padding: '0.5rem 0.75rem', borderRadius: 8, border: '1px solid #ddd', background: '#fafafa' }}>
-            Zoeken
-          </button>
-        </form>
-
-        {(!items || items.length === 0) ? (
-          <p>Geen resultaten.</p>
-        ) : (
-          <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-            {items.map((m) => (
-              <li key={m.id} style={{ borderBottom: '1px solid #eee', padding: '0.75rem 0' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', alignItems: 'center' }}>
-                  <div>
-                    <div style={{ fontWeight: 600, marginBottom: 4 }}>
-                      <Link href={`/museum/${m.slug}`} style={{ textDecoration: 'none', color: 'inherit' }}>
-                        {m.naam}
-                      </Link>
-                    </div>
-                    <div style={{ color: '#666', fontSize: 14 }}>
-                      {[m.stad, m.provincie].filter(Boolean).join(', ')}
-                    </div>
-                  </div>
-                  <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-                    {m.gratis_toegankelijk && (
-                      <span style={{ border: '1px solid #ddd', borderRadius: 999, padding: '2px 8px', fontSize: 12 }}>Gratis</span>
-                    )}
-                    {m.kindvriendelijk && (
-                      <span style={{ border: '1px solid #ddd', borderRadius: 999, padding: '2px 8px', fontSize: 12 }}>Kids</span>
-                    )}
-                  </div>
-                </div>
-              </li>
-            ))}
-          </ul>
+        </div>
+        {showFilters && (
+          <div className="control-row">
+            <label className="checkbox">
+              <input type="checkbox" name="gratis" value="1" defaultChecked={!!gratis} />
+              Free
+            </label>
+            <label className="checkbox">
+              <input type="checkbox" name="kids" value="1" defaultChecked={!!kids} />
+              Kid-friendly
+            </label>
+            {(q || gratis || kids) && (
+              <a href="/" className="btn-reset">
+                Reset
+              </a>
+            )}
+          </div>
         )}
-      </main>
+      </form>
+
+      <p className="count">{items.length} results</p>
+
+      {items.length === 0 ? (
+        <p>No results.</p>
+      ) : (
+        <ul className="grid" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+          {items.map((m) => (
+            <li key={m.id}>
+              <MuseumCard
+                museum={{
+                  id: m.id,
+                  slug: m.slug,
+                  title: m.naam,
+                  city: m.stad,
+                  province: m.provincie,
+                  free: m.gratis_toegankelijk,
+                  kids: m.kindvriendelijk,
+                }}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
     </>
   );
 }
@@ -84,7 +94,6 @@ export async function getServerSideProps({ query }) {
     .order('naam', { ascending: true });
 
   if (q) {
-    // case-insensitive zoeken op naam
     db = db.ilike('naam', `%${q}%`);
   }
   if (gratis) {
@@ -97,7 +106,6 @@ export async function getServerSideProps({ query }) {
   const { data, error } = await db;
 
   if (error) {
-    // Fallback: geen resultaten tonen i.p.v. hard crashen
     return { props: { items: [], q, gratis, kids } };
   }
 
@@ -110,4 +118,3 @@ export async function getServerSideProps({ query }) {
     },
   };
 }
-

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -176,6 +176,7 @@ img { max-width: 100%; height: auto; display: block; }
 
 .museum-card-info {
   padding: 16px;
+  background: #a7f3d0;
 }
 .museum-card-title {
   margin: 0 0 8px;
@@ -193,4 +194,11 @@ img { max-width: 100%; height: auto; display: block; }
   width: 16px;
   height: 16px;
   margin-right: 4px;
+}
+
+.museum-card-tags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 8px;
 }


### PR DESCRIPTION
## Summary
- Revamp the museum listing page with new search/filter controls and grid layout
- Map museum data to card component and show result count
- Add background color to card info section
- Restore museum results and tags by querying existing fields only

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc5057320083269a6a525c622d8014