### PR TITLE
feat: add museum building logo

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,5 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" fill="#1E3A8A"/>
-  <text x="32" y="28" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="12" text-anchor="middle">Museum</text>
-  <text x="32" y="50" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="12" text-anchor="middle">Buddy</text>
+  <text x="32" y="28" fill="#1E3A8A" font-family="Arial, sans-serif" font-size="12" text-anchor="middle">Museum</text>
+  <text x="32" y="50" fill="#1E3A8A" font-family="Arial, sans-serif" font-size="12" text-anchor="middle">Buddy</text>
 </svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,8 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <rect width="64" height="64" rx="8" fill="#1E3A8A"/>
-  <polygon points="32 12 12 24 52 24" fill="#F8FAFC"/>
-  <rect x="18" y="24" width="4" height="20" fill="#F8FAFC"/>
-  <rect x="30" y="24" width="4" height="20" fill="#F8FAFC"/>
-  <rect x="42" y="24" width="4" height="20" fill="#F8FAFC"/>
-  <rect x="12" y="44" width="40" height="4" fill="#F8FAFC"/>
+  <text x="32" y="28" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="12" text-anchor="middle">Museum</text>
+  <text x="32" y="50" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="12" text-anchor="middle">Buddy</text>
 </svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,4 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" fill="#000"/>
-  <text x="50%" y="52%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="700" fill="#fff">MB</text>
+  <rect width="64" height="64" rx="8" fill="#1E3A8A"/>
+  <polygon points="32 12 12 24 52 24" fill="#F8FAFC"/>
+  <rect x="18" y="24" width="4" height="20" fill="#F8FAFC"/>
+  <rect x="30" y="24" width="4" height="20" fill="#F8FAFC"/>
+  <rect x="42" y="24" width="4" height="20" fill="#F8FAFC"/>
+  <rect x="12" y="44" width="40" height="4" fill="#F8FAFC"/>
 </svg>


### PR DESCRIPTION
## Summary
- add simple museum icon logo for MuseumBuddy

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bec00058148326b8574bf897579dd5