### PR TITLE
Add descriptions to exhibition listings

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -43,6 +43,9 @@ export default function ExpositionCard({ exposition, periode }) {
           )}
         </h3>
         {periode && <p className="event-card-period">{periode}</p>}
+        {exposition.omschrijving && (
+          <p className="event-card-description">{exposition.omschrijving}</p>
+        )}
       </div>
       <div className="event-card-actions">
         <a

--- a/scripts/crawl.mjs
+++ b/scripts/crawl.mjs
@@ -209,19 +209,26 @@ async function crawlTarget(target) {
     }
     const bron_url = hrefCand || fetched.url;
 
+    const descCand = context.find('p').first().text();
+    const omschrijving = normalizeText(descCand).slice(0, 200);
+
     // Dedup op titel per museum
     if (existing.has(titel.toLowerCase())) {
       skippedDup++;
       return;
     }
 
-    rows.push({
+    const row = {
       museum_id: museum.id,
       titel,
       bron_url,
       is_tijdelijk: true,
       last_crawled_at: nowIso()
-    });
+    };
+
+    if (omschrijving) row.omschrijving = omschrijving;
+
+    rows.push(row);
   });
 
   let inserted = 0;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -362,6 +362,12 @@ img { max-width: 100%; height: auto; display: block; }
   color: var(--muted);
 }
 
+.event-card-description {
+  margin: 4px 0 0;
+  font-size: 14px;
+  color: var(--muted);
+}
+
 .event-card-actions {
   margin-left: auto;
 }


### PR DESCRIPTION
## Summary
- show short descriptions for exhibitions
- support fetching descriptions when crawling exhibition data
- tolerate missing description column so museum pages keep working

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c166b032708326bc266fe11013b238