### PR TITLE
Move privacy statement link to footer

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -6,7 +6,7 @@ export default function Footer() {
   return (
     <footer className="footer">
       <div className="container footer-content">
-        <Link href="/privacy">{t('privacy')}</Link>
+        <Link href="/privacy">{t('privacyLabel')}</Link>
         <Link href="/disclaimer">{t('disclaimer')}</Link>
       </div>
     </footer>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -79,9 +79,6 @@ export default function Layout({ children }) {
                 </svg>
               )}
             </button>
-            <Link href="/privacy" className="header-link">
-              {t('privacyLabel')}
-            </Link>
             <Link href="/about" className="header-icon" aria-label={t('aboutLabel')}>
               <svg
                 viewBox="0 0 24 24"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -92,13 +92,6 @@ img { max-width: 100%; height: auto; display: block; }
 }
 .lang-select svg { width:12px; height:8px; }
 .contrast-toggle svg { width:20px; height:20px; }
-.header-link {
-  display:flex;
-  align-items:center;
-  font-size:14px;
-  color: var(--text);
-  text-decoration:none;
-}
 .header-icon {
   background:none;
   border:none;


### PR DESCRIPTION
## Summary
- remove privacy policy link from header
- show privacy policy link in footer
- clean up unused header link styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7ed583f7883268458fbc5be6ea803