### PR TITLE
Add ticket purchase button for each museum

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -91,6 +91,18 @@ export default function MuseumCard({ museum }) {
             />
           )}
         </Link>
+        {museum.ticketUrl && (
+          <div className="museum-card-ticket">
+            <a
+              href={museum.ticketUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="ticket-button"
+            >
+              Ticket Kopen
+            </a>
+          </div>
+        )}
         <div className="museum-card-actions">
           <button className="icon-button" aria-label="Deel" onClick={shareMuseum}>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">

--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -91,18 +91,17 @@ export default function MuseumCard({ museum }) {
             />
           )}
         </Link>
-        {museum.ticketUrl && (
-          <div className="museum-card-ticket">
-            <a
-              href={museum.ticketUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="ticket-button"
-            >
-              Ticket Kopen
-            </a>
-          </div>
-        )}
+        <div className="museum-card-ticket">
+          <a
+            href={museum.ticketUrl || '#'}
+            target="_blank"
+            rel="noreferrer"
+            className="ticket-button"
+            aria-disabled={!museum.ticketUrl}
+          >
+            Ticket Kopen
+          </a>
+        </div>
         <div className="museum-card-actions">
           <button className="icon-button" aria-label="Deel" onClick={shareMuseum}>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">

--- a/pages/index.js
+++ b/pages/index.js
@@ -63,7 +63,7 @@ export default function Home({ items, q, hasExposities }) {
                   free: m.gratis_toegankelijk,
                   summary: museumSummaries[m.slug],
                   image: museumImages[m.slug],
-                  ticketUrl: m.ticket_affiliate_url,
+                  ticketUrl: m.ticket_affiliate_url || m.website_url,
                 }}
               />
             </li>
@@ -84,7 +84,7 @@ export async function getServerSideProps({ query }) {
 
   let db = supabase
     .from('musea')
-    .select('id, naam, stad, provincie, slug, gratis_toegankelijk, ticket_affiliate_url')
+    .select('id, naam, stad, provincie, slug, gratis_toegankelijk, ticket_affiliate_url, website_url')
     .order('naam', { ascending: true });
 
   if (q) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -63,6 +63,7 @@ export default function Home({ items, q, hasExposities }) {
                   free: m.gratis_toegankelijk,
                   summary: museumSummaries[m.slug],
                   image: museumImages[m.slug],
+                  ticketUrl: m.ticket_affiliate_url,
                 }}
               />
             </li>
@@ -83,7 +84,7 @@ export async function getServerSideProps({ query }) {
 
   let db = supabase
     .from('musea')
-    .select('id, naam, stad, provincie, slug, gratis_toegankelijk')
+    .select('id, naam, stad, provincie, slug, gratis_toegankelijk, ticket_affiliate_url')
     .order('naam', { ascending: true });
 
   if (q) {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -149,6 +149,21 @@ img { max-width: 100%; height: auto; display: block; }
   display: flex;
   gap: 8px;
 }
+.museum-card-ticket {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+}
+.ticket-button {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 8px;
+  background: var(--accent);
+  color: var(--accent-ink);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
 .icon-button {
   width: 32px;
   height: 32px;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -153,6 +153,7 @@ img { max-width: 100%; height: auto; display: block; }
   position: absolute;
   top: 8px;
   left: 8px;
+  z-index: 1;
 }
 .ticket-button {
   padding: 6px 12px;
@@ -163,6 +164,11 @@ img { max-width: 100%; height: auto; display: block; }
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+.ticket-button[aria-disabled="true"] {
+  opacity: 0.5;
+  pointer-events: none;
 }
 .icon-button {
   width: 32px;


### PR DESCRIPTION
## Summary
- show prominent "Ticket Kopen" button on museum cards linking to affiliate ticket URL
- fetch ticket URL from Supabase and pass it to museum cards
- add styling for a visible ticket purchase button

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68beb192c3048326ac4b0c297ef68e35