### PR TITLE
feat: implement header layout

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import Link from 'next/link';
 
 export default function Layout({ children }) {
@@ -6,18 +5,60 @@ export default function Layout({ children }) {
     <>
       <header className="header">
         <nav className="navbar container">
-          <Link href="/" className="brand">
-            <Image
-              src="/logo.svg"
-              alt="Museum Buddy"
-              width={60}
-              height={60}
-              className="brand-logo"
-              priority
-            />
-          </Link>
+          <div className="brand-wrap">
+            <Link href="/" className="brand-square" aria-label="MuseumBuddy Home">
+              <span className="brand-text">MUSEUM<br />BUDDY</span>
+            </Link>
+            <span className="brand-title">MuseumBuddy</span>
+          </div>
           <div className="navspacer" />
-          {/* Eventuele navigatie-items voor later */}
+          <div className="header-actions">
+            <button type="button" className="lang-select">
+              EN
+              <svg viewBox="0 0 12 8" aria-hidden="true">
+                <path
+                  d="M1 1l5 5 5-5"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+            <button type="button" className="contrast-toggle">
+              Contrast
+            </button>
+            <button type="button" className="header-icon" aria-label="Document">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <rect x="3" y="3" width="18" height="18" rx="2" />
+                <path d="M7 7h10M7 11h10M7 15h10" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              className="header-icon"
+              aria-label="Favorieten"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M21 8.25c0 4.556-9 11.25-9 11.25S3 12.806 3 8.25a5.25 5.25 0 0 1 9-3.676A5.25 5.25 0 0 1 21 8.25Z" />
+              </svg>
+            </button>
+          </div>
         </nav>
       </header>
       <main className="container">{children}</main>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -31,10 +31,49 @@ img { max-width: 100%; height: auto; display: block; }
   backdrop-filter: blur(8px);
 }
 .navbar { display:flex; align-items:center; gap:16px; padding: 16px 24px; }
-.brand { font-weight:700; font-size: 20px; letter-spacing: .2px; }
-.brand-logo { display:block; height:32px; }
 .navspacer { flex:1 }
 .navlink { color: var(--muted); font-size: 14px; }
+
+/* Header brand */
+.brand-wrap { display:flex; align-items:center; gap:12px; }
+.brand-square {
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  width:48px;
+  height:48px;
+  border-radius:8px;
+  background:#f3efe5;
+  text-align:center;
+}
+.brand-text { font-size:10px; font-weight:700; line-height:1.1; }
+.brand-title { font-weight:700; font-size:24px; }
+
+/* Header actions */
+.header-actions { display:flex; align-items:center; gap:16px; }
+.lang-select,
+.contrast-toggle {
+  display:flex;
+  align-items:center;
+  gap:4px;
+  background:none;
+  border:none;
+  font-size:14px;
+  cursor:pointer;
+}
+.lang-select svg { width:12px; height:8px; }
+.header-icon {
+  background:none;
+  border:none;
+  padding:0;
+  width:32px;
+  height:32px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  cursor:pointer;
+}
+.header-icon svg { width:20px; height:20px; }
 
 .page-title { margin: 8px 0 4px; font-size: 28px; font-weight: 700; }
 .page-subtitle { margin: 0 0 16px; color: var(--muted); }


### PR DESCRIPTION
## Summary
- add header with brand, language selector, contrast toggle, and icons
- style header elements

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bed0522b0c8326926abdc2cf910cbd