### PR TITLE
Improve Supabase guard and ticket button accessibility

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -64,17 +64,22 @@ export default function ExpositionCard({ exposition, ticketUrl, museumSlug }) {
         </h3>
       </div>
       <div className="event-card-actions">
-        <a
-          href={buyUrl || '#'}
-          target="_blank"
-          rel="noreferrer"
-          className="ticket-button"
-          aria-disabled={!buyUrl}
-          title={t('affiliateLink')}
-        >
-          <span>{t('buyTicket')}</span>
-          {showAffiliateNote && <span className="affiliate-note">{t('affiliateLinkLabel')}</span>}
-        </a>
+        {buyUrl ? (
+          <a
+            href={buyUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="ticket-button"
+            title={t('affiliateLink')}
+          >
+            <span>{t('buyTicket')}</span>
+            {showAffiliateNote && <span className="affiliate-note">{t('affiliateLinkLabel')}</span>}
+          </a>
+        ) : (
+          <button type="button" className="ticket-button" disabled aria-disabled="true">
+            <span>{t('buyTicket')}</span>
+          </button>
+        )}
         <button
           className={`icon-button large${isFavorite ? ' favorited' : ''}`}
           aria-label={t('save')}

--- a/components/SEO.js
+++ b/components/SEO.js
@@ -1,12 +1,37 @@
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 
-const SITE_URL = 'https://museumbuddy.nl';
+const RAW_SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://museumbuddy.nl';
+const SITE_URL = RAW_SITE_URL.replace(/\/+$/, '');
+
+function stripQueryAndHash(pathname = '/') {
+  if (!pathname) return '/';
+  const [withoutHash] = pathname.split('#');
+  const [cleanPath] = withoutHash.split('?');
+  return cleanPath || '/';
+}
+
+function toAbsoluteUrl(baseUrl, pathname = '/') {
+  const cleanPath = stripQueryAndHash(pathname);
+  const normalizedPath = cleanPath.startsWith('/') ? cleanPath : `/${cleanPath}`;
+  return `${baseUrl}${normalizedPath}`;
+}
+
+function resolveCanonical(customCanonical, baseUrl, fallbackPath) {
+  if (!customCanonical) {
+    return toAbsoluteUrl(baseUrl, fallbackPath);
+  }
+  if (/^https?:\/\//i.test(customCanonical)) {
+    return customCanonical;
+  }
+  return toAbsoluteUrl(baseUrl, customCanonical);
+}
 
 export default function SEO({ title, description, image, canonical }) {
   const { asPath } = useRouter();
-  const url = `${SITE_URL}${asPath}`;
-  const canonicalUrl = canonical || url;
+  const pathname = stripQueryAndHash(asPath || '/');
+  const url = toAbsoluteUrl(SITE_URL, pathname);
+  const canonicalUrl = resolveCanonical(canonical, SITE_URL, pathname);
 
   return (
     <Head>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -283,21 +283,37 @@ img { max-width: 100%; height: auto; display: block; }
   background: var(--accent-ink);
   color: var(--accent);
 }
+.ticket-button[disabled],
 .ticket-button[aria-disabled="true"] {
   opacity: 0.5;
   pointer-events: none;
+  cursor: not-allowed;
 }
 .affiliate-note {
-  display: none;
-  font-size: 10px;
-  color: #fff;
-  margin-top: 0;
-  font-weight: 400;
-  line-height: 1;
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  white-space: nowrap;
 }
 @media (max-width: 600px) {
   .affiliate-note {
+    position: static;
+    width: auto;
+    height: auto;
+    margin-top: 4px;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
     display: block;
+    font-size: 10px;
+    color: #fff;
+    font-weight: 400;
+    line-height: 1;
   }
 }
 .icon-button {


### PR DESCRIPTION
## Summary
- add a Supabase credential guard to the homepage SSR path and show a graceful fallback when configuration is missing
- make museum and exposition ticket buttons accessible while keeping the affiliate disclosure available to assistive tech
- compute deterministic hover colors for museum cards and fix canonical URL construction to strip query strings and use a configurable base URL

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c912a62bec83269a1deb7393e10dc6