### PR TITLE
Add affiliate disclaimer to footer

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -9,6 +9,9 @@ export default function Footer() {
         <Link href="/privacy">{t('privacyLabel')}</Link>
         <Link href="/disclaimer">{t('disclaimer')}</Link>
       </div>
+      <div className="container footer-disclaimer">
+        {t('affiliateDisclaimer')}
+      </div>
     </footer>
   );
 }

--- a/lib/translations.js
+++ b/lib/translations.js
@@ -42,6 +42,8 @@ const translations = {
       affiliateLink: 'This link goes to our Affiliate Partner. Prices may vary.',
     privacy: 'Privacy & Cookies',
     disclaimer: 'Disclaimer',
+    affiliateDisclaimer:
+      'Some links on this website are affiliate links. That means we may receive a small commission if you buy a ticket or make a reservation via such a link. This costs you nothing extra; prices may vary. We only include links that match the content of MuseumBuddy.',
   },
   nl: {
     homeTitle: 'MuseumBuddy — Musea',
@@ -86,6 +88,8 @@ const translations = {
       affiliateLink: 'Deze link gaat naar onze Affiliate Partner. Prijzen kunnen afwijken.',
     privacy: 'Privacy & Cookies',
     disclaimer: 'Disclaimer',
+    affiliateDisclaimer:
+      'Sommige links op deze website zijn affiliate-links. Dat betekent dat wij een kleine commissie kunnen ontvangen als je via zo\u2019n link een kaartje koopt of een reservering maakt. Dit kost jou niets extra, prijzen kunnen wel verschillen. We vermelden alleen links die passen bij de inhoud van MuseumBuddy.',
   },
 };
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -62,6 +62,12 @@ img { max-width: 100%; height: auto; display: block; }
   color: var(--muted);
 }
 
+.footer-disclaimer {
+  padding: 0 24px 16px;
+  font-size: 14px;
+  color: var(--muted);
+}
+
 /* Header brand */
 .brand-wrap { display:flex; align-items:center; gap:12px; }
 .brand-square {


### PR DESCRIPTION
## Summary
- show affiliate disclosure text in footer
- add translations for the disclosure in English and Dutch
- style the footer disclaimer section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7eeccf6908326a0c272ceec65b1e8