### PR TITLE
Revamp museum card layout and CTA styling

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -103,7 +103,7 @@ export default function MuseumCard({ museum }) {
           )}
         </Link>
         <div className="image-credit">
-          {t('museumLabel')}: {museum.title} — {t('imageCreditLabel')}: 
+          {t('museumLabel')}: {museum.title} — {t('imageCreditLabel')}:
           {museum.imageCredit ? (
             <>
               {museum.imageCredit.author}
@@ -120,26 +120,6 @@ export default function MuseumCard({ museum }) {
             </>
           ) : (
             t('unknown')
-          )}
-        </div>
-        <div className="museum-card-ticket">
-          {museum.ticketUrl ? (
-            <a
-              href={museum.ticketUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="ticket-button"
-              title={t('affiliateLink')}
-            >
-              <span>{t('buyTicket')}</span>
-              {showAffiliateNote && (
-                <span className="affiliate-note">{t('affiliateLinkLabel')}</span>
-              )}
-            </a>
-          ) : (
-            <button type="button" className="ticket-button" disabled aria-disabled="true">
-              <span>{t('buyTicket')}</span>
-            </button>
           )}
         </div>
         <div className="museum-card-actions">
@@ -178,19 +158,54 @@ export default function MuseumCard({ museum }) {
             {museum.title}
           </Link>
         </h3>
-        <p className="museum-card-location">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-            <path d="M12 11.25a2.25 2.25 0 1 0 0-4.5 2.25 2.25 0 0 0 0 4.5Z" />
-            <path d="M12 21s-7.5-7.048-7.5-11.25a7.5 7.5 0 1 1 15 0C19.5 13.952 12 21 12 21Z" />
-          </svg>
-          {[museum.city, museum.province].filter(Boolean).join(', ')}
-        </p>
+        <div className="museum-card-meta">
+          <p className="museum-card-location">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M12 11.25a2.25 2.25 0 1 0 0-4.5 2.25 2.25 0 0 0 0 4.5Z" />
+              <path d="M12 21s-7.5-7.048-7.5-11.25a7.5 7.5 0 1 1 15 0C19.5 13.952 12 21 12 21Z" />
+            </svg>
+            {[museum.city, museum.province].filter(Boolean).join(', ')}
+          </p>
+          {hours && (
+            <p className="museum-card-hours">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <circle cx="12" cy="12" r="7.25" />
+                <path d="M12 8v4l2.5 2.5" />
+              </svg>
+              {hours}
+            </p>
+          )}
+        </div>
         {summary && <p className="museum-card-summary">{summary}</p>}
-        {hours && <p className="museum-card-hours">{hours}</p>}
         {museum.free && (
           <div className="museum-card-tags">
             <span className="tag">{t('free')}</span>
           </div>
+        )}
+      </div>
+      <div className={`museum-card-cta${museum.ticketUrl ? '' : ' is-disabled'}`}>
+        {museum.ticketUrl ? (
+          <a
+            href={museum.ticketUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="ticket-button ticket-button--bar"
+            title={t('affiliateLink')}
+          >
+            <span className="ticket-label">{t('buyTicket')}</span>
+            {showAffiliateNote && (
+              <span className="affiliate-note">{t('affiliateLinkLabel')}</span>
+            )}
+          </a>
+        ) : (
+          <button
+            type="button"
+            className="ticket-button ticket-button--bar is-disabled"
+            disabled
+            aria-disabled="true"
+          >
+            <span className="ticket-label">{t('buyTicket')}</span>
+          </button>
         )}
       </div>
     </article>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -856,66 +856,192 @@ button.hero-quick-link {
   display: block;
 }
 
+/* MuseumCard component */
 .image-credit {
   position: absolute;
   bottom: 0;
   left: 0;
   width: 100%;
-  padding: 4px 8px;
+  padding: 10px 14px;
   font-size: 12px;
-  color: var(--muted);
+  color: rgba(255,255,255,0.92);
+  background: linear-gradient(0deg, rgba(15,23,42,0.7) 0%, rgba(15,23,42,0) 100%);
+  text-shadow: 0 1px 2px rgba(15,23,42,0.7);
+}
+[data-theme='dark'] .image-credit {
+  color: rgba(226,232,240,0.92);
+  background: linear-gradient(0deg, rgba(2,6,23,0.85) 0%, rgba(2,6,23,0) 100%);
+}
+.image-credit a {
+  color: inherit;
+  text-decoration: underline;
 }
 
-/* MuseumCard component */
 .museum-card {
+  --museum-card-media-ratio: 4 / 3;
   background: var(--surface);
-  border-radius: 12px;
+  border-radius: 16px;
   overflow: hidden;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+  box-shadow: 0 12px 32px rgba(15,23,42,0.12);
   display: flex;
   flex-direction: column;
   width: 100%;
+  position: relative;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+.museum-card:hover,
+.museum-card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 22px 44px rgba(15,23,42,0.18);
+}
+@media (prefers-reduced-motion: reduce) {
+  .museum-card,
+  .museum-card:hover,
+  .museum-card:focus-within {
+    transform: none;
+    transition: box-shadow 0.25s ease;
+  }
 }
 .museum-card-image {
   position: relative;
   width: 100%;
-  aspect-ratio: 4 / 3;
+  aspect-ratio: var(--museum-card-media-ratio);
+  overflow: hidden;
+}
+.museum-card-image img {
+  transition: transform 0.4s ease;
+}
+.museum-card:hover .museum-card-image img {
+  transform: scale(1.03);
 }
 .museum-card-actions {
   position: absolute;
-  top: 8px;
-  right: 8px;
+  bottom: 20px;
+  right: 20px;
   display: flex;
-  gap: 8px;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 20px;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  box-shadow: 0 16px 36px rgba(15,23,42,0.22);
+  backdrop-filter: blur(14px);
+  color: var(--text);
+  z-index: 2;
 }
-.museum-card-ticket {
-  position: absolute;
-  top: 8px;
-  left: 8px;
-  z-index: 1;
+.museum-card-cta {
+  background: var(--accent);
+  display: flex;
+  align-items: stretch;
+}
+.museum-card-cta.is-disabled {
+  background: var(--border);
+}
+[data-theme='dark'] .museum-card-cta.is-disabled {
+  background: rgba(148,163,184,0.18);
 }
 .ticket-button {
-  padding: 6px 12px;
-  border: none;
-  border-radius: 8px;
-  background: var(--accent);
-  color: var(--accent-ink);
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
-  display: flex;
+  display: inline-flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  text-align: center;
-  text-decoration: none;
   gap: 6px;
+  padding: 12px 18px;
+  border: none;
+  border-radius: 14px;
+  background: var(--accent);
+  color: var(--accent-ink);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  text-decoration: none;
   min-width: 0;
+  box-shadow: 0 12px 24px rgba(15,23,42,0.14);
+  line-height: 1.2;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
 }
 .ticket-button:hover {
   background: var(--accent-ink);
   color: var(--accent);
+  transform: translateY(-1px);
+  box-shadow: 0 18px 36px rgba(15,23,42,0.2);
+}
+.ticket-button:focus-visible {
+  background: var(--accent-ink);
+  color: var(--accent);
+  transform: translateY(-1px);
+  box-shadow: 0 18px 36px rgba(15,23,42,0.2);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.ticket-button--bar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 18px 24px;
+  border-radius: 0;
+  background: transparent;
+  color: var(--accent-ink);
+  box-shadow: none;
+  gap: 4px;
+  letter-spacing: 0.08em;
+}
+.museum-card-cta .ticket-button--bar:hover {
+  background: transparent;
+  color: var(--accent-ink);
+  transform: none;
+  box-shadow: none;
+}
+.museum-card-cta .ticket-button--bar:focus-visible {
+  background: transparent;
+  color: var(--accent-ink);
+  transform: none;
+  box-shadow: none;
+  outline: 2px solid rgba(255,255,255,0.55);
+  outline-offset: -2px;
+}
+.museum-card-cta.is-disabled .ticket-button--bar {
+  color: var(--muted);
+  cursor: not-allowed;
+  pointer-events: none;
+  opacity: 1;
+  background: transparent;
+  box-shadow: none;
+  outline: none;
+}
+.ticket-button.is-disabled {
+  background: transparent;
+}
+.ticket-label {
+  font-family: var(--font-title), var(--font-body), system-ui, -apple-system, "Segoe UI", sans-serif;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+}
+.affiliate-note {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 10px;
+  border-radius: 999px;
+  background: rgba(0,0,0,0.25);
+  color: #ffffff;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.35);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.12);
+}
+[data-theme='dark'] .affiliate-note {
+  background: rgba(255,255,255,0.7);
+  color: var(--accent-ink);
+  text-shadow: none;
+  box-shadow: inset 0 0 0 1px rgba(15,23,42,0.12);
 }
 .museum-info-links .ticket-button {
   width: 100%;
@@ -929,103 +1055,127 @@ button.hero-quick-link {
 }
 .ticket-button[disabled],
 .ticket-button[aria-disabled="true"] {
-  opacity: 0.5;
+  background: var(--border);
+  color: var(--muted);
+  box-shadow: none;
+  opacity: 1;
   pointer-events: none;
   cursor: not-allowed;
 }
-.affiliate-note {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-  white-space: nowrap;
-}
-@media (max-width: 600px) {
-  .affiliate-note {
-    position: static;
-    width: auto;
-    height: auto;
-    margin-top: 4px;
-    overflow: visible;
-    clip: auto;
-    white-space: normal;
-    display: block;
-    font-size: 10px;
-    color: inherit;
-    font-weight: 400;
-    line-height: 1;
-  }
-}
 .icon-button {
-  width: 32px;
-  height: 32px;
+  width: 36px;
+  height: 36px;
   border: none;
   border-radius: 50%;
-  background: rgba(255,255,255,0.9);
+  background: transparent;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
+  color: inherit;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
 }
 .icon-button svg {
   width: 18px;
   height: 18px;
 }
-
 .icon-button.large {
-  width: 36px;
-  height: 36px;
+  width: 40px;
+  height: 40px;
 }
-
 .icon-button.large svg {
   width: 20px;
   height: 20px;
 }
-
-/* Favorited state */
+.icon-button:hover,
+.icon-button:focus-visible {
+  background: rgba(255,255,255,0.22);
+  transform: translateY(-1px);
+}
+[data-theme='dark'] .icon-button:hover,
+[data-theme='dark'] .icon-button:focus-visible {
+  background: rgba(15,23,42,0.55);
+}
+.icon-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .icon-button.favorited {
   background: var(--accent);
   color: var(--accent-ink);
+  box-shadow: 0 10px 24px rgba(255,90,60,0.4);
 }
 .icon-button.favorited svg path {
   fill: currentColor;
 }
 
 .museum-card-info {
-  padding: 16px;
+  padding: 20px 20px 18px;
   background: var(--surface);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
   transition: background 0.3s ease;
 }
 .museum-card:hover .museum-card-info {
   background: var(--hover-bg, var(--surface));
 }
 .museum-card-title {
-  margin: 0 0 8px;
-  font-size: 20px;
-  font-weight: 600;
-}
-.museum-card-location {
   margin: 0;
-  display: flex;
-  align-items: center;
-  font-size: 14px;
-  color: var(--muted);
+  font-size: clamp(1.15rem, 1.2vw + 1rem, 1.45rem);
+  font-weight: 700;
+  line-height: 1.24;
+  letter-spacing: -0.01em;
 }
-.museum-card-location svg {
+.museum-card-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.9rem;
+  color: var(--muted);
+  letter-spacing: 0.01em;
+}
+@media (min-width: 640px) {
+  .museum-card-meta {
+    flex-direction: row;
+    align-items: center;
+    gap: 16px;
+  }
+}
+.museum-card-location,
+.museum-card-hours {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.museum-card-location svg,
+.museum-card-hours svg {
   width: 16px;
   height: 16px;
-  margin-right: 4px;
 }
-
+.museum-card-summary {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.65;
+  letter-spacing: 0.01em;
+  color: var(--text);
+}
 .museum-card-tags {
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
-  margin-top: 8px;
+  margin-top: 4px;
+}
+
+@media (min-width: 768px) {
+  .museum-card {
+    --museum-card-media-ratio: 16 / 9;
+  }
+}
+.museum-card:hover .ticket-button,
+.museum-card:focus-within .ticket-button {
+  text-decoration: none;
 }
 
 /* Events list and cards */


### PR DESCRIPTION
## Summary
- redesign the museum card markup to surface location and hours with icons, float share/favorite controls, and pin the ticket CTA into an accent bottom bar
- refresh global card styles with responsive media ratios, hover elevation, and a floating action container while keeping affiliate labels legible in light and dark themes
- tune typography, spacing, and CTA button treatments so titles and body copy follow the updated hierarchy

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdc3bc9e7883268e866acfe80ad1fb