### PR TITLE
Fix loading of museum images

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -77,15 +77,26 @@ export default function MuseumCard({ museum }) {
           style={{ display: 'block', width: '100%', height: '100%', position: 'relative' }}
           aria-label={`Bekijk ${museum.title}`}
         >
-          {museum.image && (
-            <Image
-              src={museum.image.startsWith('/') ? museum.image : `/${museum.image}`}
-              alt={museum.title}
-              fill
-              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-              style={{ objectFit: 'cover' }}
-            />
-          )}
+          {(() => {
+            const src = museum.image
+              ? museum.image.startsWith('http://') || museum.image.startsWith('https://')
+                ? museum.image
+                : museum.image.startsWith('/')
+                ? museum.image
+                : `/${museum.image}`
+              : null;
+            return (
+              src && (
+                <Image
+                  src={src}
+                  alt={museum.title}
+                  fill
+                  sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                  style={{ objectFit: 'cover' }}
+                />
+              )
+            );
+          })()}
         </Link>
         <div className="museum-card-actions">
           <button className="icon-button" aria-label="Deel" onClick={shareMuseum}>

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,14 @@
 // next.config.js
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
   // geen "output: 'export'"
+  images: {
+    remotePatterns: [
+      { protocol: 'https', hostname: '**' },
+      { protocol: 'http', hostname: '**' },
+    ],
+  },
 };
 
 module.exports = nextConfig;

--- a/pages/index.js
+++ b/pages/index.js
@@ -71,7 +71,7 @@ export default function Home({ items, q, gratis, kids }) {
                   province: m.provincie,
                   free: m.gratis_toegankelijk,
                   kids: m.kindvriendelijk,
-                  image: museumImages[m.slug],
+                  image: m.image_url || museumImages[m.slug],
                 }}
               />
             </li>
@@ -93,7 +93,7 @@ export async function getServerSideProps({ query }) {
 
   let db = supabase
     .from('musea')
-    .select('id, naam, stad, provincie, slug, gratis_toegankelijk, kindvriendelijk')
+    .select('id, naam, stad, provincie, slug, gratis_toegankelijk, kindvriendelijk, image_url')
     .order('naam', { ascending: true });
 
   if (q) {

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -44,6 +44,10 @@ export default function MuseumDetail({ museum, exposities, error }) {
   const todayStr = todayYMD('Europe/Amsterdam');
   const today = new Date(todayStr + 'T00:00:00');
   const name = museum ? museumNames[museum.slug] || museum.naam : '';
+  let imgSrc = museum && (museum.image_url || museumImages[museum.slug]);
+  if (imgSrc && !(imgSrc.startsWith('http://') || imgSrc.startsWith('https://') || imgSrc.startsWith('/'))) {
+    imgSrc = `/${imgSrc}`;
+  }
 
   return (
     <>
@@ -62,10 +66,10 @@ export default function MuseumDetail({ museum, exposities, error }) {
           {[museum.stad, museum.provincie].filter(Boolean).join(', ')}
         </p>
 
-        {museumImages[museum.slug] && (
+        {imgSrc && (
           <div style={{ position: 'relative', width: '100%', height: 300, margin: '1rem 0' }}>
             <Image
-              src={museumImages[museum.slug]}
+              src={imgSrc}
               alt={name}
               fill
               sizes="(max-width: 800px) 100vw, 800px"
@@ -161,7 +165,7 @@ export async function getServerSideProps(context) {
 
   const { data: museum, error: museumError } = await supabase
     .from('musea')
-    .select('id, naam, stad, provincie, website_url, ticket_affiliate_url, slug')
+    .select('id, naam, stad, provincie, website_url, ticket_affiliate_url, slug, image_url')
     .eq('slug', slug)
     .single();
 

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -163,11 +163,22 @@ export async function getServerSideProps(context) {
 
   const supabase = createClient(url, anon);
 
-  const { data: museum, error: museumError } = await supabase
-    .from('musea')
-    .select('id, naam, stad, provincie, website_url, ticket_affiliate_url, slug, image_url')
-    .eq('slug', slug)
-    .single();
+  const selectMuseum = async (cols) =>
+    supabase
+      .from('musea')
+      .select(cols)
+      .eq('slug', slug)
+      .single();
+
+  let { data: museum, error: museumError } = await selectMuseum(
+    'id, naam, stad, provincie, website_url, ticket_affiliate_url, slug, image_url'
+  );
+
+  if (museumError) {
+    ({ data: museum, error: museumError } = await selectMuseum(
+      'id, naam, stad, provincie, website_url, ticket_affiliate_url, slug'
+    ));
+  }
 
   if (museumError) {
     if (museumError.code === 'PGRST116') {


### PR DESCRIPTION
## Summary
- Handle absolute URLs so museum photos can load
- Pull museum image URLs from Supabase and allow remote domains
- Provide fallback to local images when no remote photo exists

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68be8eed3d4483268a18f66a197cf170