### PR TITLE
feat: add Museum Buddy logo

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -10,8 +10,8 @@ export default function Layout({ children }) {
             <Image
               src="/logo.svg"
               alt="Museum Buddy"
-              width={100}
-              height={100}
+              width={150}
+              height={150}
               className="brand-logo"
               priority
             />

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -10,8 +10,8 @@ export default function Layout({ children }) {
             <Image
               src="/logo.svg"
               alt="Museum Buddy"
-              width={32}
-              height={32}
+              width={100}
+              height={100}
               className="brand-logo"
               priority
             />

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,12 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-  <g fill="#000">
-    <rect x="20" y="20" width="160" height="20" />
-    <rect x="40" y="60" width="30" height="80" />
-    <rect x="85" y="60" width="30" height="80" />
-    <rect x="130" y="60" width="30" height="80" />
-  </g>
-  <text x="100" y="160" font-family="Helvetica, Arial, sans-serif"
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 80">
+  <text x="100" y="35" font-family="Helvetica, Arial, sans-serif"
         font-weight="700" font-size="28" text-anchor="middle">Museum</text>
-  <text x="100" y="190" font-family="Helvetica, Arial, sans-serif"
+  <text x="100" y="65" font-family="Helvetica, Arial, sans-serif"
         font-weight="700" font-size="28" text-anchor="middle">Buddy</text>
 </svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,4 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" fill="#000"/>
-  <text x="50%" y="52%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="700" fill="#fff">MB</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <g fill="#000">
+    <rect x="20" y="20" width="160" height="20" />
+    <rect x="40" y="60" width="30" height="80" />
+    <rect x="85" y="60" width="30" height="80" />
+    <rect x="130" y="60" width="30" height="80" />
+  </g>
+  <text x="100" y="160" font-family="Helvetica, Arial, sans-serif"
+        font-weight="700" font-size="28" text-anchor="middle">Museum</text>
+  <text x="100" y="190" font-family="Helvetica, Arial, sans-serif"
+        font-weight="700" font-size="28" text-anchor="middle">Buddy</text>
 </svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -32,7 +32,7 @@ img { max-width: 100%; height: auto; display: block; }
 }
 .navbar { display:flex; align-items:center; gap:16px; padding: 16px 24px; }
 .brand { font-weight:700; font-size: 20px; letter-spacing: .2px; }
-.brand-logo { display:block; height:32px; }
+.brand-logo { display:block; height:100px; }
 .navspacer { flex:1 }
 .navlink { color: var(--muted); font-size: 14px; }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -32,7 +32,7 @@ img { max-width: 100%; height: auto; display: block; }
 }
 .navbar { display:flex; align-items:center; gap:16px; padding: 16px 24px; }
 .brand { font-weight:700; font-size: 20px; letter-spacing: .2px; }
-.brand-logo { display:block; height:100px; }
+.brand-logo { display:block; height:150px; }
 .navspacer { flex:1 }
 .navlink { color: var(--muted); font-size: 14px; }
 


### PR DESCRIPTION
## Summary
- replace placeholder logo with Museum Buddy design
- enlarge logo usage in layout and styles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bec2d1fe788326a5624ff9b90bd88f