### PR TITLE
Rename Tropenmuseum to Wereldmuseum

### DIFF
--- a/lib/museumImages.js
+++ b/lib/museumImages.js
@@ -22,6 +22,7 @@ const museumImages = {
   'scheepvaartmuseum-amsterdam': '/images/scheepvaartmuseum-amsterdam.jpg',
   'stedelijk-museum-amsterdam': '/images/stedelijk-museum-amsterdam.jpg',
   'straat-museum-amsterdam': '/images/straat-museum-amsterdam.jpg',
+  'tropenmuseum-amsterdam': '/images/wereldmuseum-amsterdam.jpg',
   'van-gogh-museum-amsterdam': '/images/van-gogh-museum-amsterdam.jpg',
   'wereldmuseum-amsterdam': '/images/wereldmuseum-amsterdam.jpg',
   'woonbootmuseum-amsterdam': '/images/woonbootmuseum-amsterdam.jpg',

--- a/lib/museumNames.js
+++ b/lib/museumNames.js
@@ -1,0 +1,6 @@
+const museumNames = {
+  'tropenmuseum-amsterdam': 'Wereldmuseum Amsterdam',
+  'wereldmuseum-amsterdam': 'Wereldmuseum Amsterdam',
+};
+
+export default museumNames;

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { createClient } from '@supabase/supabase-js';
 import MuseumCard from '../components/MuseumCard';
 import museumImages from '../lib/museumImages';
+import museumNames from '../lib/museumNames';
 
 export default function Home({ items, q, gratis, kids }) {
   const [showFilters, setShowFilters] = useState(false);
@@ -65,7 +66,7 @@ export default function Home({ items, q, gratis, kids }) {
                 museum={{
                   id: m.id,
                   slug: m.slug,
-                  title: m.naam,
+                  title: museumNames[m.slug] || m.naam,
                   city: m.stad,
                   province: m.provincie,
                   free: m.gratis_toegankelijk,

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -2,6 +2,7 @@ import Head from 'next/head';
 import Image from 'next/image';
 import { createClient } from '@supabase/supabase-js';
 import museumImages from '../../lib/museumImages';
+import museumNames from '../../lib/museumNames';
 
 function formatDate(d) {
   if (!d) return '';
@@ -42,12 +43,13 @@ export default function MuseumDetail({ museum, exposities, error }) {
 
   const todayStr = todayYMD('Europe/Amsterdam');
   const today = new Date(todayStr + 'T00:00:00');
+  const name = museum ? museumNames[museum.slug] || museum.naam : '';
 
   return (
     <>
       <Head>
-        <title>{museum?.naam ? `${museum.naam} — MuseumBuddy` : 'Museum — MuseumBuddy'}</title>
-        <meta name="description" content={`Informatie en exposities van ${museum?.naam || 'museum'}.`} />
+        <title>{name ? `${name} — MuseumBuddy` : 'Museum — MuseumBuddy'}</title>
+        <meta name="description" content={`Informatie en exposities van ${name || 'museum'}.`} />
       </Head>
 
       <main style={{ maxWidth: 800, margin: '2rem auto', padding: '0 1rem' }}>
@@ -55,7 +57,7 @@ export default function MuseumDetail({ museum, exposities, error }) {
           &larr; Terug
         </a>
 
-        <h1 style={{ margin: '0 0 0.25rem' }}>{museum.naam}</h1>
+        <h1 style={{ margin: '0 0 0.25rem' }}>{name}</h1>
         <p style={{ marginTop: 0, color: '#666' }}>
           {[museum.stad, museum.provincie].filter(Boolean).join(', ')}
         </p>
@@ -64,7 +66,7 @@ export default function MuseumDetail({ museum, exposities, error }) {
           <div style={{ position: 'relative', width: '100%', height: 300, margin: '1rem 0' }}>
             <Image
               src={museumImages[museum.slug]}
-              alt={museum.naam}
+              alt={name}
               fill
               sizes="(max-width: 800px) 100vw, 800px"
               style={{ objectFit: 'cover' }}

--- a/scripts/targets.json
+++ b/scripts/targets.json
@@ -61,8 +61,8 @@
   },
 
   {
-    "slug": "tropenmuseum-amsterdam",
-    "url": "https://www.tropenmuseum.nl",
+    "slug": "wereldmuseum-amsterdam",
+    "url": "https://www.wereldmuseum.nl/nl/locatie/amsterdam",
     "item": ".view-content .node, .card, article, a:has(h2), a:has(h3)"
   },
   {


### PR DESCRIPTION
## Summary
- display Tropenmuseum as Wereldmuseum Amsterdam through name overrides
- map Tropenmuseum slug to Wereldmuseum image so a photo appears in the app

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc5b6d73f483269cf5b835b6a47ea6