### PR TITLE
Remove duplicate exposition duration

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -17,7 +17,7 @@ function formatRange(start, end, locale) {
   return `${startFmt} - ${endFmt}`;
 }
 
-export default function ExpositionCard({ exposition, periode }) {
+export default function ExpositionCard({ exposition }) {
   if (!exposition) return null;
 
   const start = exposition.start_datum ? new Date(exposition.start_datum + 'T00:00:00') : null;
@@ -42,7 +42,6 @@ export default function ExpositionCard({ exposition, periode }) {
             exposition.titel
           )}
         </h3>
-        {periode && <p className="event-card-period">{periode}</p>}
       </div>
       <div className="event-card-actions">
         <a

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -105,17 +105,11 @@ export default function MuseumDetail({ museum, exposities, error }) {
           <p>{t('noExpositions')}</p>
         ) : (
           <ul className="events-list">
-            {exposities.map((e) => {
-              const periode = [formatDate(e.start_datum, locale), formatDate(e.eind_datum, locale)]
-                .filter(Boolean)
-                .join(' – ');
-
-              return (
-                <li key={e.id}>
-                  <ExpositionCard exposition={e} periode={periode} />
-                </li>
-              );
-            })}
+            {exposities.map((e) => (
+              <li key={e.id}>
+                <ExpositionCard exposition={e} />
+              </li>
+            ))}
           </ul>
         )}
       </main>


### PR DESCRIPTION
## Summary
- remove duplicate exposition period from card rendering
- simplify museum exposition list by dropping unused period prop

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c168fe0b888326bc7fbe3ba2c814f5