### PR TITLE
Display affiliate disclaimer on mobile ticket buttons

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -88,6 +88,7 @@ export default function ExpositionCard({ exposition, ticketUrl }) {
           </svg>
         </button>
       </div>
+      {buyUrl && <p className="affiliate-note">{t('affiliateLink')}</p>}
     </article>
   );
 }

--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -92,6 +92,9 @@ export default function MuseumCard({ museum }) {
           >
             {t('buyTicket')}
           </a>
+          {museum.ticketUrl && (
+            <p className="affiliate-note">{t('affiliateLink')}</p>
+          )}
         </div>
         <div className="museum-card-actions">
           <button className="icon-button" aria-label={t('share')} onClick={shareMuseum}>

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -152,6 +152,9 @@ export default function MuseumDetail({ museum, exposities, error }) {
             </button>
           )}
         </div>
+        {museum.ticket_affiliate_url && (
+          <p className="affiliate-note">{t('affiliateLink')}</p>
+        )}
 
         <h2 className="page-title">{t('expositionsTitle')}</h2>
         {!exposities || exposities.length === 0 ? (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -260,6 +260,17 @@ img { max-width: 100%; height: auto; display: block; }
   opacity: 0.5;
   pointer-events: none;
 }
+.affiliate-note {
+  display: none;
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 4px;
+}
+@media (max-width: 600px) {
+  .affiliate-note {
+    display: block;
+  }
+}
 .icon-button {
   width: 32px;
   height: 32px;

--- a/tests/affiliateLink.test.cjs
+++ b/tests/affiliateLink.test.cjs
@@ -11,9 +11,11 @@ const files = [
   'pages/museum/[slug].js',
 ];
 const tooltipPattern = /title={t\('affiliateLink'\)}/;
+const notePattern = /className="affiliate-note"/;
 for (const file of files) {
   const content = fs.readFileSync(file, 'utf8');
   assert(tooltipPattern.test(content), `Tooltip missing in ${file}`);
+  assert(notePattern.test(content), `Affiliate note missing in ${file}`);
 }
 
-console.log('Affiliate link tooltip tests passed.');
+console.log('Affiliate link tooltip and note tests passed.');


### PR DESCRIPTION
## Summary
- show affiliate disclaimer text under ticket purchase links so mobile users see partner and price variation info
- style affiliate note for small screens and keep existing tooltip
- update tests to cover new disclaimer elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2d5b412c88326811f1a37d3e6bd1f