### PR TITLE
Add expositions page with ticket button hover effect

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -79,6 +79,17 @@ export default function ExpositionCard({ exposition, status, periode }) {
         ) : (
           <div style={{ width: '100%', height: '100%', background: '#ddd' }} />
         )}
+        <div className="museum-card-ticket">
+          <a
+            href={exposition.bron_url || '#'}
+            target="_blank"
+            rel="noreferrer"
+            className="ticket-button"
+            aria-disabled={!exposition.bron_url}
+          >
+            Ticket Kopen
+          </a>
+        </div>
         <div className="museum-card-actions">
           <button className="icon-button" aria-label="Deel" onClick={shareExposition}>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">

--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -66,61 +66,15 @@ export default function ExpositionCard({ exposition, status, periode }) {
 
   return (
     <article className="museum-card exposition-card">
-      <div className="museum-card-image">
-        {exposition.bron_url ? (
-          <a
-            href={exposition.bron_url}
-            target="_blank"
-            rel="noreferrer"
-            style={{ display: 'block', width: '100%', height: '100%' }}
-          >
-            <div style={{ width: '100%', height: '100%', background: '#ddd' }} />
-          </a>
-        ) : (
-          <div style={{ width: '100%', height: '100%', background: '#ddd' }} />
-        )}
-        <div className="museum-card-ticket">
-          <a
-            href={exposition.bron_url || '#'}
-            target="_blank"
-            rel="noreferrer"
-            className="ticket-button"
-            aria-disabled={!exposition.bron_url}
-          >
-            Ticket Kopen
-          </a>
-        </div>
-        <div className="museum-card-actions">
-          <button className="icon-button" aria-label="Deel" onClick={shareExposition}>
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7" />
-              <path d="M16 6l-4-4-4 4" />
-              <path d="M12 2v14" />
-            </svg>
-          </button>
-          <button
-            className={`icon-button${isFavorite ? ' favorited' : ''}`}
-            aria-label="Bewaar"
-            aria-pressed={isFavorite}
-            onClick={toggleFavorite}
-          >
-            <svg
-              viewBox="0 0 24 24"
-              fill={isFavorite ? 'currentColor' : 'none'}
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M21 8.25c0 4.556-9 11.25-9 11.25S3 12.806 3 8.25a5.25 5.25 0 0 1 9-3.676A5.25 5.25 0 0 1 21 8.25Z" />
-            </svg>
-          </button>
-        </div>
-      </div>
       <div className="museum-card-info">
         <h3 className="museum-card-title">
           {exposition.bron_url ? (
-            <a href={exposition.bron_url} target="_blank" rel="noreferrer" style={{ color: 'inherit', textDecoration: 'none' }}>
+            <a
+              href={exposition.bron_url}
+              target="_blank"
+              rel="noreferrer"
+              style={{ color: 'inherit', textDecoration: 'none' }}
+            >
               {exposition.titel}
             </a>
           ) : (
@@ -133,6 +87,41 @@ export default function ExpositionCard({ exposition, status, periode }) {
             <span className="tag">{status}</span>
           </div>
         )}
+      </div>
+      <div className="museum-card-actions">
+        <a
+          href={exposition.bron_url || '#'}
+          target="_blank"
+          rel="noreferrer"
+          className="ticket-button"
+          aria-disabled={!exposition.bron_url}
+        >
+          Ticket Kopen
+        </a>
+        <button className="icon-button" aria-label="Deel" onClick={shareExposition}>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7" />
+            <path d="M16 6l-4-4-4 4" />
+            <path d="M12 2v14" />
+          </svg>
+        </button>
+        <button
+          className={`icon-button${isFavorite ? ' favorited' : ''}`}
+          aria-label="Bewaar"
+          aria-pressed={isFavorite}
+          onClick={toggleFavorite}
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill={isFavorite ? 'currentColor' : 'none'}
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M21 8.25c0 4.556-9 11.25-9 11.25S3 12.806 3 8.25a5.25 5.25 0 0 1 9-3.676A5.25 5.25 0 0 1 21 8.25Z" />
+          </svg>
+        </button>
       </div>
     </article>
   );

--- a/pages/exposities.js
+++ b/pages/exposities.js
@@ -48,7 +48,7 @@ export default function Exposities({ exposities, error }) {
       {!exposities || exposities.length === 0 ? (
         <p>Geen lopende of komende exposities.</p>
       ) : (
-        <ul className="grid" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+        <ul className="exposition-list">
           {exposities.map((e) => {
             const start = e.start_datum ? new Date(e.start_datum + 'T00:00:00') : null;
             const end = e.eind_datum ? new Date(e.eind_datum + 'T00:00:00') : null;

--- a/pages/exposities.js
+++ b/pages/exposities.js
@@ -1,0 +1,104 @@
+import Head from 'next/head';
+import { createClient } from '@supabase/supabase-js';
+import ExpositionCard from '../components/ExpositionCard';
+
+function formatDate(d) {
+  if (!d) return '';
+  try {
+    const date = new Date(d + 'T00:00:00');
+    return date.toLocaleDateString('nl-NL', { day: '2-digit', month: '2-digit', year: 'numeric' });
+  } catch {
+    return d;
+  }
+}
+
+function todayYMD(tz = 'Europe/Amsterdam') {
+  const fmt = new Intl.DateTimeFormat('sv-SE', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  return fmt.format(new Date());
+}
+
+export default function Exposities({ exposities, error }) {
+  if (error) {
+    return (
+      <>
+        <Head>
+          <title>Exposities — MuseumBuddy</title>
+        </Head>
+        <p>Er ging iets mis</p>
+        <a href="/" style={{ display: 'inline-block', marginTop: '1rem' }}>&larr; Terug</a>
+      </>
+    );
+  }
+
+  const todayStr = todayYMD('Europe/Amsterdam');
+  const today = new Date(todayStr + 'T00:00:00');
+
+  return (
+    <>
+      <Head>
+        <title>Exposities — MuseumBuddy</title>
+        <meta name="description" content="Overzicht van lopende en komende exposities." />
+      </Head>
+      <h1 className="page-title">Exposities</h1>
+      {!exposities || exposities.length === 0 ? (
+        <p>Geen lopende of komende exposities.</p>
+      ) : (
+        <ul className="grid" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+          {exposities.map((e) => {
+            const start = e.start_datum ? new Date(e.start_datum + 'T00:00:00') : null;
+            const end = e.eind_datum ? new Date(e.eind_datum + 'T00:00:00') : null;
+
+            let status = '';
+            if (start && start > today) status = 'Komt eraan';
+            else if ((!start || start <= today) && (!end || end >= today)) status = 'Loopt nu';
+
+            const periode = [formatDate(e.start_datum), formatDate(e.eind_datum)]
+              .filter(Boolean)
+              .join(' – ');
+
+            return (
+              <li key={e.id}>
+                <ExpositionCard exposition={e} status={status} periode={periode} />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </>
+  );
+}
+
+export async function getServerSideProps() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anon) {
+    return { props: { exposities: [], error: true } };
+  }
+
+  const supabase = createClient(url, anon);
+  const today = todayYMD('Europe/Amsterdam');
+
+  const { data, error } = await supabase
+    .from('exposities')
+    .select('id, titel, start_datum, eind_datum, bron_url')
+    .or(`eind_datum.gte.${today},eind_datum.is.null`)
+    .order('start_datum', { ascending: true, nullsFirst: false });
+
+  if (error) {
+    return { props: { exposities: [], error: true } };
+  }
+
+  return {
+    props: {
+      exposities: data || [],
+      error: false,
+    },
+  };
+}
+

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -272,6 +272,16 @@ img { max-width: 100%; height: auto; display: block; }
   margin-top: 8px;
 }
 
+/* Exposition card hover border */
+.exposition-card {
+  border: 2px solid #ffffff;
+  transition: border-color 0.3s ease;
+}
+
+.exposition-card:hover {
+  border-color: #000000;
+}
+
 /* Smaller typography for exposition cards */
 .exposition-card .museum-card-title {
   font-size: 16px;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -112,6 +112,15 @@ img { max-width: 100%; height: auto; display: block; }
 @media (min-width: 640px){ .grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 @media (min-width: 1024px){ .grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
 
+.exposition-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
 .card {
   position: relative;
   width: 100%;
@@ -273,9 +282,12 @@ img { max-width: 100%; height: auto; display: block; }
 }
 
 /* Exposition card hover border */
+
 .exposition-card {
   border: 2px solid #ffffff;
   transition: border-color 0.3s ease;
+  flex-direction: row;
+  align-items: center;
 }
 
 .exposition-card:hover {
@@ -293,4 +305,15 @@ img { max-width: 100%; height: auto; display: block; }
 
 .exposition-card .tag {
   font-size: 12px;
+}
+
+.exposition-card .museum-card-info {
+  flex: 1;
+}
+
+.exposition-card .museum-card-actions {
+  position: static;
+  top: auto;
+  right: auto;
+  margin-left: 16px;
 }


### PR DESCRIPTION
## Summary
- add dedicated `/exposities` page listing active and upcoming exhibitions
- enable ticket button and hover border styling for exposition cards

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bed37597e083268b722af756edf3a9