### PR TITLE
Hide affiliate label for direct museum ticket links

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -1,5 +1,6 @@
 import { useLanguage } from './LanguageContext';
 import { useFavorites } from './FavoritesContext';
+import { shouldShowAffiliateNote } from '../lib/nonAffiliateMuseums';
 
 function formatRange(start, end, locale) {
   if (!start) return '';
@@ -18,7 +19,7 @@ function formatRange(start, end, locale) {
   return `${startFmt} - ${endFmt}`;
 }
 
-export default function ExpositionCard({ exposition, ticketUrl }) {
+export default function ExpositionCard({ exposition, ticketUrl, museumSlug }) {
   if (!exposition) return null;
 
   const start = exposition.start_datum ? new Date(exposition.start_datum + 'T00:00:00') : null;
@@ -29,6 +30,8 @@ export default function ExpositionCard({ exposition, ticketUrl }) {
   const rangeLabel = formatRange(start, end, locale);
   const isFavorite = favorites.some((f) => f.id === exposition.id && f.type === 'exposition');
   const buyUrl = ticketUrl || exposition.ticketUrl || exposition.bron_url;
+  const slug = museumSlug || exposition.museumSlug;
+  const showAffiliateNote = Boolean(buyUrl) && (!slug || shouldShowAffiliateNote(slug));
 
   const handleFavorite = () => {
     toggleFavorite({
@@ -38,6 +41,7 @@ export default function ExpositionCard({ exposition, ticketUrl }) {
       eind_datum: exposition.eind_datum,
       bron_url: exposition.bron_url,
       ticketUrl: buyUrl,
+      museumSlug: slug,
       type: 'exposition',
     });
   };
@@ -69,7 +73,7 @@ export default function ExpositionCard({ exposition, ticketUrl }) {
           title={t('affiliateLink')}
         >
           <span>{t('buyTicket')}</span>
-          {buyUrl && <span className="affiliate-note">{t('affiliateLinkLabel')}</span>}
+          {showAffiliateNote && <span className="affiliate-note">{t('affiliateLinkLabel')}</span>}
         </a>
         <button
           className={`icon-button large${isFavorite ? ' favorited' : ''}`}

--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -5,6 +5,7 @@ import { useFavorites } from './FavoritesContext';
 import { useLanguage } from './LanguageContext';
 import museumSummaries from '../lib/museumSummaries';
 import museumOpeningHours from '../lib/museumOpeningHours';
+import { shouldShowAffiliateNote } from '../lib/nonAffiliateMuseums';
 
 export default function MuseumCard({ museum }) {
   if (!museum) return null;
@@ -19,6 +20,7 @@ export default function MuseumCard({ museum }) {
 
   const summary = museumSummaries[museum.slug]?.[lang] || museum.summary;
   const hours = museumOpeningHours[museum.slug]?.[lang];
+  const showAffiliateNote = Boolean(museum.ticketUrl) && shouldShowAffiliateNote(museum.slug);
 
   const handleFavorite = () => {
     toggleFavorite({ ...museum, type: 'museum' });
@@ -108,7 +110,7 @@ export default function MuseumCard({ museum }) {
             title={t('affiliateLink')}
           >
             <span>{t('buyTicket')}</span>
-            {museum.ticketUrl && (
+            {showAffiliateNote && (
               <span className="affiliate-note">{t('affiliateLinkLabel')}</span>
             )}
           </a>

--- a/lib/nonAffiliateMuseums.js
+++ b/lib/nonAffiliateMuseums.js
@@ -1,0 +1,13 @@
+const NON_AFFILIATE_MUSEUM_SLUGS = new Set([
+  'anne-frank-huis-amsterdam',
+  'eye-filmmuseum-amsterdam',
+  'het-grachtenmuseum-amsterdam',
+  'huis-marseille-amsterdam',
+]);
+
+export function shouldShowAffiliateNote(slug) {
+  if (!slug) return true;
+  return !NON_AFFILIATE_MUSEUM_SLUGS.has(slug);
+}
+
+export default NON_AFFILIATE_MUSEUM_SLUGS;

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -9,6 +9,7 @@ import museumTicketUrls from '../../lib/museumTicketUrls';
 import ExpositionCard from '../../components/ExpositionCard';
 import { useLanguage } from '../../components/LanguageContext';
 import { useFavorites } from '../../components/FavoritesContext';
+import { shouldShowAffiliateNote } from '../../lib/nonAffiliateMuseums';
 
 function formatDate(d, locale) {
   if (!d) return '';
@@ -50,9 +51,11 @@ export default function MuseumDetail({ museum, exposities, error }) {
     );
   }
 
-    const name = museum ? museumNames[museum.slug] || museum.naam : '';
-    const openingHours = museum ? museumOpeningHours[museum.slug]?.[lang] : null;
-    const credit = museum ? museumImageCredits[museum.slug] : null;
+  const name = museum ? museumNames[museum.slug] || museum.naam : '';
+  const openingHours = museum ? museumOpeningHours[museum.slug]?.[lang] : null;
+  const credit = museum ? museumImageCredits[museum.slug] : null;
+  const ticketUrl = museum ? museum.ticket_affiliate_url || museum.website_url : null;
+  const showAffiliateNote = museum ? shouldShowAffiliateNote(museum.slug) : true;
   const museumItem =
     museum && name
       ? {
@@ -60,7 +63,7 @@ export default function MuseumDetail({ museum, exposities, error }) {
           slug: museum.slug,
           title: name,
           image: museumImages[museum.slug],
-          ticketUrl: museum.ticket_affiliate_url || museum.website_url,
+          ticketUrl,
         }
       : null;
   const isFavorite = museumItem
@@ -147,7 +150,9 @@ export default function MuseumDetail({ museum, exposities, error }) {
               title={t('affiliateLink')}
             >
               <span>{t('tickets')}</span>
-              <span className="affiliate-note">{t('affiliateLinkLabel')}</span>
+              {showAffiliateNote && (
+                <span className="affiliate-note">{t('affiliateLinkLabel')}</span>
+              )}
             </a>
           )}
           {museumItem && (
@@ -180,7 +185,8 @@ export default function MuseumDetail({ museum, exposities, error }) {
               <li key={e.id}>
                 <ExpositionCard
                   exposition={e}
-                  ticketUrl={museum.ticket_affiliate_url || museum.website_url}
+                  ticketUrl={ticketUrl}
+                  museumSlug={museum.slug}
                 />
               </li>
             ))}


### PR DESCRIPTION
## Summary
- add a helper that lists museums whose ticket buttons should not show the affiliate note
- use the helper in museum and exposition cards so the affiliate label is hidden for those entries
- pass the museum slug to exposition cards on the detail page to keep the affiliate label logic consistent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c83969e42883268381cd7e106b7ce2