### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,8 +1,12 @@
 import Link from 'next/link';
+import Head from 'next/head';
 
 export default function Layout({ children }) {
   return (
     <>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
       <header className="header">
         <nav className="navbar container">
           <div className="brand-wrap">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -76,6 +76,14 @@ img { max-width: 100%; height: auto; display: block; }
 }
 .header-icon svg { width:20px; height:20px; }
 
+@media (max-width: 600px) {
+  .brand-title { display: none; }
+  .navbar { padding: 16px 12px; }
+  .header-actions { gap: 8px; }
+  .lang-select,
+  .contrast-toggle { display: none; }
+}
+
 .page-title { margin: 8px 0 4px; font-size: 28px; font-weight: 700; }
 .page-subtitle { margin: 0 0 16px; color: var(--muted); }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -338,3 +338,24 @@ img { max-width: 100%; height: auto; display: block; }
   margin-left: auto;
 }
 
+@media (max-width: 600px) {
+  .event-card {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 12px;
+    gap: 12px;
+  }
+  .event-card-date {
+    width: 100%;
+    text-align: left;
+    margin-bottom: 8px;
+  }
+  .event-card-actions {
+    margin-left: 0;
+    width: 100%;
+    margin-top: 8px;
+  }
+  .event-card-actions .ticket-button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- ensure pages scale correctly on mobile by adding viewport meta tag
- optimize header for small screens by hiding excess buttons and tightening spacing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bef937d5d88326b6c16852a607f0bf