### PR TITLE
feat: translate footer pages

### DIFF
--- a/pages/disclaimer.js
+++ b/pages/disclaimer.js
@@ -1,55 +1,111 @@
 import Head from 'next/head';
+import { useLanguage } from '../components/LanguageContext';
 
 export default function DisclaimerPage() {
+  const { lang } = useLanguage();
   return (
     <>
       <Head>
-        <title>Algemene voorwaarden & Disclaimer - MuseumBuddy</title>
+        <title>
+          {lang === 'en'
+            ? 'Terms & Disclaimer - MuseumBuddy'
+            : 'Algemene voorwaarden & Disclaimer - MuseumBuddy'}
+        </title>
         <meta
           name="description"
-          content="Lees de algemene voorwaarden en disclaimer van MuseumBuddy."
+          content={
+            lang === 'en'
+              ? 'Read the terms and disclaimer of MuseumBuddy.'
+              : 'Lees de algemene voorwaarden en disclaimer van MuseumBuddy.'
+          }
         />
       </Head>
-      <h1 className="page-title">Algemene voorwaarden & Disclaimer</h1>
-      <p>
-        MuseumBuddy streeft naar actuele en juiste informatie, maar kan niet garanderen
-        dat alle gegevens volledig of foutloos zijn. Het gebruik van de informatie is
-        volledig voor eigen risico van de gebruiker.
-      </p>
-      <p>
-        MuseumBuddy is niet aansprakelijk voor directe of indirecte schade die ontstaat
-        door het gebruik van deze website of door informatie van externe websites waarnaar
-        wordt gelinkt.
-      </p>
-      <p>
-        Alle inhoud op deze website is auteursrechtelijk beschermd. Niets mag zonder
-        voorafgaande schriftelijke toestemming worden gekopieerd of verspreid.
-      </p>
-      <p>
-        MuseumBuddy werkt samen met Supabase, Vercel en diverse affiliatepartners. Sommige
-        links op deze website zijn affiliate-links. Dit betekent dat wij een kleine
-        commissie kunnen ontvangen als je via zo’n link iets boekt of koopt, zonder extra
-        kosten voor jou.
-      </p>
-      <p>
-        Deze website is uitsluitend bedoeld als informatieve gids. Je blijft altijd zelf
-        verantwoordelijk voor je keuzes, boekingen en het controleren van actuele
-        gegevens bij de betreffende musea of aanbieders.
-      </p>
-      <p>
-        Op deze voorwaarden is uitsluitend Nederlands recht van toepassing. Geschillen
-        worden voorgelegd aan de bevoegde rechter in Nederland.
-      </p>
-      <p>
-        MuseumBuddy kan deze voorwaarden wijzigen. De meest actuele versie is altijd te
-        vinden op deze website.
-      </p>
-      <p>
-        Voor vragen kun je mailen naar{' '}
-        <a className="link-accent" href="mailto:info@museumbuddy.nl">
-          info@museumbuddy.nl
-        </a>
-      </p>
+      {lang === 'en' ? (
+        <>
+          <h1 className="page-title">Terms & Disclaimer</h1>
+          <p>
+            MuseumBuddy strives to provide current and accurate information but cannot
+            guarantee that all data is complete or error-free. Use of the information is
+            entirely at your own risk.
+          </p>
+          <p>
+            MuseumBuddy is not liable for direct or indirect damages arising from the
+            use of this website or information from external websites to which it links.
+          </p>
+          <p>
+            All content on this website is protected by copyright. Nothing may be
+            copied or distributed without prior written permission.
+          </p>
+          <p>
+            MuseumBuddy collaborates with Supabase, Vercel and various affiliate
+            partners. Some links on this website are affiliate links. This means we may
+            receive a small commission if you book or buy something through such a link,
+            at no extra cost to you.
+          </p>
+          <p>
+            This website is intended solely as an informative guide. You remain
+            responsible for your choices, bookings and for checking up-to-date
+            information with the relevant museums or providers.
+          </p>
+          <p>
+            These terms are governed exclusively by Dutch law. Disputes will be
+            submitted to the competent court in the Netherlands.
+          </p>
+          <p>
+            MuseumBuddy may change these terms. The most current version can always be
+            found on this website.
+          </p>
+          <p>
+            For questions you can email{' '}
+            <a className="link-accent" href="mailto:info@museumbuddy.nl">
+              info@museumbuddy.nl
+            </a>
+          </p>
+        </>
+      ) : (
+        <>
+          <h1 className="page-title">Algemene voorwaarden & Disclaimer</h1>
+          <p>
+            MuseumBuddy streeft naar actuele en juiste informatie, maar kan niet
+            garanderen dat alle gegevens volledig of foutloos zijn. Het gebruik van de
+            informatie is volledig voor eigen risico van de gebruiker.
+          </p>
+          <p>
+            MuseumBuddy is niet aansprakelijk voor directe of indirecte schade die
+            ontstaat door het gebruik van deze website of door informatie van externe
+            websites waarnaar wordt gelinkt.
+          </p>
+          <p>
+            Alle inhoud op deze website is auteursrechtelijk beschermd. Niets mag zonder
+            voorafgaande schriftelijke toestemming worden gekopieerd of verspreid.
+          </p>
+          <p>
+            MuseumBuddy werkt samen met Supabase, Vercel en diverse affiliatepartners.
+            Sommige links op deze website zijn affiliate-links. Dit betekent dat wij een
+            kleine commissie kunnen ontvangen als je via zo’n link iets boekt of koopt,
+            zonder extra kosten voor jou.
+          </p>
+          <p>
+            Deze website is uitsluitend bedoeld als informatieve gids. Je blijft altijd
+            zelf verantwoordelijk voor je keuzes, boekingen en het controleren van
+            actuele gegevens bij de betreffende musea of aanbieders.
+          </p>
+          <p>
+            Op deze voorwaarden is uitsluitend Nederlands recht van toepassing.
+            Geschillen worden voorgelegd aan de bevoegde rechter in Nederland.
+          </p>
+          <p>
+            MuseumBuddy kan deze voorwaarden wijzigen. De meest actuele versie is
+            altijd te vinden op deze website.
+          </p>
+          <p>
+            Voor vragen kun je mailen naar{' '}
+            <a className="link-accent" href="mailto:info@museumbuddy.nl">
+              info@museumbuddy.nl
+            </a>
+          </p>
+        </>
+      )}
     </>
   );
 }

