### PR TITLE
Add About page and link from header

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -35,7 +35,7 @@ export default function Layout({ children }) {
             <button type="button" className="contrast-toggle">
               Contrast
             </button>
-            <button type="button" className="header-icon" aria-label="Document">
+            <Link href="/about" className="header-icon" aria-label="About MuseumBuddy">
               <svg
                 viewBox="0 0 24 24"
                 fill="none"
@@ -47,7 +47,7 @@ export default function Layout({ children }) {
                 <rect x="3" y="3" width="18" height="18" rx="2" />
                 <path d="M7 7h10M7 11h10M7 15h10" />
               </svg>
-            </button>
+            </Link>
             <Link href="/favorites" className="header-icon" aria-label="Favorieten">
               <svg
                 viewBox="0 0 24 24"

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,0 +1,13 @@
+import Head from 'next/head';
+
+export default function AboutPage() {
+  return (
+    <>
+      <Head>
+        <title>About MuseumBuddy</title>
+      </Head>
+      <h1 className="page-title">About MuseumBuddy</h1>
+      <p>This page will contain information about MuseumBuddy.</p>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholder About MuseumBuddy page for future content
- link document icon in header to About page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c023711bec83269181a50773f10092