### PR TITLE
Shrink exposition card fonts

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -65,7 +65,7 @@ export default function ExpositionCard({ exposition, status, periode }) {
   };
 
   return (
-    <article className="museum-card">
+    <article className="museum-card exposition-card">
       <div className="museum-card-image">
         {exposition.bron_url ? (
           <a

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -206,3 +206,16 @@ img { max-width: 100%; height: auto; display: block; }
   flex-wrap: wrap;
   margin-top: 8px;
 }
+
+/* Smaller typography for exposition cards */
+.exposition-card .museum-card-title {
+  font-size: 18px;
+}
+
+.exposition-card .museum-card-location {
+  font-size: 12px;
+}
+
+.exposition-card .tag {
+  font-size: 12px;
+}


### PR DESCRIPTION
## Summary
- reduce typography on exposition cards for a lighter appearance

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bea7456d008326b100a80d5f976669