### PR TITLE
Center favorite button on exposition card

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -375,6 +375,7 @@ img { max-width: 100%; height: auto; display: block; }
 .event-card-actions {
   margin-left: auto;
   display: flex;
+  align-items: center;
   gap: 8px;
 }
 
@@ -403,6 +404,7 @@ img { max-width: 100%; height: auto; display: block; }
     margin-left: 0;
     width: 100%;
     margin-top: 8px;
+    align-items: center;
     gap: 8px;
   }
   .event-card-actions .ticket-button {


### PR DESCRIPTION
## Summary
- center favorite icon alongside website button on exposition pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c17f13fe08832697cc68a324ee511f