### PR TITLE
Style exhibition page with card layout

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'react';
+
+export default function ExpositionCard({ exposition, status, periode }) {
+  if (!exposition) return null;
+
+  const [isFavorite, setIsFavorite] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = JSON.parse(localStorage.getItem('favoriteExpositions') || '[]');
+      setIsFavorite(stored.includes(exposition.id));
+    } catch {
+      // ignore
+    }
+  }, [exposition.id]);
+
+  const toggleFavorite = () => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = JSON.parse(localStorage.getItem('favoriteExpositions') || '[]');
+      const exists = stored.includes(exposition.id);
+      const next = exists ? stored.filter((id) => id !== exposition.id) : [...stored, exposition.id];
+      localStorage.setItem('favoriteExpositions', JSON.stringify(next));
+      setIsFavorite(!exists);
+    } catch {
+      // ignore
+    }
+  };
+
+  const shareExposition = async () => {
+    if (typeof window === 'undefined') return;
+
+    const url = exposition.bron_url || window.location.href;
+    const shareData = {
+      title: exposition.titel,
+      text: exposition.titel,
+      url,
+    };
+
+    if (navigator.share) {
+      try {
+        await navigator.share(shareData);
+        return;
+      } catch {
+        // ignore
+      }
+    }
+
+    if (navigator.clipboard) {
+      try {
+        await navigator.clipboard.writeText(url);
+        alert('Link gekopieerd naar klembord');
+        return;
+      } catch {
+        // ignore
+      }
+    }
+
+    try {
+      window.open(url, '_blank', 'noopener,noreferrer');
+    } catch {
+      window.prompt('Kopieer deze link', url);
+    }
+  };
+
+  return (
+    <article className="museum-card">
+      <div className="museum-card-image">
+        {exposition.bron_url ? (
+          <a
+            href={exposition.bron_url}
+            target="_blank"
+            rel="noreferrer"
+            style={{ display: 'block', width: '100%', height: '100%' }}
+          >
+            <div style={{ width: '100%', height: '100%', background: '#ddd' }} />
+          </a>
+        ) : (
+          <div style={{ width: '100%', height: '100%', background: '#ddd' }} />
+        )}
+        <div className="museum-card-actions">
+          <button className="icon-button" aria-label="Deel" onClick={shareExposition}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7" />
+              <path d="M16 6l-4-4-4 4" />
+              <path d="M12 2v14" />
+            </svg>
+          </button>
+          <button
+            className={`icon-button${isFavorite ? ' favorited' : ''}`}
+            aria-label="Bewaar"
+            aria-pressed={isFavorite}
+            onClick={toggleFavorite}
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill={isFavorite ? 'currentColor' : 'none'}
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M21 8.25c0 4.556-9 11.25-9 11.25S3 12.806 3 8.25a5.25 5.25 0 0 1 9-3.676A5.25 5.25 0 0 1 21 8.25Z" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div className="museum-card-info">
+        <h3 className="museum-card-title">
+          {exposition.bron_url ? (
+            <a href={exposition.bron_url} target="_blank" rel="noreferrer" style={{ color: 'inherit', textDecoration: 'none' }}>
+              {exposition.titel}
+            </a>
+          ) : (
+            exposition.titel
+          )}
+        </h3>
+        {periode && <p className="museum-card-location">{periode}</p>}
+        {status && (
+          <div className="museum-card-tags">
+            <span className="tag">{status}</span>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
+

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -53,18 +53,18 @@ export default function MuseumDetail({ museum, exposities, error }) {
         <meta name="description" content={`Informatie en exposities van ${name || 'museum'}.`} />
       </Head>
 
-      <main style={{ maxWidth: 800, margin: '2rem auto', padding: '0 1rem' }}>
-        <a href="/" style={{ display: 'inline-block', marginBottom: '1rem' }}>
+      <main className="container" style={{ maxWidth: 800 }}>
+        <a href="/" className="backlink" style={{ display: 'inline-block', marginBottom: 16 }}>
           &larr; Terug
         </a>
 
-        <h1 style={{ margin: '0 0 0.25rem' }}>{name}</h1>
-        <p style={{ marginTop: 0, color: '#666' }}>
+        <h1 className="detail-title">{name}</h1>
+        <p className="detail-sub">
           {[museum.stad, museum.provincie].filter(Boolean).join(', ')}
         </p>
 
         {museumImages[museum.slug] && (
-          <div style={{ position: 'relative', width: '100%', height: 300, margin: '1rem 0' }}>
+          <div style={{ position: 'relative', width: '100%', height: 300, margin: '16px 0' }}>
             <Image
               src={museumImages[museum.slug]}
               alt={name}
@@ -75,13 +75,13 @@ export default function MuseumDetail({ museum, exposities, error }) {
           </div>
         )}
 
-        <div style={{ display: 'flex', gap: '0.5rem', margin: '1rem 0' }}>
+        <div style={{ display: 'flex', gap: '8px', margin: '16px 0' }}>
           {museum.website_url && (
             <a
               href={museum.website_url}
               target="_blank"
               rel="noreferrer"
-              style={{ padding: '0.5rem 0.75rem', border: '1px solid #ddd', borderRadius: 8, textDecoration: 'none' }}
+              className="btn-reset"
             >
               Website
             </a>
@@ -91,14 +91,14 @@ export default function MuseumDetail({ museum, exposities, error }) {
               href={museum.ticket_affiliate_url}
               target="_blank"
               rel="noreferrer"
-              style={{ padding: '0.5rem 0.75rem', border: '1px solid #ddd', borderRadius: 8, textDecoration: 'none' }}
+              className="btn-reset"
             >
               Tickets (affiliate)
             </a>
           )}
         </div>
 
-        <h2>Exposities</h2>
+        <h2 className="page-title">Exposities</h2>
         {!exposities || exposities.length === 0 ? (
           <p>Geen lopende of komende exposities.</p>
         ) : (

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import { createClient } from '@supabase/supabase-js';
 import museumImages from '../../lib/museumImages';
 import museumNames from '../../lib/museumNames';
+import ExpositionCard from '../../components/ExpositionCard';
 
 function formatDate(d) {
   if (!d) return '';
@@ -101,7 +102,7 @@ export default function MuseumDetail({ museum, exposities, error }) {
         {!exposities || exposities.length === 0 ? (
           <p>Geen lopende of komende exposities.</p>
         ) : (
-          <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+          <ul className="grid" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
             {exposities.map((e) => {
               const start = e.start_datum ? new Date(e.start_datum + 'T00:00:00') : null;
               const end = e.eind_datum ? new Date(e.eind_datum + 'T00:00:00') : null;
@@ -114,29 +115,9 @@ export default function MuseumDetail({ museum, exposities, error }) {
                 .filter(Boolean)
                 .join(' – ');
 
-              const inhoud = (
-                <div>
-                  <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                    <div style={{ fontWeight: 600 }}>{e.titel}</div>
-                    {status && (
-                      <span style={{ border: '1px solid #ddd', borderRadius: 999, padding: '2px 8px', fontSize: 12 }}>
-                        {status}
-                      </span>
-                    )}
-                  </div>
-                  <div style={{ color: '#666', fontSize: 14 }}>{periode}</div>
-                </div>
-              );
-
               return (
-                <li key={e.id} style={{ borderBottom: '1px solid #eee', padding: '0.75rem 0' }}>
-                  {e.bron_url ? (
-                    <a href={e.bron_url} target="_blank" rel="noreferrer" style={{ color: 'inherit', textDecoration: 'none' }}>
-                      {inhoud}
-                    </a>
-                  ) : (
-                    inhoud
-                  )}
+                <li key={e.id}>
+                  <ExpositionCard exposition={e} status={status} periode={periode} />
                 </li>
               );
             })}


### PR DESCRIPTION
## Summary
- add `ExpositionCard` component to present each museum exhibition in a card with share and favorite actions
- render museum exhibition list using responsive card grid

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bea32ce7748326ab2fd15bee6fb0af