### PR TITLE
Add random hover colors to museum cards

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -1,11 +1,15 @@
 import Link from 'next/link';
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 
 export default function MuseumCard({ museum }) {
   if (!museum) return null;
 
   const [isFavorite, setIsFavorite] = useState(false);
+  const hoverColor = useMemo(() => {
+    const colors = ['#A7D8F0', '#77DDDD', '#F7C59F', '#D8BFD8', '#EAE0C8'];
+    return colors[Math.floor(Math.random() * colors.length)];
+  }, [museum.id]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -70,7 +74,7 @@ export default function MuseumCard({ museum }) {
   };
 
   return (
-    <article className="museum-card">
+    <article className="museum-card" style={{ '--hover-bg': hoverColor }}>
       <div className="museum-card-image">
         <Link
           href={{ pathname: '/museum/[slug]', query: { slug: museum.slug } }}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -176,7 +176,11 @@ img { max-width: 100%; height: auto; display: block; }
 
 .museum-card-info {
   padding: 16px;
-  background: #a7f3d0;
+  background: #fff;
+  transition: background 0.3s ease;
+}
+.museum-card:hover .museum-card-info {
+  background: var(--hover-bg, #fff);
 }
 .museum-card-title {
   margin: 0 0 8px;


### PR DESCRIPTION
## Summary
- give each museum card a random hover color and start with a white info background

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bea1af39108326bcabb816c901bc73