### PR TITLE
Set non-header background to #DED7B7

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -10,6 +10,7 @@
 *{ box-sizing:border-box }
 html, body { padding:0; margin:0; background:var(--bg); color:var(--text); }
 body {
+  background:#DED7B7;
   font-family: system-ui, -apple-system, Segoe UI, Ubuntu, Cantarell, Noto Sans, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
   font-weight: 400;
   line-height: 1.6;


### PR DESCRIPTION
## Summary
- apply #DED7B7 as page background while preserving the header's original color

## Testing
- `npm test` *(fails: Missing script: "test"*)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bed1f1c5708326b7f6c27840ed4f98