### PR TITLE
feat: add theme toggle with mobile support

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -2,10 +2,12 @@ import Link from 'next/link';
 import Head from 'next/head';
 import { useFavorites } from './FavoritesContext';
 import { useLanguage } from './LanguageContext';
+import { useTheme } from './ThemeContext';
 
 export default function Layout({ children }) {
   const { favorites } = useFavorites();
   const { lang, switchLang, t } = useLanguage();
+  const { theme, toggleTheme } = useTheme();
   return (
     <>
       <Head>
@@ -38,8 +40,43 @@ export default function Layout({ children }) {
                 />
               </svg>
             </button>
-            <button type="button" className="contrast-toggle">
-              {t('contrast')}
+            <button
+              type="button"
+              className="contrast-toggle"
+              onClick={toggleTheme}
+              aria-label={t('contrast')}
+            >
+              {theme === 'dark' ? (
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <circle cx="12" cy="12" r="5" />
+                  <line x1="12" y1="1" x2="12" y2="3" />
+                  <line x1="12" y1="21" x2="12" y2="23" />
+                  <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+                  <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+                  <line x1="1" y1="12" x2="3" y2="12" />
+                  <line x1="21" y1="12" x2="23" y2="12" />
+                  <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+                  <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+                </svg>
+              ) : (
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+                </svg>
+              )}
             </button>
             <Link href="/about" className="header-icon" aria-label={t('aboutLabel')}>
               <svg

--- a/components/ThemeContext.js
+++ b/components/ThemeContext.js
@@ -1,0 +1,42 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext();
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem('theme');
+      if (stored === 'light' || stored === 'dark') {
+        setTheme(stored);
+        document.documentElement.dataset.theme = stored;
+      } else {
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const initial = prefersDark ? 'dark' : 'light';
+        setTheme(initial);
+        document.documentElement.dataset.theme = initial;
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      document.documentElement.dataset.theme = theme;
+      window.localStorage.setItem('theme', theme);
+    }
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(theme === 'dark' ? 'light' : 'dark');
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,14 +2,17 @@ import '../styles/globals.css';
 import Layout from '../components/Layout';
 import { FavoritesProvider } from '../components/FavoritesContext';
 import { LanguageProvider } from '../components/LanguageContext';
+import { ThemeProvider } from '../components/ThemeContext';
 
 export default function MyApp({ Component, pageProps }) {
   return (
     <LanguageProvider>
       <FavoritesProvider>
-        <Layout>
-          <Component {...pageProps} />
-        </Layout>
+        <ThemeProvider>
+          <Layout>
+            <Component {...pageProps} />
+          </Layout>
+        </ThemeProvider>
       </FavoritesProvider>
     </LanguageProvider>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,16 +1,28 @@
 :root{
   --bg:#ffffff;          /* zachte achtergrondkleur */
+  --body-bg:#DED7B7;     /* originele body achtergrond */
   --text:#000000;
   --muted:#6b7280;       /* grijs voor subtitels */
   --border:#e5e7eb;      /* subtiele randen */
   --accent:#000000;      /* warme accentkleur */
   --accent-ink:#ffffff;
+  --surface:#f3f4f6;
+}
+
+[data-theme='dark']{
+  --bg:#0f172a;
+  --body-bg:#0f172a;
+  --text:#f1f5f9;
+  --muted:#94a3b8;
+  --border:#1e293b;
+  --accent:#f1f5f9;
+  --accent-ink:#000000;
+  --surface:#1f2937;
 }
 
 *{ box-sizing:border-box }
-html, body { padding:0; margin:0; background:var(--bg); color:var(--text); }
+html, body { padding:0; margin:0; background:var(--body-bg); color:var(--text); }
 body {
-  background:#DED7B7;
   font-family: system-ui, -apple-system, Segoe UI, Ubuntu, Cantarell, Noto Sans, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
   font-weight: 400;
   line-height: 1.6;
@@ -44,7 +56,7 @@ img { max-width: 100%; height: auto; display: block; }
   width:48px;
   height:48px;
   border-radius:8px;
-  background:#f3efe5;
+  background:var(--surface);
   text-align:center;
 }
 .brand-text { font-size:10px; font-weight:700; line-height:1.1; }
@@ -63,6 +75,7 @@ img { max-width: 100%; height: auto; display: block; }
   cursor:pointer;
 }
 .lang-select svg { width:12px; height:8px; }
+.contrast-toggle svg { width:20px; height:20px; }
 .header-icon {
   background:none;
   border:none;
@@ -96,7 +109,6 @@ img { max-width: 100%; height: auto; display: block; }
   .brand-title { display: none; }
   .navbar { padding: 16px 12px; }
   .header-actions { gap: 8px; }
-  .contrast-toggle { display: none; }
 }
 
 .page-title { margin: 8px 0 4px; font-size: 28px; font-weight: 700; }
@@ -109,14 +121,14 @@ img { max-width: 100%; height: auto; display: block; }
   border: 1px solid var(--border);
   border-radius: 10px;
   font-size: 14px;
-  background: #fff;
+  background: var(--bg);
 }
 .controls { display:grid; gap:12px; }
 .control-row { display:flex; gap:16px; flex-wrap:wrap; align-items:center; }
 .checkbox { display:flex; gap:8px; align-items:center; color:#222; font-size:14px; }
 .btn-reset {
   padding: 8px 12px; border:1px solid var(--border); border-radius:10px;
-  background:#f8fafc; cursor:pointer; font-size:14px;
+  background:var(--surface); cursor:pointer; font-size:14px;
 }
 
 /* Tags */
@@ -142,7 +154,7 @@ img { max-width: 100%; height: auto; display: block; }
   border-radius: 16px;
   overflow: hidden;
   transition: transform .15s ease;
-  background: #f3f4f6;
+  background: var(--surface);
 }
 .card:hover { transform: translateY(-1px); }
 .card-title { margin:0; font-size:18px; font-weight:600; color:inherit; }
@@ -180,7 +192,7 @@ img { max-width: 100%; height: auto; display: block; }
   border-radius: 16px;
   overflow: hidden;
   margin: 12px 0 16px;
-  background: #f3f4f6;
+  background: var(--surface);
 }
 
 .hero img {
@@ -192,7 +204,7 @@ img { max-width: 100%; height: auto; display: block; }
 
 /* MuseumCard component */
 .museum-card {
-  background: #f3f4f6;
+  background: var(--surface);
   border-radius: 12px;
   overflow: hidden;
   box-shadow: 0 1px 2px rgba(0,0,0,0.05);
@@ -264,11 +276,11 @@ img { max-width: 100%; height: auto; display: block; }
 
 .museum-card-info {
   padding: 16px;
-  background: #fff;
+  background: var(--surface);
   transition: background 0.3s ease;
 }
 .museum-card:hover .museum-card-info {
-  background: var(--hover-bg, #fff);
+  background: var(--hover-bg, var(--surface));
 }
 .museum-card-title {
   margin: 0 0 8px;
@@ -308,7 +320,7 @@ img { max-width: 100%; height: auto; display: block; }
 .event-card {
   display: flex;
   align-items: center;
-  background: #f3f4f6;
+  background: var(--surface);
   border-radius: 12px;
   padding: 16px;
   gap: 16px;


### PR DESCRIPTION
## Summary
- add ThemeContext for light/dark mode
- expose contrast toggle button in header and mobile
- style site with CSS variables for dark theme
- restore original light background color

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c02dcaaefc832684e9cbb9b87455d0