### PR TITLE
feat: show exposition images

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -102,7 +102,14 @@ export default function ExpositionCard({ exposition, status, periode }) {
         )}
         <div className="museum-card-actions">
           <button className="icon-button" aria-label="Deel" onClick={shareExposition}>
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
               <path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7" />
               <path d="M16 6l-4-4-4 4" />
               <path d="M12 2v14" />

--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -67,7 +67,28 @@ export default function ExpositionCard({ exposition, status, periode }) {
   return (
     <article className="museum-card exposition-card">
       <div className="museum-card-image">
-        {exposition.bron_url ? (
+        {exposition.image_url ? (
+          exposition.bron_url ? (
+            <a
+              href={exposition.bron_url}
+              target="_blank"
+              rel="noreferrer"
+              style={{ display: 'block', width: '100%', height: '100%' }}
+            >
+              <img
+                src={exposition.image_url}
+                alt={exposition.titel}
+                style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+              />
+            </a>
+          ) : (
+            <img
+              src={exposition.image_url}
+              alt={exposition.titel}
+              style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+            />
+          )
+        ) : exposition.bron_url ? (
           <a
             href={exposition.bron_url}
             target="_blank"

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -155,12 +155,21 @@ export async function getServerSideProps(context) {
   }
 
   const today = todayYMD('Europe/Amsterdam'); // "YYYY-MM-DD"
-  const { data: exposities, error: exError } = await supabase
+  let { data: exposities, error: exError } = await supabase
     .from('exposities')
     .select('id, titel, start_datum, eind_datum, bron_url, image_url')
     .eq('museum_id', museum.id)
     .or(`eind_datum.gte.${today},eind_datum.is.null`)
     .order('start_datum', { ascending: true, nullsFirst: false });
+
+  if (exError && exError.message && exError.message.includes('image_url')) {
+    ({ data: exposities, error: exError } = await supabase
+      .from('exposities')
+      .select('id, titel, start_datum, eind_datum, bron_url')
+      .eq('museum_id', museum.id)
+      .or(`eind_datum.gte.${today},eind_datum.is.null`)
+      .order('start_datum', { ascending: true, nullsFirst: false }));
+  }
 
   if (exError) {
     context.res.statusCode = 500;

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -157,7 +157,7 @@ export async function getServerSideProps(context) {
   const today = todayYMD('Europe/Amsterdam'); // "YYYY-MM-DD"
   const { data: exposities, error: exError } = await supabase
     .from('exposities')
-    .select('id, titel, start_datum, eind_datum, bron_url')
+    .select('id, titel, start_datum, eind_datum, bron_url, image_url')
     .eq('museum_id', museum.id)
     .or(`eind_datum.gte.${today},eind_datum.is.null`)
     .order('start_datum', { ascending: true, nullsFirst: false });


### PR DESCRIPTION
## Summary
- display externally hosted images on exposition cards when available
- load image_url field for exposities during server-side fetching

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68beaa646ce88326baa8f8785ab33168