### PR TITLE
Add hero layout and filter trigger

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -16,14 +16,38 @@ export default function Layout({ children }) {
       </Head>
       <header className="header">
         <nav className="navbar container">
-          <div className="brand-wrap">
+          <div className="brand-wrap header-brand">
             <Link href="/" className="brand-square" aria-label={t('homeLabel')}>
-              <span className="brand-text">MUSEUM<br />BUDDY</span>
+              <span className="brand-letter">MB</span>
             </Link>
-            <span className="brand-title">MuseumBuddy</span>
+            <div className="brand-wordmark">
+              <span className="brand-title">MuseumBuddy</span>
+              <span className="brand-tagline">{t('heroTagline')}</span>
+            </div>
           </div>
           <div className="navspacer" />
           <div className="header-actions">
+            <button
+              type="button"
+              className="filters-trigger"
+              aria-label={t('filtersButton')}
+              aria-haspopup="dialog"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M4 4h16" />
+                <path d="M7 12h10" />
+                <path d="M10 20h4" />
+              </svg>
+              <span>{t('filtersButton')}</span>
+            </button>
             <button
               type="button"
               className="lang-select"

--- a/lib/translations.js
+++ b/lib/translations.js
@@ -2,7 +2,11 @@ const translations = {
   en: {
     homeTitle: 'MuseumBuddy — Museums',
     homeDescription: 'Search and filter museums in the Netherlands.',
+    heroTagline: 'Culture compass',
+    heroTitle: 'Discover museums across the Netherlands',
+    heroSubtitle: 'Search museums, explore current exhibitions, and plan your next cultural outing.',
     searchPlaceholder: 'Search',
+    filtersButton: 'Filters & search',
     expositions: 'Expositions',
     reset: 'Reset',
     results: 'results',
@@ -54,7 +58,11 @@ const translations = {
   nl: {
     homeTitle: 'MuseumBuddy — Musea',
     homeDescription: 'Zoek en filter musea in Nederland.',
+    heroTagline: 'Cultuurkompas',
+    heroTitle: 'Ontdek musea in heel Nederland',
+    heroSubtitle: 'Zoek musea, bekijk actuele exposities en plan je volgende culturele uitje.',
     searchPlaceholder: 'Zoek',
+    filtersButton: 'Filters & zoeken',
     expositions: 'Exposities',
     reset: 'Reset',
     results: 'resultaten',

--- a/pages/index.js
+++ b/pages/index.js
@@ -171,25 +171,32 @@ export default function Home({ initialMuseums = [], initialError = null }) {
   return (
     <>
       <SEO title={t('homeTitle')} description={t('homeDescription')} />
-      <form className="controls" onSubmit={(e) => e.preventDefault()}>
-        <div className="control-row">
+      <section className="hero">
+        <div className="hero-content">
+          <span className="hero-tagline">{t('heroTagline')}</span>
+          <h1 className="hero-title">{t('heroTitle')}</h1>
+          <p className="hero-subtext">{t('heroSubtitle')}</p>
+        </div>
+        <form className="hero-card hero-search" onSubmit={(e) => e.preventDefault()}>
           <input
             type="text"
-            className="input"
+            className="input hero-input"
             placeholder={t('searchPlaceholder')}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
           />
-          <a href={expositiesHref} className="btn-reset">
-            {t('expositions')}
-          </a>
-          {(query || hasExposities) && (
-            <a href="/" className="btn-reset">
-              {t('reset')}
+          <div className="hero-actions">
+            <a href={expositiesHref} className="hero-quick-link hero-quick-link--primary">
+              {t('expositions')}
             </a>
-          )}
-        </div>
-      </form>
+            {(query || hasExposities) && (
+              <a href="/" className="hero-quick-link hero-quick-link--ghost">
+                {t('reset')}
+              </a>
+            )}
+          </div>
+        </form>
+      </section>
 
       <p className="count">{results.length} {t('results')}</p>
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -179,11 +179,12 @@ export default function Home({ initialMuseums = [], initialError = null }) {
         </div>
         <form className="hero-card hero-search" onSubmit={(e) => e.preventDefault()}>
           <input
-            type="text"
+            type="search"
             className="input hero-input"
             placeholder={t('searchPlaceholder')}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
+            aria-label={t('searchPlaceholder')}
           />
           <div className="hero-actions">
             <a href={expositiesHref} className="hero-quick-link hero-quick-link--primary">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -140,21 +140,40 @@ img { max-width: 100%; height: auto; display: block; }
 
 /* Header brand */
 .brand-wrap { display:flex; align-items:center; gap:12px; }
+.header-brand {
+  padding: 10px 16px;
+  background: var(--surface);
+  border-radius: 18px;
+  border: 1px solid var(--panel-border);
+  box-shadow: var(--panel-shadow);
+}
 .brand-square {
   display:flex;
   align-items:center;
   justify-content:center;
-  width:48px;
-  height:48px;
-  border-radius:8px;
-  background:var(--surface);
-  text-align:center;
+  width:52px;
+  height:52px;
+  border-radius:14px;
+  background:var(--accent);
+  color:var(--accent-ink);
+  font-weight:700;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+  font-size:16px;
 }
-.brand-text { font-size:10px; font-weight:700; line-height:1.1; }
-.brand-title { font-weight:700; font-size:24px; }
+.brand-letter { line-height:1; }
+.brand-wordmark { display:flex; flex-direction:column; gap:4px; }
+.brand-title { font-weight:700; font-size:22px; letter-spacing:-0.01em; }
+.brand-tagline {
+  font-size:0.75rem;
+  font-weight:600;
+  letter-spacing:0.24em;
+  text-transform:uppercase;
+  color:var(--muted);
+}
 
 /* Header actions */
-.header-actions { display:flex; align-items:center; gap:16px; }
+.header-actions { display:flex; align-items:center; gap:14px; }
 .lang-select,
 .contrast-toggle {
   display:flex;
@@ -168,6 +187,25 @@ img { max-width: 100%; height: auto; display: block; }
 }
 .lang-select svg { width:12px; height:8px; }
 .contrast-toggle svg { width:20px; height:20px; }
+.filters-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: none;
+  background: var(--accent);
+  color: var(--accent-ink);
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  box-shadow: 0 14px 28px rgba(255, 90, 60, 0.28);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.filters-trigger svg { width: 18px; height: 18px; }
+.filters-trigger:hover { transform: translateY(-1px); box-shadow: 0 18px 32px rgba(255, 90, 60, 0.34); }
+.filters-trigger:focus-visible { outline: 2px solid var(--accent-ink); outline-offset: 3px; }
+.filters-trigger span { white-space: nowrap; }
 .header-icon {
   background:none;
   border:none;
@@ -198,13 +236,20 @@ img { max-width: 100%; height: auto; display: block; }
 }
 
 @media (max-width: 600px) {
-  .brand-title { display: none; }
+  .header-brand { padding: 8px 12px; }
+  .brand-title { font-size: 20px; }
+  .brand-tagline { display: none; }
   .navbar { padding: 16px 12px; }
   .header-actions { gap: 8px; }
   .header {
     backdrop-filter: none;
     background: var(--bg);
   }
+  .filters-trigger span { display: none; }
+}
+
+@media (max-width: 420px) {
+  .filters-trigger { padding: 10px; }
 }
 
 .page-title {
@@ -230,12 +275,101 @@ img { max-width: 100%; height: auto; display: block; }
   font-size: 14px;
   background: var(--bg);
 }
-.controls { display:grid; gap:12px; }
-.control-row { display:flex; gap:16px; flex-wrap:wrap; align-items:center; }
-.checkbox { display:flex; gap:8px; align-items:center; color:#222; font-size:14px; }
-.btn-reset {
-  padding: 8px 12px; border:1px solid var(--border); border-radius:10px;
-  background:var(--surface); cursor:pointer; font-size:14px;
+
+/* Hero */
+.hero {
+  display: grid;
+  gap: clamp(24px, 5vw, 48px);
+  align-items: center;
+  margin: clamp(24px, 6vw, 64px) 0 clamp(16px, 5vw, 48px);
+}
+.hero-content {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(12px, 2vw, 20px);
+}
+.hero-tagline {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.hero-title {
+  margin: 0;
+  font-size: clamp(2.4rem, 2.1vw + 2.1rem, 3.4rem);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+}
+.hero-subtext {
+  margin: 0;
+  font-size: clamp(1rem, 0.5vw + 0.95rem, 1.15rem);
+  color: var(--muted);
+  max-width: 560px;
+}
+.hero-card {
+  background: var(--surface);
+  border-radius: 24px;
+  border: 1px solid var(--panel-border);
+  box-shadow: var(--panel-shadow);
+  padding: clamp(20px, 4vw, 32px);
+  display: grid;
+  gap: 16px;
+}
+.hero-search { display: grid; gap: 16px; }
+.hero-input {
+  padding: 16px 18px;
+  font-size: 16px;
+  border-radius: 14px;
+  background: var(--body-bg);
+  border: 1px solid var(--panel-border);
+}
+.hero-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.hero-quick-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--panel-border);
+  background: var(--chip-bg);
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.12);
+}
+.hero-quick-link:hover { transform: translateY(-1px); box-shadow: 0 16px 28px rgba(15, 23, 42, 0.16); }
+.hero-quick-link--primary {
+  background: var(--accent);
+  color: var(--accent-ink);
+  border-color: transparent;
+  box-shadow: 0 16px 28px rgba(255, 90, 60, 0.3);
+}
+.hero-quick-link--ghost {
+  background: transparent;
+  color: var(--muted);
+  border-color: var(--panel-border);
+}
+
+@media (min-width: 900px) {
+  .hero { grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr); }
+}
+
+@media (max-width: 768px) {
+  .hero { margin-top: 20px; }
+  .hero-card { border-radius: 20px; }
+}
+
+@media (max-width: 600px) {
+  .hero { gap: 24px; }
+  .hero-card { padding: 20px; }
 }
 
 /* Tags */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -278,45 +278,83 @@ img { max-width: 100%; height: auto; display: block; }
 
 /* Hero */
 .hero {
+  position: relative;
   display: grid;
   gap: clamp(24px, 5vw, 48px);
   align-items: center;
   margin: clamp(24px, 6vw, 64px) 0 clamp(16px, 5vw, 48px);
+  padding: clamp(32px, 6vw, 56px);
+  border-radius: clamp(24px, 5vw, 40px);
+  overflow: hidden;
+  background: #0f172a;
+  box-shadow: 0 42px 80px rgba(15, 23, 42, 0.38);
+  color: #f8fafc;
+  isolation: isolate;
 }
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: -2%;
+  background-image: url('/images/rijksmuseum-amsterdam.png');
+  background-size: cover;
+  background-position: center bottom;
+  transform: scale(1.02);
+  filter: saturate(1.05) brightness(0.82);
+  z-index: -2;
+}
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: -2%;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.1) 0%, rgba(15, 23, 42, 0.82) 68%),
+    linear-gradient(120deg, rgba(15, 23, 42, 0.7) 0%, rgba(15, 23, 42, 0.15) 55%);
+  z-index: -1;
+}
+.hero > * { position: relative; z-index: 1; }
 .hero-content {
   display: flex;
   flex-direction: column;
   gap: clamp(12px, 2vw, 20px);
+  max-width: 560px;
 }
 .hero-tagline {
   font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: rgba(248, 250, 252, 0.72);
 }
 .hero-title {
   margin: 0;
   font-size: clamp(2.4rem, 2.1vw + 2.1rem, 3.4rem);
   line-height: 1.1;
   letter-spacing: -0.02em;
+  color: inherit;
 }
 .hero-subtext {
   margin: 0;
   font-size: clamp(1rem, 0.5vw + 0.95rem, 1.15rem);
-  color: var(--muted);
+  color: rgba(248, 250, 252, 0.85);
   max-width: 560px;
 }
 .hero-card {
-  background: var(--surface);
+  background: var(--panel-bg);
   border-radius: 24px;
   border: 1px solid var(--panel-border);
   box-shadow: var(--panel-shadow);
   padding: clamp(20px, 4vw, 32px);
   display: grid;
   gap: 16px;
+  color: var(--text);
+  backdrop-filter: blur(12px);
 }
-.hero-search { display: grid; gap: 16px; }
+.hero-search {
+  display: grid;
+  gap: 16px;
+  max-width: 460px;
+  width: 100%;
+  justify-self: start;
+}
 .hero-input {
   padding: 16px 18px;
   font-size: 16px;
@@ -357,18 +395,29 @@ img { max-width: 100%; height: auto; display: block; }
   color: var(--muted);
   border-color: var(--panel-border);
 }
+[data-theme='dark'] .hero {
+  box-shadow: 0 42px 80px rgba(2, 6, 23, 0.65);
+}
+[data-theme='dark'] .hero::before {
+  filter: saturate(1.05) brightness(0.58);
+}
+[data-theme='dark'] .hero::after {
+  background: linear-gradient(180deg, rgba(2, 6, 23, 0.38) 0%, rgba(2, 6, 23, 0.86) 72%),
+    linear-gradient(120deg, rgba(2, 6, 23, 0.78) 0%, rgba(2, 6, 23, 0.2) 55%);
+}
 
 @media (min-width: 900px) {
   .hero { grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr); }
 }
 
 @media (max-width: 768px) {
-  .hero { margin-top: 20px; }
+  .hero { margin-top: 20px; padding: clamp(24px, 6vw, 40px); border-radius: 28px; }
   .hero-card { border-radius: 20px; }
 }
 
 @media (max-width: 600px) {
-  .hero { gap: 24px; }
+  .hero { gap: 24px; padding: 24px; border-radius: 24px; }
+  .hero::before { background-position: center; }
   .hero-card { padding: 20px; }
 }
 


### PR DESCRIPTION
## Summary
- refresh the header branding with an accent lockup and add a visible Filters/Search trigger
- introduce a hero header on the home page with translated hero copy and elevated search card
- expand global styles for the new hero, header, and button treatments and add supporting translations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb4af45188326b28523bc137a944d