### PR TITLE
Fix icon visibility in dark mode

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -73,6 +73,7 @@ img { max-width: 100%; height: auto; display: block; }
   border:none;
   font-size:14px;
   cursor:pointer;
+  color: var(--text);
 }
 .lang-select svg { width:12px; height:8px; }
 .contrast-toggle svg { width:20px; height:20px; }


### PR DESCRIPTION
## Summary
- ensure language selector and contrast toggle icons inherit theme color to display correctly in dark mode

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1404a5f108326a4e4a24f7a8ce5c6