### PR TITLE
Add helper script to roll back latest crawler results

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,15 @@ python scripts/supabase_dedup.py
 ```
 
 The script fetches all rows, keeps only unique `museum_id` values, writes the cleaned data back, and ensures the constraint exists to prevent future duplicates.
+
+## Remove latest crawler results
+
+If a crawl inserted incorrect data you can roll the changes back by deleting the rows created in the most recent run. Provide the Supabase service role credentials (`SUPABASE_SERVICE_ROLE_KEY` or `SUPABASE_SERVICE_KEY`) and run:
+
+```
+export SUPABASE_URL="<project-url>"
+export SUPABASE_SERVICE_ROLE_KEY="<service-role-key>"
+npm run crawl:rollback
+```
+
+The script finds the highest `last_crawled_at` value in the `exposities` table and removes every row that was created during that crawl.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "next build",
     "start": "next start",
     "crawl": "node scripts/crawl.mjs",
+    "crawl:rollback": "node scripts/rollbackLastCrawl.mjs",
     "test": "node tests/affiliateLink.test.cjs"
   },
   "engines": {

--- a/scripts/rollbackLastCrawl.mjs
+++ b/scripts/rollbackLastCrawl.mjs
@@ -1,0 +1,80 @@
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
+
+if (!SUPABASE_URL || !SERVICE_ROLE) {
+  console.error('❌ Missing SUPABASE_URL or service role key environment variables.');
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SERVICE_ROLE);
+
+async function fetchLatestCrawlTimestamp() {
+  const { data, error } = await supabase
+    .from('exposities')
+    .select('last_crawled_at')
+    .not('last_crawled_at', 'is', null)
+    .order('last_crawled_at', { ascending: false })
+    .limit(1);
+
+  if (error) {
+    throw new Error(`Could not fetch latest crawl timestamp: ${error.message}`);
+  }
+
+  return data && data.length > 0 ? data[0].last_crawled_at : null;
+}
+
+async function countRowsWithTimestamp(timestamp) {
+  const { count, error } = await supabase
+    .from('exposities')
+    .select('*', { head: true, count: 'exact' })
+    .eq('last_crawled_at', timestamp);
+
+  if (error) {
+    throw new Error(`Could not count rows for timestamp ${timestamp}: ${error.message}`);
+  }
+
+  return count || 0;
+}
+
+async function deleteRowsWithTimestamp(timestamp) {
+  const { data, error } = await supabase
+    .from('exposities')
+    .delete()
+    .eq('last_crawled_at', timestamp)
+    .select('id');
+
+  if (error) {
+    throw new Error(`Deleting rows for timestamp ${timestamp} failed: ${error.message}`);
+  }
+
+  return data ? data.length : 0;
+}
+
+async function main() {
+  console.log('🔍 Looking up latest crawler results...');
+  const latestTimestamp = await fetchLatestCrawlTimestamp();
+
+  if (!latestTimestamp) {
+    console.log('ℹ️  No crawler results found with a last_crawled_at value.');
+    return;
+  }
+
+  const rowCount = await countRowsWithTimestamp(latestTimestamp);
+
+  if (rowCount === 0) {
+    console.log(`ℹ️  No rows found for timestamp ${latestTimestamp}. Nothing to remove.`);
+    return;
+  }
+
+  console.log(`🗑️  Removing ${rowCount} rows from last crawl at ${latestTimestamp}...`);
+  const removedCount = await deleteRowsWithTimestamp(latestTimestamp);
+
+  console.log(`✅ Removed ${removedCount} rows created at ${latestTimestamp}.`);
+}
+
+main().catch((err) => {
+  console.error('❌ Failed to rollback last crawl:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a Supabase script that deletes all exposities rows sharing the latest `last_crawled_at`
- expose the rollback helper through an npm script for easy usage
- document how to remove the last crawler run in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c83f128644832685c285bf39ee1156