### PR TITLE
Add favorites tracking and page

### DIFF
--- a/components/FavoritesContext.js
+++ b/components/FavoritesContext.js
@@ -1,0 +1,54 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+const FavoritesContext = createContext({ favorites: [], toggleFavorite: () => {} });
+
+export function FavoritesProvider({ children }) {
+  const [favorites, setFavorites] = useState([]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = JSON.parse(localStorage.getItem('favorites') || '[]');
+      if (Array.isArray(stored)) {
+        const valid = stored.filter(
+          (m) =>
+            m &&
+            typeof m === 'object' &&
+            'id' in m &&
+            'slug' in m &&
+            'image' in m &&
+            'title' in m
+        );
+        setFavorites(valid);
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem('favorites', JSON.stringify(favorites));
+    } catch {
+      // ignore
+    }
+  }, [favorites]);
+
+  const toggleFavorite = (museum) => {
+    setFavorites((prev) => {
+      const exists = prev.some((m) => m.id === museum.id);
+      return exists ? prev.filter((m) => m.id !== museum.id) : [...prev, museum];
+    });
+  };
+
+  return (
+    <FavoritesContext.Provider value={{ favorites, toggleFavorite }}>
+      {children}
+    </FavoritesContext.Provider>
+  );
+}
+
+export function useFavorites() {
+  return useContext(FavoritesContext);
+}

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,7 +1,9 @@
 import Link from 'next/link';
 import Head from 'next/head';
+import { useFavorites } from './FavoritesContext';
 
 export default function Layout({ children }) {
+  const { favorites } = useFavorites();
   return (
     <>
       <Head>
@@ -46,11 +48,7 @@ export default function Layout({ children }) {
                 <path d="M7 7h10M7 11h10M7 15h10" />
               </svg>
             </button>
-            <button
-              type="button"
-              className="header-icon"
-              aria-label="Favorieten"
-            >
+            <Link href="/favorites" className="header-icon" aria-label="Favorieten">
               <svg
                 viewBox="0 0 24 24"
                 fill="none"
@@ -61,7 +59,10 @@ export default function Layout({ children }) {
               >
                 <path d="M21 8.25c0 4.556-9 11.25-9 11.25S3 12.806 3 8.25a5.25 5.25 0 0 1 9-3.676A5.25 5.25 0 0 1 21 8.25Z" />
               </svg>
-            </button>
+              {favorites.length > 0 && (
+                <span className="favorite-count">{favorites.length}</span>
+              )}
+            </Link>
           </div>
         </nav>
       </header>

--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -1,40 +1,20 @@
 import Link from 'next/link';
 import Image from 'next/image';
-import { useEffect, useState, useMemo } from 'react';
+import { useMemo } from 'react';
+import { useFavorites } from './FavoritesContext';
 
 export default function MuseumCard({ museum }) {
   if (!museum) return null;
 
-  const [isFavorite, setIsFavorite] = useState(false);
+  const { favorites, toggleFavorite } = useFavorites();
+  const isFavorite = favorites.some((f) => f.id === museum.id);
   const hoverColor = useMemo(() => {
     const colors = ['#A7D8F0', '#77DDDD', '#F7C59F', '#D8BFD8', '#EAE0C8'];
     return colors[Math.floor(Math.random() * colors.length)];
   }, [museum.id]);
 
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    try {
-      const stored = JSON.parse(localStorage.getItem('favorites') || '[]');
-      setIsFavorite(stored.includes(museum.id));
-    } catch {
-      // ignore
-    }
-  }, [museum.id]);
-
-  const toggleFavorite = () => {
-    if (typeof window === 'undefined') return;
-    try {
-      const stored = JSON.parse(localStorage.getItem('favorites') || '[]');
-      const exists = stored.includes(museum.id);
-      const next = exists
-        ? stored.filter((id) => id !== museum.id)
-        : [...stored, museum.id];
-
-      localStorage.setItem('favorites', JSON.stringify(next));
-      setIsFavorite(!exists);
-    } catch {
-      // ignore
-    }
+  const handleFavorite = () => {
+    toggleFavorite(museum);
   };
 
   const shareMuseum = async () => {
@@ -114,7 +94,7 @@ export default function MuseumCard({ museum }) {
             className={`icon-button${isFavorite ? ' favorited' : ''}`}
             aria-label="Bewaar"
             aria-pressed={isFavorite}
-            onClick={toggleFavorite}
+            onClick={handleFavorite}
           >
             <svg
               viewBox="0 0 24 24"

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,9 +1,13 @@
 import '../styles/globals.css';
 import Layout from '../components/Layout';
+import { FavoritesProvider } from '../components/FavoritesContext';
+
 export default function MyApp({ Component, pageProps }) {
   return (
-    <Layout>
-      <Component {...pageProps} />
-    </Layout>
+    <FavoritesProvider>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </FavoritesProvider>
   );
 }

--- a/pages/favorites.js
+++ b/pages/favorites.js
@@ -1,0 +1,27 @@
+import Head from 'next/head';
+import MuseumCard from '../components/MuseumCard';
+import { useFavorites } from '../components/FavoritesContext';
+
+export default function FavoritesPage() {
+  const { favorites } = useFavorites();
+
+  return (
+    <>
+      <Head>
+        <title>Favorieten</title>
+      </Head>
+      <h1 className="page-title">Favorieten</h1>
+      {favorites.length === 0 ? (
+        <p>Geen favorieten.</p>
+      ) : (
+        <ul className="grid" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+          {favorites.map((m) => (
+            <li key={m.id}>
+              <MuseumCard museum={m} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -73,8 +73,24 @@ img { max-width: 100%; height: auto; display: block; }
   align-items:center;
   justify-content:center;
   cursor:pointer;
+  position:relative;
 }
 .header-icon svg { width:20px; height:20px; }
+.header-icon .favorite-count {
+  position:absolute;
+  top:-4px;
+  right:-4px;
+  background:var(--accent);
+  color:var(--accent-ink);
+  border-radius:9999px;
+  min-width:16px;
+  height:16px;
+  font-size:12px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:0 4px;
+}
 
 @media (max-width: 600px) {
   .brand-title { display: none; }


### PR DESCRIPTION
## Summary
- track favorites across app with new FavoritesContext
- show favorite count in header and link to favorites page
- list saved museums on new /favorites page
- normalize stored favorites to ignore legacy ID entries

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c016d8a7d0832692f5404133f57639