### PR TITLE
Add remote image crawler and integrate image references

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,13 @@ python scripts/supabase_dedup.py
 ```
 
 The script fetches all rows, keeps only unique `museum_id` values, writes the cleaned data back, and ensures the constraint exists to prevent future duplicates.
+
+## Image crawler
+
+A TypeScript script extracts a preferred image from a museum website and stores only the remote URL in the `musea` table.
+
+```
+npx ts-node scripts/image-crawler.ts <museum_id> <museum_url> [attribution]
+```
+
+Environment variables `SUPABASE_URL` (or `NEXT_PUBLIC_SUPABASE_URL`) and `SUPABASE_SERVICE_ROLE_KEY` must be set so the script can update the `image_url`, `image_source` and optional `attribution` columns for the given museum.

--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -77,14 +77,29 @@ export default function MuseumCard({ museum }) {
           style={{ display: 'block', width: '100%', height: '100%', position: 'relative' }}
           aria-label={`Bekijk ${museum.title}`}
         >
-          {museum.image && (
+          {museum.image_url && (
             <Image
-              src={museum.image.startsWith('/') ? museum.image : `/${museum.image}`}
+              src={museum.image_url}
               alt={museum.title}
               fill
               sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
               style={{ objectFit: 'cover' }}
             />
+          )}
+          {museum.attribution && (
+            <div
+              style={{
+                position: 'absolute',
+                bottom: 0,
+                right: 0,
+                background: 'rgba(0,0,0,0.6)',
+                color: '#fff',
+                fontSize: 12,
+                padding: '2px 4px',
+              }}
+            >
+              {museum.attribution}
+            </div>
           )}
         </Link>
         <div className="museum-card-actions">

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,21 @@
 // next.config.js
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**',
+        pathname: '/**',
+      },
+      {
+        protocol: 'http',
+        hostname: '**',
+        pathname: '/**',
+      },
+    ],
+  },
   // geen "output: 'export'"
 };
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "crawl": "node scripts/crawl.mjs"
+    "crawl": "node scripts/crawl.mjs",
+    "crawl-image": "ts-node scripts/image-crawler.ts"
   },
   "engines": {
     "node": "20.x"
@@ -17,5 +18,11 @@
     "next": "14.2.3",
     "react": "18.2.0",
     "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.19",
+    "@types/react": "^18.2.37",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.0"
   }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,7 +2,6 @@ import Head from 'next/head';
 import { useState } from 'react';
 import { createClient } from '@supabase/supabase-js';
 import MuseumCard from '../components/MuseumCard';
-import museumImages from '../lib/museumImages';
 import museumNames from '../lib/museumNames';
 
 export default function Home({ items, q, gratis, kids }) {
@@ -71,7 +70,8 @@ export default function Home({ items, q, gratis, kids }) {
                   province: m.provincie,
                   free: m.gratis_toegankelijk,
                   kids: m.kindvriendelijk,
-                  image: museumImages[m.slug],
+                  image_url: m.image_url,
+                  attribution: m.attribution,
                 }}
               />
             </li>
@@ -93,7 +93,8 @@ export async function getServerSideProps({ query }) {
 
   let db = supabase
     .from('musea')
-    .select('id, naam, stad, provincie, slug, gratis_toegankelijk, kindvriendelijk')
+    // select all columns to avoid errors if optional image fields are missing
+    .select('*')
     .order('naam', { ascending: true });
 
   if (q) {

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -1,7 +1,6 @@
 import Head from 'next/head';
 import Image from 'next/image';
 import { createClient } from '@supabase/supabase-js';
-import museumImages from '../../lib/museumImages';
 import museumNames from '../../lib/museumNames';
 
 function formatDate(d) {
@@ -62,15 +61,20 @@ export default function MuseumDetail({ museum, exposities, error }) {
           {[museum.stad, museum.provincie].filter(Boolean).join(', ')}
         </p>
 
-        {museumImages[museum.slug] && (
-          <div style={{ position: 'relative', width: '100%', height: 300, margin: '1rem 0' }}>
-            <Image
-              src={museumImages[museum.slug]}
-              alt={name}
-              fill
-              sizes="(max-width: 800px) 100vw, 800px"
-              style={{ objectFit: 'cover' }}
-            />
+        {museum.image_url && (
+          <div style={{ margin: '1rem 0' }}>
+            <div style={{ position: 'relative', width: '100%', height: 300 }}>
+              <Image
+                src={museum.image_url}
+                alt={name}
+                fill
+                sizes="(max-width: 800px) 100vw, 800px"
+                style={{ objectFit: 'cover' }}
+              />
+            </div>
+            {museum.attribution && (
+              <p style={{ fontSize: 12, color: '#666', marginTop: 4 }}>{museum.attribution}</p>
+            )}
           </div>
         )}
 
@@ -161,7 +165,8 @@ export async function getServerSideProps(context) {
 
   const { data: museum, error: museumError } = await supabase
     .from('musea')
-    .select('id, naam, stad, provincie, website_url, ticket_affiliate_url, slug')
+    // select all columns so missing optional fields don't break the query
+    .select('*')
     .eq('slug', slug)
     .single();
 

--- a/scripts/image-crawler.ts
+++ b/scripts/image-crawler.ts
@@ -1,0 +1,121 @@
+import axios from 'axios';
+import * as cheerio from 'cheerio';
+import { createClient } from '@supabase/supabase-js';
+
+const [museumIdArg, museumUrl, attribution] = process.argv.slice(2);
+
+if (!museumIdArg || !museumUrl) {
+  console.error('Usage: ts-node scripts/image-crawler.ts <museum_id> <museum_url> [attribution]');
+  process.exit(1);
+}
+
+const museumId = Number(museumIdArg);
+if (Number.isNaN(museumId)) {
+  console.error('museum_id must be a number');
+  process.exit(1);
+}
+
+async function fetchHtml(url: string): Promise<string> {
+  const res = await axios.get(url, {
+    timeout: 30000,
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (compatible; MuseumBuddyBot/1.0; +https://example.com/bot)',
+      Accept: 'text/html,application/xhtml+xml',
+    },
+    validateStatus: (s) => s >= 200 && s < 400,
+  });
+  return res.data as string;
+}
+
+function resolveUrl(src: string, base: string): string {
+  try {
+    return new URL(src, base).href;
+  } catch {
+    return src;
+  }
+}
+
+function extractJsonLdImage($: cheerio.CheerioAPI, base: string): string | null {
+  const scripts = $('script[type="application/ld+json"]');
+  for (const el of scripts.toArray()) {
+    try {
+      const json = JSON.parse($(el).contents().text());
+      const img = (json.image && (Array.isArray(json.image) ? json.image[0] : json.image)) || null;
+      if (typeof img === 'string') return resolveUrl(img, base);
+      if (img && typeof img.url === 'string') return resolveUrl(img.url, base);
+    } catch {
+      // ignore JSON errors
+    }
+  }
+  return null;
+}
+
+function largestImage($: cheerio.CheerioAPI, base: string): string | null {
+  let bestUrl: string | null = null;
+  let bestArea = 0;
+  $('img').each((_, el) => {
+    const src = $(el).attr('src');
+    if (!src) return;
+    const w = parseInt($(el).attr('width') || '0', 10);
+    const h = parseInt($(el).attr('height') || '0', 10);
+    const area = w * h;
+    if (!bestUrl || area > bestArea) {
+      bestUrl = resolveUrl(src, base);
+      bestArea = area;
+    }
+  });
+  return bestUrl;
+}
+
+async function findImageUrl(html: string, pageUrl: string): Promise<string | null> {
+  const $ = cheerio.load(html);
+  const og = $('meta[property="og:image"]').attr('content');
+  if (og) return resolveUrl(og, pageUrl);
+  const tw = $('meta[name="twitter:image"]').attr('content');
+  if (tw) return resolveUrl(tw, pageUrl);
+  const ld = extractJsonLdImage($, pageUrl);
+  if (ld) return ld;
+  return largestImage($, pageUrl);
+}
+
+async function validateImage(url: string): Promise<boolean> {
+  try {
+    const res = await axios.head(url, { timeout: 15000 });
+    const type = (res.headers['content-type'] || '') as string;
+    return type.startsWith('image/');
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const html = await fetchHtml(museumUrl);
+  const imageUrl = await findImageUrl(html, museumUrl);
+  if (!imageUrl) throw new Error('No image found');
+  const ok = await validateImage(imageUrl);
+  if (!ok) throw new Error('URL is not an image');
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceKey) throw new Error('Missing Supabase env vars');
+
+  const supabase = createClient(supabaseUrl, serviceKey);
+
+  const { error } = await supabase
+    .from('musea')
+    .update({
+      image_url: imageUrl,
+      image_source: museumUrl,
+      attribution: attribution || null,
+      image_updated_at: new Date().toISOString(),
+    })
+    .eq('id', museumId);
+
+  if (error) throw error;
+  console.log(`Stored image for museum ${museumId}: ${imageUrl}`);
+}
+
+main().catch((err) => {
+  console.error('Failed:', err);
+  process.exit(1);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["scripts/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- update image crawler to write remote image URLs and attribution directly into `musea`
- read stored `image_url` data on museum pages and cards to show remote images with credit
- permit any http/https image hosts in Next.js config and document crawler usage
- fetch all museum columns to avoid errors when optional image fields are missing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit`
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6de0096c8326bf965c04c8ee3e18