--- a/pages/privacy.js
+++ b/pages/privacy.js
@@ -1,68 +1,145 @@
 import Head from 'next/head';
+import { useLanguage } from '../components/LanguageContext';
 
 export default function PrivacyPage() {
+  const { lang } = useLanguage();
   return (
     <>
       <Head>
-        <title>Privacyverklaring - MuseumBuddy</title>
+        <title>
+          {lang === 'en'
+            ? 'Privacy Policy - MuseumBuddy'
+            : 'Privacyverklaring - MuseumBuddy'}
+        </title>
         <meta
           name="description"
-          content="Lees hoe MuseumBuddy met jouw persoonsgegevens omgaat."
+          content={
+            lang === 'en'
+              ? 'Learn how MuseumBuddy handles your personal data.'
+              : 'Lees hoe MuseumBuddy met jouw persoonsgegevens omgaat.'
+          }
         />
       </Head>
-      <h1 className="page-title">Privacyverklaring</h1>
-      <p>
-        MuseumBuddy verwerkt zo min mogelijk persoonsgegevens. We gebruiken geen eigen
-        trackingcookies of analytics.
-      </p>
-      <p>
-        Wel kan het voorkomen dat externe partijen, zoals onze affiliatepartners, cookies
-        plaatsen om te meten of een bezoek via onze link tot een aankoop of boeking leidt.
-        Raadpleeg hun eigen privacybeleid voor meer informatie.
-      </p>
-      <h2>Welke gegevens wij verwerken</h2>
-      <ul>
-        <li>
-          Technische gegevens die je browser automatisch meestuurt (IP-adres,
-          browsertype, tijdstip). Deze gegevens worden uitsluitend gebruikt voor het
-          veilig aanbieden van de site en niet voor profilering.
-        </li>
-        <li>Gegevens die je zelf verstrekt via e-mail of een formulier.</li>
-      </ul>
-      <h2>Grondslag en doel</h2>
-      <p>
-        Wij verwerken deze gegevens uitsluitend om de website goed te laten werken,
-        vragen te beantwoorden en – indien van toepassing – affiliate inkomsten te kunnen
-        ontvangen.
-      </p>
-      <h2>Bewaartermijnen</h2>
-      <p>We bewaren gegevens niet langer dan nodig.</p>
-      <h2>Delen met derden</h2>
-      <p>
-        We delen geen persoonsgegevens met derden, behalve voor hosting (Vercel),
-        database (Supabase) en affiliatepartners, voor zover noodzakelijk voor het
-        functioneren van de site.
-      </p>
-      <h2>Cookies</h2>
-      <p>
-        MuseumBuddy plaatst zelf geen cookies voor marketing of analyse. Onze
-        affiliatepartners kunnen dat wel doen zodra je op een affiliate-link klikt. Je
-        kunt cookies altijd wissen of blokkeren via je browserinstellingen.
-      </p>
-      <h2>Jouw rechten</h2>
-      <p>
-        Je hebt recht op inzage, correctie en verwijdering van jouw persoonsgegevens.
-        Mail naar <a className="link-accent" href="mailto:info@museumbuddy.nl">info@museumbuddy.nl</a>.
-      </p>
-      <h2>Verwerkingsverantwoordelijke</h2>
-      <p>
-        MuseumBuddy
-        <br />
-        E-mail:{' '}
-        <a className="link-accent" href="mailto:info@museumbuddy.nl">
-          info@museumbuddy.nl
-        </a>
-      </p>
+      {lang === 'en' ? (
+        <>
+          <h1 className="page-title">Privacy Policy</h1>
+          <p>
+            MuseumBuddy processes as little personal data as possible. We do not use
+            our own tracking cookies or analytics.
+          </p>
+          <p>
+            However, external parties, such as our affiliate partners, may place
+            cookies to measure whether a visit through our link leads to a purchase or
+            reservation. Consult their own privacy policies for more information.
+          </p>
+          <h2>What data we process</h2>
+          <ul>
+            <li>
+              Technical data automatically sent by your browser (IP address, browser
+              type, time). These data are used solely to securely provide the site and
+              not for profiling.
+            </li>
+            <li>Data you provide yourself via email or a form.</li>
+          </ul>
+          <h2>Legal basis and purpose</h2>
+          <p>
+            We process this data only to operate the website properly, answer
+            questions and, where applicable, to receive affiliate income.
+          </p>
+          <h2>Retention periods</h2>
+          <p>We do not store data longer than necessary.</p>
+          <h2>Sharing with third parties</h2>
+          <p>
+            We do not share personal data with third parties, except for hosting
+            (Vercel), database (Supabase) and affiliate partners, insofar as necessary
+            for the functioning of the site.
+          </p>
+          <h2>Cookies</h2>
+          <p>
+            MuseumBuddy itself does not place cookies for marketing or analysis. Our
+            affiliate partners may do so once you click an affiliate link. You can
+            always delete or block cookies via your browser settings.
+          </p>
+          <h2>Your rights</h2>
+          <p>
+            You have the right to access, rectify and delete your personal data. Email
+            <a className="link-accent" href="mailto:info@museumbuddy.nl">
+              info@museumbuddy.nl
+            </a>
+            .
+          </p>
+          <h2>Controller</h2>
+          <p>
+            MuseumBuddy
+            <br />
+            Email{' '}
+            <a className="link-accent" href="mailto:info@museumbuddy.nl">
+              info@museumbuddy.nl
+            </a>
+          </p>
+        </>
+      ) : (
+        <>
+          <h1 className="page-title">Privacyverklaring</h1>
+          <p>
+            MuseumBuddy verwerkt zo min mogelijk persoonsgegevens. We gebruiken geen
+            eigen trackingcookies of analytics.
+          </p>
+          <p>
+            Wel kan het voorkomen dat externe partijen, zoals onze affiliatepartners,
+            cookies plaatsen om te meten of een bezoek via onze link tot een aankoop of
+            boeking leidt. Raadpleeg hun eigen privacybeleid voor meer informatie.
+          </p>
+          <h2>Welke gegevens wij verwerken</h2>
+          <ul>
+            <li>
+              Technische gegevens die je browser automatisch meestuurt (IP-adres,
+              browsertype, tijdstip). Deze gegevens worden uitsluitend gebruikt voor
+              het veilig aanbieden van de site en niet voor profilering.
+            </li>
+            <li>Gegevens die je zelf verstrekt via e-mail of een formulier.</li>
+          </ul>
+          <h2>Grondslag en doel</h2>
+          <p>
+            Wij verwerken deze gegevens uitsluitend om de website goed te laten
+            werken, vragen te beantwoorden en – indien van toepassing – affiliate
+            inkomsten te kunnen ontvangen.
+          </p>
+          <h2>Bewaartermijnen</h2>
+          <p>We bewaren gegevens niet langer dan nodig.</p>
+          <h2>Delen met derden</h2>
+          <p>
+            We delen geen persoonsgegevens met derden, behalve voor hosting (Vercel),
+            database (Supabase) en affiliatepartners, voor zover noodzakelijk voor het
+            functioneren van de site.
+          </p>
+          <h2>Cookies</h2>
+          <p>
+            MuseumBuddy plaatst zelf geen cookies voor marketing of analyse. Onze
+            affiliatepartners kunnen dat wel doen zodra je op een affiliate-link
+            klikt. Je kunt cookies altijd wissen of blokkeren via je
+            browserinstellingen.
+          </p>
+          <h2>Jouw rechten</h2>
+          <p>
+            Je hebt recht op inzage, correctie en verwijdering van jouw
+            persoonsgegevens. Mail naar{' '}
+            <a className="link-accent" href="mailto:info@museumbuddy.nl">
+              info@museumbuddy.nl
+            </a>
+            .
+          </p>
+          <h2>Verwerkingsverantwoordelijke</h2>
+          <p>
+            MuseumBuddy
+            <br />
+            E-mail{' '}
+            <a className="link-accent" href="mailto:info@museumbuddy.nl">
+              info@museumbuddy.nl
+            </a>
+          </p>
+        </>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add bilingual privacy page with English and Dutch content
- add bilingual terms and disclaimer page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7f3616a908326b997f8f33e4b53e1