### PR TITLE
Remove unused museum type selector

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -18,9 +18,6 @@ export default function Home({ items, q, gratis }) {
 
       <form method="get" className="controls">
         <div className="control-row">
-          <select name="type" className="select" defaultValue="musea">
-            <option value="musea">Museums</option>
-          </select>
           <button
             type="button"
             className="btn-reset"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -40,7 +40,7 @@ img { max-width: 100%; height: auto; display: block; }
 .page-subtitle { margin: 0 0 16px; color: var(--muted); }
 
 /* Controls */
-.input, .select {
+.input {
   width: 100%;
   padding: 12px 14px;
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- drop unused museum type dropdown from search controls
- clean up CSS for removed select

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be9c777eac83268ea2fa7a5d626734