### PR TITLE
Rename Tropenmuseum to Wereldmuseum

### DIFF
--- a/scripts/targets.json
+++ b/scripts/targets.json
@@ -61,8 +61,8 @@
   },
 
   {
-    "slug": "tropenmuseum-amsterdam",
-    "url": "https://www.tropenmuseum.nl",
+    "slug": "wereldmuseum-amsterdam",
+    "url": "https://www.wereldmuseum.nl/nl/locatie/amsterdam",
     "item": ".view-content .node, .card, article, a:has(h2), a:has(h3)"
   },
   {


### PR DESCRIPTION
## Summary
- replace Tropenmuseum entry with Wereldmuseum Amsterdam in crawl targets
- point crawler to Wereldmuseum Amsterdam URL

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bc5b6d73f483269cf5b835b6a47ea6