### PR TITLE
Add museum and photographer credits to images

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -76,6 +76,9 @@ export default function MuseumCard({ museum }) {
             />
           )}
         </Link>
+        <div className="image-credit">
+          {t('museumLabel')}: {museum.title} — {t('photographerLabel')}: {museum.photographer || t('unknown')}
+        </div>
         <div className="museum-card-ticket">
           <a
             href={museum.ticketUrl || '#'}

--- a/lib/museumImageCredits.js
+++ b/lib/museumImageCredits.js
@@ -1,0 +1,3 @@
+const museumImageCredits = {};
+
+export default museumImageCredits;

--- a/lib/translations.js
+++ b/lib/translations.js
@@ -32,6 +32,9 @@ const translations = {
     copyThisLink: 'Copy this link',
     duration: 'Duration',
     museumDescription: 'Information and expositions of {name}.',
+    museumLabel: 'Museum',
+    photographerLabel: 'Photographer',
+    unknown: 'Unknown',
   },
   nl: {
     homeTitle: 'MuseumBuddy — Musea',
@@ -66,6 +69,9 @@ const translations = {
     copyThisLink: 'Kopieer deze link',
     duration: 'Looptijd',
     museumDescription: 'Informatie en exposities van {name}.',
+    museumLabel: 'Museum',
+    photographerLabel: 'Fotograaf',
+    unknown: 'Onbekend',
   },
 };
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 import MuseumCard from '../components/MuseumCard';
 import museumImages from '../lib/museumImages';
 import museumNames from '../lib/museumNames';
+import museumImageCredits from '../lib/museumImageCredits';
 import { useLanguage } from '../components/LanguageContext';
 
 function todayYMD(tz = 'Europe/Amsterdam') {
@@ -63,6 +64,7 @@ export default function Home({ items, q, hasExposities }) {
                   province: m.provincie,
                   free: m.gratis_toegankelijk,
                   image: museumImages[m.slug],
+                  photographer: museumImageCredits[m.slug],
                   ticketUrl: m.ticket_affiliate_url || m.website_url,
                 }}
               />

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import { createClient } from '@supabase/supabase-js';
 import museumImages from '../../lib/museumImages';
 import museumNames from '../../lib/museumNames';
+import museumImageCredits from '../../lib/museumImageCredits';
 import ExpositionCard from '../../components/ExpositionCard';
 import { useLanguage } from '../../components/LanguageContext';
 import { useFavorites } from '../../components/FavoritesContext';
@@ -89,6 +90,9 @@ export default function MuseumDetail({ museum, exposities, error }) {
               sizes="(max-width: 800px) 100vw, 800px"
               style={{ objectFit: 'cover' }}
             />
+            <div className="image-credit">
+              {t('museumLabel')}: {name} — {t('photographerLabel')}: {museumImageCredits[museum.slug] || t('unknown')}
+            </div>
           </div>
         )}
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -203,6 +203,16 @@ img { max-width: 100%; height: auto; display: block; }
   display: block;
 }
 
+.image-credit {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  padding: 4px 8px;
+  font-size: 12px;
+  color: var(--text);
+}
+
 /* MuseumCard component */
 .museum-card {
   background: var(--surface);


### PR DESCRIPTION
## Summary
- add caption overlay on museum images showing museum and photographer
- add translations and mapping for photo credits
- style credit overlay without dark border for cleaner appearance

## Testing
- `npm test` (fails: command not found: npm)
- `npm run build` (fails: command not found: npm)


------
https://chatgpt.com/codex/tasks/task_e_68c16bd16e1c83268cbc09bf213d7401