### PR TITLE
Add ticket purchase option for exposition listings

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-export default function ExpositionCard({ exposition, status, periode }) {
+export default function ExpositionCard({ exposition, status, periode, ticketUrl }) {
   if (!exposition) return null;
 
   const [isFavorite, setIsFavorite] = useState(false);
@@ -120,6 +120,18 @@ export default function ExpositionCard({ exposition, status, periode }) {
         {status && (
           <div className="museum-card-tags">
             <span className="tag">{status}</span>
+          </div>
+        )}
+        {ticketUrl && (
+          <div className="exposition-ticket">
+            <a
+              href={ticketUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="ticket-button"
+            >
+              Ticket Kopen
+            </a>
           </div>
         )}
       </div>

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -98,7 +98,7 @@ export default function MuseumDetail({ museum, exposities, error }) {
           )}
         </div>
 
-        <h2 className="page-title">Exposities</h2>
+        <h2 className="page-title">Expositie</h2>
         {!exposities || exposities.length === 0 ? (
           <p>Geen lopende of komende exposities.</p>
         ) : (
@@ -117,7 +117,12 @@ export default function MuseumDetail({ museum, exposities, error }) {
 
               return (
                 <li key={e.id}>
-                  <ExpositionCard exposition={e} status={status} periode={periode} />
+                  <ExpositionCard
+                    exposition={e}
+                    status={status}
+                    periode={periode}
+                    ticketUrl={museum.ticket_affiliate_url || museum.website_url || e.bron_url}
+                  />
                 </li>
               );
             })}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -284,3 +284,12 @@ img { max-width: 100%; height: auto; display: block; }
 .exposition-card .tag {
   font-size: 12px;
 }
+
+.exposition-card .exposition-ticket {
+  margin-top: 8px;
+}
+
+.exposition-card .ticket-button {
+  font-size: 12px;
+  padding: 4px 8px;
+}


### PR DESCRIPTION
## Summary
- show "Ticket Kopen" button on exposition cards
- pass museum ticket URL to exposition cards and tweak heading
- style exposition ticket button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bef01da9908326a50d4bcea59d8082