### PR TITLE
Center favorite button on exposition card

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -276,6 +276,17 @@ img { max-width: 100%; height: auto; display: block; }
   height: 18px;
 }
 
+.event-card-actions .icon-button {
+  width: 36px;
+  height: 36px;
+  margin-top: 2px;
+}
+
+.event-card-actions .icon-button svg {
+  width: 20px;
+  height: 20px;
+}
+
 /* Favorited state */
 .icon-button.favorited {
   background: var(--accent);
@@ -375,6 +386,7 @@ img { max-width: 100%; height: auto; display: block; }
 .event-card-actions {
   margin-left: auto;
   display: flex;
+  align-items: center;
   gap: 8px;
 }
 
@@ -403,6 +415,7 @@ img { max-width: 100%; height: auto; display: block; }
     margin-left: 0;
     width: 100%;
     margin-top: 8px;
+    align-items: center;
     gap: 8px;
   }
   .event-card-actions .ticket-button {


### PR DESCRIPTION
## Summary
- enlarge favorite button and adjust positioning for symmetry with exposition website button

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c17f13fe08832697cc68a324ee511f