### PR TITLE
Update typography and palette to new design

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,10 +1,43 @@
+import { useEffect } from 'react';
+import { Inter, Montserrat } from 'next/font/google';
 import '../styles/globals.css';
 import Layout from '../components/Layout';
 import { FavoritesProvider } from '../components/FavoritesContext';
 import { LanguageProvider } from '../components/LanguageContext';
 import { ThemeProvider } from '../components/ThemeContext';
 
+const titleFont = Montserrat({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  display: 'swap',
+  variable: '--font-title',
+});
+
+const bodyFont = Inter({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  display: 'swap',
+  variable: '--font-body',
+});
+
+const fontClassList = [
+  titleFont.variable,
+  titleFont.className,
+  bodyFont.variable,
+  bodyFont.className,
+].filter(Boolean);
+
 export default function MyApp({ Component, pageProps }) {
+  useEffect(() => {
+    if (typeof document === 'undefined') return undefined;
+
+    document.body.classList.add(...fontClassList);
+
+    return () => {
+      document.body.classList.remove(...fontClassList);
+    };
+  }, []);
+
   return (
     <LanguageProvider>
       <FavoritesProvider>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,39 +1,39 @@
 :root{
-  --bg:#ffffff;          /* zachte achtergrondkleur */
-  --body-bg:#DED7B7;     /* originele body achtergrond */
-  --text:#000000;
-  --muted:#6b7280;       /* grijs voor subtitels */
-  --border:#e5e7eb;      /* subtiele randen */
-  --accent:#000000;      /* warme accentkleur */
+  --bg:#f8f9fb;
+  --body-bg:#eef1f6;
+  --text:#1f2937;
+  --muted:#667085;
+  --border:#d9dde3;
+  --accent:#ff5a3c;
   --accent-ink:#ffffff;
-  --surface:#f3f4f6;
-  --panel-bg:rgba(255,255,255,0.94);
-  --panel-border:rgba(15,23,42,0.08);
-  --panel-shadow:0 32px 60px rgba(15,23,42,0.12);
-  --info-card-bg:rgba(249,209,205,0.92);
-  --info-card-text:#2d1a12;
-  --chip-bg:rgba(255,255,255,0.8);
-  --chip-border:rgba(15,23,42,0.08);
+  --surface:#ffffff;
+  --panel-bg:rgba(255,255,255,0.95);
+  --panel-border:rgba(31,41,55,0.08);
+  --panel-shadow:0 28px 60px rgba(15,23,42,0.12);
+  --info-card-bg:rgba(255,244,235,0.94);
+  --info-card-text:#4a3523;
+  --chip-bg:rgba(255,255,255,0.85);
+  --chip-border:rgba(31,41,55,0.08);
   --chip-active-bg:var(--accent);
   --chip-active-text:var(--accent-ink);
 }
 
 [data-theme='dark']{
-  --bg:#0f172a;
-  --body-bg:#0f172a;
-  --text:#f1f5f9;
+  --bg:#101828;
+  --body-bg:#0b1220;
+  --text:#e2e8f0;
   --muted:#94a3b8;
-  --border:#1e293b;
-  --accent:#f1f5f9;
-  --accent-ink:#000000;
+  --border:#1f2937;
+  --accent:#ff784f;
+  --accent-ink:#0b1220;
   --surface:#1f2937;
   --panel-bg:rgba(15,23,42,0.92);
-  --panel-border:rgba(148,163,184,0.2);
-  --panel-shadow:0 32px 60px rgba(2,6,23,0.6);
-  --info-card-bg:rgba(15,23,42,0.78);
+  --panel-border:rgba(148,163,184,0.18);
+  --panel-shadow:0 32px 60px rgba(2,6,23,0.55);
+  --info-card-bg:rgba(30,41,59,0.85);
   --info-card-text:var(--text);
   --chip-bg:rgba(148,163,184,0.12);
-  --chip-border:rgba(148,163,184,0.25);
+  --chip-border:rgba(148,163,184,0.24);
   --chip-active-bg:var(--accent);
   --chip-active-text:var(--accent-ink);
 }
@@ -41,15 +41,67 @@
 *{ box-sizing:border-box }
 html, body { padding:0; margin:0; background:var(--body-bg); color:var(--text); }
 body {
-  font-family: system-ui, -apple-system, Segoe UI, Ubuntu, Cantarell, Noto Sans, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  font-family: var(--font-body), system-ui, -apple-system, "Segoe UI", Ubuntu, Cantarell, "Noto Sans", "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
   font-weight: 400;
-  line-height: 1.6;
+  font-size: 16px;
+  line-height: 1.75;
+  letter-spacing: 0.01em;
 }
 h1, h2, h3, h4, h5, h6 {
-  font-family: sans-serif;
+  font-family: var(--font-title), var(--font-body), system-ui, -apple-system, "Segoe UI", sans-serif;
   font-weight: 700;
-  line-height: 1.3;
+  color: var(--text);
+  margin: 0 0 0.75em;
 }
+
+h1 {
+  font-size: clamp(2.75rem, 1.6vw + 2.3rem, 3.5rem);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin-top: 0.5em;
+}
+
+h2 {
+  font-size: clamp(2.1rem, 1.2vw + 1.7rem, 2.8rem);
+  line-height: 1.18;
+  letter-spacing: -0.015em;
+}
+
+h3 {
+  font-size: clamp(1.65rem, 1vw + 1.3rem, 2.2rem);
+  line-height: 1.22;
+  letter-spacing: -0.01em;
+}
+
+h4 {
+  font-size: 1.5rem;
+  line-height: 1.3;
+  letter-spacing: -0.005em;
+}
+
+h5 {
+  font-size: 1.25rem;
+  line-height: 1.35;
+}
+
+h6 {
+  font-size: 1.125rem;
+  line-height: 1.4;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+p {
+  margin: 0 0 1.5em;
+}
+
+ul,
+ol {
+  margin: 0 0 1.5em;
+  padding-left: 1.5em;
+  line-height: 1.7;
+}
+
 a { color: inherit; text-decoration: none; }
 img { max-width: 100%; height: auto; display: block; }
 
@@ -155,8 +207,19 @@ img { max-width: 100%; height: auto; display: block; }
   }
 }
 
-.page-title { margin: 8px 0 4px; font-size: 28px; font-weight: 700; }
-.page-subtitle { margin: 0 0 16px; color: var(--muted); }
+.page-title {
+  margin: 24px 0 12px;
+  font-family: var(--font-title), var(--font-body), system-ui, sans-serif;
+  font-size: clamp(2rem, 1vw + 1.8rem, 2.6rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.page-subtitle {
+  margin: 0 0 24px;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.6;
+}
 
 /* Controls */
 .input {
@@ -179,11 +242,15 @@ img { max-width: 100%; height: auto; display: block; }
 .tag {
   color: var(--muted);
   margin-right: 8px;
-  font-family: sans-serif;
+  font-family: var(--font-body), system-ui, sans-serif;
+  font-size: 0.875rem;
+  letter-spacing: 0.02em;
 }
 
 .description {
-  font-family: sans-serif;
+  font-family: var(--font-body), system-ui, sans-serif;
+  font-size: 0.95rem;
+  line-height: 1.6;
 }
 
 /* Cards grid */


### PR DESCRIPTION
## Summary
- import the Montserrat and Inter fonts with `next/font` and attach their classes to the document body
- refresh the light theme color variables and matching dark theme accents for the new neutral palette
- expand the global typography scale and spacing for headings, body copy, and utility text styles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb2976f10832690be0bb3b1855443