### PR TITLE
Invert ticket button colors on hover

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -166,6 +166,10 @@ img { max-width: 100%; height: auto; display: block; }
   cursor: pointer;
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
 }
+.ticket-button:hover {
+  background: var(--accent-ink);
+  color: var(--accent);
+}
 .ticket-button[aria-disabled="true"] {
   opacity: 0.5;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- invert ticket button colors on hover to improve visual feedback

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68beb529d3b88326aea1d6adf9efaf04