### PR TITLE
feat: show affiliate notice on ticket buttons

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -64,6 +64,7 @@ export default function ExpositionCard({ exposition }) {
           rel="noreferrer"
           className="ticket-button"
           aria-disabled={!exposition.bron_url}
+          title={t('affiliateLink')}
         >
           {t('buyTicket')}
         </a>

--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -88,6 +88,7 @@ export default function MuseumCard({ museum }) {
             rel="noreferrer"
             className="ticket-button"
             aria-disabled={!museum.ticketUrl}
+            title={t('affiliateLink')}
           >
             {t('buyTicket')}
           </a>

--- a/lib/translations.js
+++ b/lib/translations.js
@@ -36,7 +36,7 @@ const translations = {
     photographerLabel: 'Photographer',
     unknown: 'Unknown',
     openingHours: 'Opening hours',
-    affiliateLink: 'This link goes to our Affiliate Partner.',
+    affiliateLink: 'This link goes to our Affiliate Partner. Prices may vary.',
   },
   nl: {
     homeTitle: 'MuseumBuddy — Musea',
@@ -75,7 +75,7 @@ const translations = {
     photographerLabel: 'Fotograaf',
     unknown: 'Onbekend',
     openingHours: 'Openingstijden',
-    affiliateLink: 'Deze link gaat naar onze Affiliate Partner.',
+    affiliateLink: 'Deze link gaat naar onze Affiliate Partner. Prijzen kunnen afwijken.',
   },
 };
 

--- a/lib/translations.js
+++ b/lib/translations.js
@@ -36,6 +36,7 @@ const translations = {
     photographerLabel: 'Photographer',
     unknown: 'Unknown',
     openingHours: 'Opening hours',
+    affiliateLink: 'This link goes to our Affiliate Partner.',
   },
   nl: {
     homeTitle: 'MuseumBuddy — Musea',
@@ -74,6 +75,7 @@ const translations = {
     photographerLabel: 'Fotograaf',
     unknown: 'Onbekend',
     openingHours: 'Openingstijden',
+    affiliateLink: 'Deze link gaat naar onze Affiliate Partner.',
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "crawl": "node scripts/crawl.mjs"
+    "crawl": "node scripts/crawl.mjs",
+    "test": "node tests/affiliateLink.test.cjs"
   },
   "engines": {
     "node": "20.x"

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -120,6 +120,7 @@ export default function MuseumDetail({ museum, exposities, error }) {
               target="_blank"
               rel="noreferrer"
               className="btn-reset"
+              title={t('affiliateLink')}
             >
               {t('tickets')}
             </a>

--- a/tests/affiliateLink.test.cjs
+++ b/tests/affiliateLink.test.cjs
@@ -2,8 +2,8 @@ const fs = require('fs');
 const assert = require('assert');
 
 const translationsContent = fs.readFileSync('lib/translations.js', 'utf8');
-assert(/affiliateLink:\s*'This link goes to our Affiliate Partner.'/.test(translationsContent), 'English translation missing');
-assert(/affiliateLink:\s*'Deze link gaat naar onze Affiliate Partner.'/.test(translationsContent), 'Dutch translation missing');
+assert(/affiliateLink:\s*'This link goes to our Affiliate Partner\. Prices may vary\.'/.test(translationsContent), 'English translation missing');
+assert(/affiliateLink:\s*'Deze link gaat naar onze Affiliate Partner\. Prijzen kunnen afwijken\.'/.test(translationsContent), 'Dutch translation missing');
 
 const files = [
   'components/MuseumCard.js',

--- a/tests/affiliateLink.test.cjs
+++ b/tests/affiliateLink.test.cjs
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const assert = require('assert');
+
+const translationsContent = fs.readFileSync('lib/translations.js', 'utf8');
+assert(/affiliateLink:\s*'This link goes to our Affiliate Partner.'/.test(translationsContent), 'English translation missing');
+assert(/affiliateLink:\s*'Deze link gaat naar onze Affiliate Partner.'/.test(translationsContent), 'Dutch translation missing');
+
+const files = [
+  'components/MuseumCard.js',
+  'components/ExpositionCard.js',
+  'pages/museum/[slug].js',
+];
+const tooltipPattern = /title={t\('affiliateLink'\)}/;
+for (const file of files) {
+  const content = fs.readFileSync(file, 'utf8');
+  assert(tooltipPattern.test(content), `Tooltip missing in ${file}`);
+}
+
+console.log('Affiliate link tooltip tests passed.');


### PR DESCRIPTION
## Summary
- add multilingual affiliate link tooltip to ticket buttons
- cover new affiliate tooltip with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2a67c3914832690445d5af1fa9b56