### PR TITLE
Remove Musea link from header

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -18,7 +18,6 @@ export default function Layout({ children }) {
           </Link>
           <div className="navspacer" />
           {/* Eventuele navigatie-items voor later */}
-          <Link href="/" className="navlink">Musea</Link>
         </nav>
       </header>
       <main className="container">{children}</main>


### PR DESCRIPTION
## Summary
- remove Musea link from layout header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bec5716df48326861aa97a9c8b8967