### PR TITLE
feat: add SEO component and meta tags

### DIFF
--- a/components/SEO.js
+++ b/components/SEO.js
@@ -1,0 +1,27 @@
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+
+const SITE_URL = 'https://museumbuddy.nl';
+
+export default function SEO({ title, description, image, canonical }) {
+  const { asPath } = useRouter();
+  const url = `${SITE_URL}${asPath}`;
+  const canonicalUrl = canonical || url;
+
+  return (
+    <Head>
+      {title && <title>{title}</title>}
+      {description && <meta name="description" content={description} />}
+      <meta property="og:type" content="website" />
+      {title && <meta property="og:title" content={title} />}
+      {description && <meta property="og:description" content={description} />}
+      <meta property="og:url" content={url} />
+      {image && <meta property="og:image" content={image} />}
+      <meta name="twitter:card" content="summary_large_image" />
+      {title && <meta name="twitter:title" content={title} />}
+      {description && <meta name="twitter:description" content={description} />}
+      {image && <meta name="twitter:image" content={image} />}
+      <link rel="canonical" href={canonicalUrl} />
+    </Head>
+  );
+}

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,13 +1,11 @@
-import Head from 'next/head';
+import SEO from '../components/SEO';
 import { useLanguage } from '../components/LanguageContext';
 
 export default function AboutPage() {
   const { t } = useLanguage();
   return (
     <>
-      <Head>
-        <title>{t('aboutTitle')}</title>
-      </Head>
+      <SEO title={t('aboutTitle')} />
       <h1 className="page-title">{t('aboutTitle')}</h1>
       <p>{t('aboutBody')}</p>
     </>

--- a/pages/disclaimer.js
+++ b/pages/disclaimer.js
@@ -1,25 +1,19 @@
-import Head from 'next/head';
+import SEO from '../components/SEO';
 import { useLanguage } from '../components/LanguageContext';
 
 export default function DisclaimerPage() {
   const { lang } = useLanguage();
+  const title =
+    lang === 'en'
+      ? 'Terms & Disclaimer - MuseumBuddy'
+      : 'Algemene voorwaarden & Disclaimer - MuseumBuddy';
+  const description =
+    lang === 'en'
+      ? 'Read the terms and disclaimer of MuseumBuddy.'
+      : 'Lees de algemene voorwaarden en disclaimer van MuseumBuddy.';
   return (
     <>
-      <Head>
-        <title>
-          {lang === 'en'
-            ? 'Terms & Disclaimer - MuseumBuddy'
-            : 'Algemene voorwaarden & Disclaimer - MuseumBuddy'}
-        </title>
-        <meta
-          name="description"
-          content={
-            lang === 'en'
-              ? 'Read the terms and disclaimer of MuseumBuddy.'
-              : 'Lees de algemene voorwaarden en disclaimer van MuseumBuddy.'
-          }
-        />
-      </Head>
+      <SEO title={title} description={description} />
       {lang === 'en' ? (
         <>
           <h1 className="page-title">Terms & Disclaimer</h1>

--- a/pages/favorites.js
+++ b/pages/favorites.js
@@ -1,4 +1,4 @@
-import Head from 'next/head';
+import SEO from '../components/SEO';
 import MuseumCard from '../components/MuseumCard';
 import ExpositionCard from '../components/ExpositionCard';
 import { useFavorites } from '../components/FavoritesContext';
@@ -13,9 +13,7 @@ export default function FavoritesPage() {
 
   return (
     <>
-      <Head>
-        <title>{t('favoritesTitle')}</title>
-      </Head>
+      <SEO title={t('favoritesTitle')} />
       <h1 className="page-title">{t('favoritesTitle')}</h1>
       {favorites.length === 0 ? (
         <p>{t('noFavorites')}</p>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,3 @@
-import Head from 'next/head';
 import { createClient } from '@supabase/supabase-js';
 import { useEffect, useState } from 'react';
 import MuseumCard from '../components/MuseumCard';
@@ -8,6 +7,7 @@ import museumImageCredits from '../lib/museumImageCredits';
 import museumTicketUrls from '../lib/museumTicketUrls';
 import { useLanguage } from '../components/LanguageContext';
 import { supabase as supabaseClient } from '../lib/supabase';
+import SEO from '../components/SEO';
 
 function todayYMD(tz = 'Europe/Amsterdam') {
   const fmt = new Intl.DateTimeFormat('sv-SE', {
@@ -68,10 +68,7 @@ export default function Home({ items, q, hasExposities }) {
 
   return (
     <>
-      <Head>
-        <title>{t('homeTitle')}</title>
-        <meta name="description" content={t('homeDescription')} />
-      </Head>
+      <SEO title={t('homeTitle')} description={t('homeDescription')} />
 
       <form className="controls" onSubmit={(e) => e.preventDefault()}>
         <div className="control-row">

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -1,4 +1,4 @@
-import Head from 'next/head';
+import SEO from '../../components/SEO';
 import Image from 'next/image';
 import { createClient } from '@supabase/supabase-js';
 import museumImages from '../../lib/museumImages';
@@ -36,11 +36,10 @@ export default function MuseumDetail({ museum, exposities, error }) {
   const locale = lang === 'en' ? 'en-GB' : 'nl-NL';
 
   if (error) {
+    const errorTitle = 'Museum — MuseumBuddy';
     return (
       <>
-        <Head>
-          <title>Museum — MuseumBuddy</title>
-        </Head>
+        <SEO title={errorTitle} />
         <main style={{ maxWidth: 800, margin: '2rem auto', padding: '0 1rem' }}>
           <p>{t('somethingWrong')}</p>
           <a href="/" style={{ display: 'inline-block', marginTop: '1rem' }}>
@@ -76,10 +75,10 @@ export default function MuseumDetail({ museum, exposities, error }) {
 
   return (
     <>
-      <Head>
-        <title>{name ? `${name} — MuseumBuddy` : 'Museum — MuseumBuddy'}</title>
-        <meta name="description" content={t('museumDescription', { name: name || 'museum' })} />
-      </Head>
+      <SEO
+        title={name ? `${name} — MuseumBuddy` : 'Museum — MuseumBuddy'}
+        description={t('museumDescription', { name: name || 'museum' })}
+      />
 
       <main className="container" style={{ maxWidth: 800 }}>
         <a href="/" className="backlink" style={{ display: 'inline-block', marginBottom: 16 }}>

--- a/pages/privacy.js
+++ b/pages/privacy.js
@@ -1,25 +1,19 @@
-import Head from 'next/head';
+import SEO from '../components/SEO';
 import { useLanguage } from '../components/LanguageContext';
 
 export default function PrivacyPage() {
   const { lang } = useLanguage();
+  const title =
+    lang === 'en'
+      ? 'Privacy Policy - MuseumBuddy'
+      : 'Privacyverklaring - MuseumBuddy';
+  const description =
+    lang === 'en'
+      ? 'Learn how MuseumBuddy handles your personal data.'
+      : 'Lees hoe MuseumBuddy met jouw persoonsgegevens omgaat.';
   return (
     <>
-      <Head>
-        <title>
-          {lang === 'en'
-            ? 'Privacy Policy - MuseumBuddy'
-            : 'Privacyverklaring - MuseumBuddy'}
-        </title>
-        <meta
-          name="description"
-          content={
-            lang === 'en'
-              ? 'Learn how MuseumBuddy handles your personal data.'
-              : 'Lees hoe MuseumBuddy met jouw persoonsgegevens omgaat.'
-          }
-        />
-      </Head>
+      <SEO title={title} description={description} />
       {lang === 'en' ? (
         <>
           <h1 className="page-title">Privacy Policy</h1>


### PR DESCRIPTION
## Summary
- add reusable SEO component providing open graph, twitter, and canonical tags
- replace inline `<Head>` usage in pages with the new `<SEO>` component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7f5406d1c832688377da02602d22d