### PR TITLE
Center favorite button on exposition card

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -68,7 +68,7 @@ export default function ExpositionCard({ exposition }) {
           {t('buyTicket')}
         </a>
         <button
-          className={`icon-button${isFavorite ? ' favorited' : ''}`}
+          className={`icon-button large${isFavorite ? ' favorited' : ''}`}
           aria-label={t('save')}
           aria-pressed={isFavorite}
           onClick={handleFavorite}

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -96,7 +96,7 @@ export default function MuseumDetail({ museum, exposities, error }) {
           </div>
         )}
 
-        <div style={{ display: 'flex', gap: '8px', margin: '16px 0' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', margin: '16px 0' }}>
           {museum.website_url && (
             <a
               href={museum.website_url}
@@ -119,7 +119,7 @@ export default function MuseumDetail({ museum, exposities, error }) {
           )}
           {museumItem && (
             <button
-              className={`icon-button${isFavorite ? ' favorited' : ''}`}
+              className={`icon-button large${isFavorite ? ' favorited' : ''}`}
               aria-label={t('save')}
               aria-pressed={isFavorite}
               onClick={handleFavorite}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -276,6 +276,16 @@ img { max-width: 100%; height: auto; display: block; }
   height: 18px;
 }
 
+.icon-button.large {
+  width: 36px;
+  height: 36px;
+}
+
+.icon-button.large svg {
+  width: 20px;
+  height: 20px;
+}
+
 /* Favorited state */
 .icon-button.favorited {
   background: var(--accent);
@@ -375,6 +385,7 @@ img { max-width: 100%; height: auto; display: block; }
 .event-card-actions {
   margin-left: auto;
   display: flex;
+  align-items: center;
   gap: 8px;
 }
 
@@ -403,6 +414,7 @@ img { max-width: 100%; height: auto; display: block; }
     margin-left: 0;
     width: 100%;
     margin-top: 8px;
+    align-items: center;
     gap: 8px;
   }
   .event-card-actions .ticket-button {


### PR DESCRIPTION
## Summary
- enlarge favorite button and adjust positioning for symmetry with exposition website button
- unify large heart icon styling across exposition cards and museum pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c17f13fe08832697cc68a324ee511f