### PR TITLE
Add footer with privacy and disclaimer links

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+import { useLanguage } from './LanguageContext';
+
+export default function Footer() {
+  const { t } = useLanguage();
+  return (
+    <footer className="footer">
+      <div className="container footer-content">
+        <Link href="/privacy">{t('privacy')}</Link>
+        <Link href="/disclaimer">{t('disclaimer')}</Link>
+      </div>
+    </footer>
+  );
+}

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import { useFavorites } from './FavoritesContext';
 import { useLanguage } from './LanguageContext';
 import { useTheme } from './ThemeContext';
+import Footer from './Footer';
 
 export default function Layout({ children }) {
   const { favorites } = useFavorites();
@@ -110,6 +111,7 @@ export default function Layout({ children }) {
         </nav>
       </header>
       <main className="container">{children}</main>
+      <Footer />
     </>
   );
 }

--- a/lib/translations.js
+++ b/lib/translations.js
@@ -39,6 +39,8 @@ const translations = {
       unknown: 'Unknown',
       openingHours: 'Opening hours',
       affiliateLink: 'This link goes to our Affiliate Partner. Prices may vary.',
+    privacy: 'Privacy & Cookies',
+    disclaimer: 'Disclaimer',
   },
   nl: {
     homeTitle: 'MuseumBuddy — Musea',
@@ -80,6 +82,8 @@ const translations = {
       unknown: 'Onbekend',
       openingHours: 'Openingstijden',
       affiliateLink: 'Deze link gaat naar onze Affiliate Partner. Prijzen kunnen afwijken.',
+    privacy: 'Privacy & Cookies',
+    disclaimer: 'Disclaimer',
   },
 };
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -47,6 +47,21 @@ img { max-width: 100%; height: auto; display: block; }
 .navspacer { flex:1 }
 .navlink { color: var(--muted); font-size: 14px; }
 
+/* Footer */
+.footer {
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+  margin-top: 48px;
+}
+
+.footer-content {
+  display: flex;
+  gap: 16px;
+  padding: 16px 24px;
+  font-size: 14px;
+  color: var(--muted);
+}
+
 /* Header brand */
 .brand-wrap { display:flex; align-items:center; gap:12px; }
 .brand-square {


### PR DESCRIPTION
## Summary
- add footer component with privacy and disclaimer links
- render footer from Layout so it's visible on all pages
- provide translations and global styles for footer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7e76af4f88326bf281bcff2be8729