### PR TITLE
Add sticky action bar and enhance museum detail styling

### DIFF
--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -186,6 +186,8 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
   const ticketUrl = affiliateTicketUrl || directTicketUrl;
   const showAffiliateNote = Boolean(affiliateTicketUrl) && shouldShowAffiliateNote(slug);
   const locationLines = getLocationLines(resolvedMuseum);
+  const hasWebsite = Boolean(resolvedMuseum.websiteUrl);
+  const hasTicketLink = Boolean(ticketUrl);
 
   const heroImage = useMemo(() => {
     if (!rawImage) return null;
@@ -326,6 +328,43 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
           <span>{t('back')}</span>
         </Link>
 
+        <div className="museum-primary-action-bar">
+          <div className="museum-primary-action-group">
+            {hasTicketLink ? (
+              <a
+                href={ticketUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="museum-primary-action primary"
+                title={t('affiliateLink')}
+              >
+                <span>{t('buyTicket')}</span>
+                {showAffiliateNote && <span className="affiliate-note">{t('affiliateLinkLabel')}</span>}
+              </a>
+            ) : (
+              <button type="button" className="museum-primary-action primary" disabled aria-disabled="true">
+                <span>{t('buyTicket')}</span>
+              </button>
+            )}
+
+            {hasWebsite && (
+              <a
+                href={resolvedMuseum.websiteUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="museum-primary-action secondary"
+              >
+                <span>{t('website')}</span>
+              </a>
+            )}
+          </div>
+
+          <div className="museum-primary-action-utility">
+            <ShareButton onShare={handleShare} label={t('share')} />
+            <FavoriteButton active={isFavorite} onToggle={handleFavorite} label={t('save')} />
+          </div>
+        </div>
+
         <div className="museum-detail-grid">
           <div className="museum-expositions-card">
             <header className="museum-detail-header">
@@ -333,10 +372,6 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
                 <p className="detail-sub">{[resolvedMuseum.city, resolvedMuseum.province].filter(Boolean).join(', ')}</p>
                 <h1 className="detail-title">{displayName}</h1>
                 {summary && <p className="detail-sub">{summary}</p>}
-              </div>
-              <div className="museum-detail-actions">
-                <ShareButton onShare={handleShare} label={t('share')} />
-                <FavoriteButton active={isFavorite} onToggle={handleFavorite} label={t('save')} />
               </div>
             </header>
 
@@ -362,36 +397,8 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
           </div>
 
           <aside className="museum-sidebar">
-            <div className="museum-sidebar-card">
+            <div className="museum-sidebar-card support-card">
               <h2 className="museum-sidebar-title">{t('visitorInformation')}</h2>
-              <div className="museum-info-links">
-                {ticketUrl ? (
-                  <a
-                    href={ticketUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="museum-info-link primary ticket-button"
-                    title={t('affiliateLink')}
-                  >
-                    <span>{t('buyTicket')}</span>
-                    {showAffiliateNote && <span className="affiliate-note">{t('affiliateLinkLabel')}</span>}
-                  </a>
-                ) : (
-                  <button type="button" className="museum-info-link primary ticket-button" disabled aria-disabled="true">
-                    <span>{t('buyTicket')}</span>
-                  </button>
-                )}
-                {resolvedMuseum.websiteUrl && (
-                  <a
-                    href={resolvedMuseum.websiteUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="museum-info-link"
-                  >
-                    <span>{t('website')}</span>
-                  </a>
-                )}
-              </div>
 
               <div className="museum-info-details">
                 {openingHours && (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -982,21 +982,18 @@ button.hero-quick-link {
 
 @media (max-width: 720px) {
   .museum-primary-action-bar {
-    position: fixed;
-    left: 50%;
-    bottom: 20px;
-    bottom: calc(20px + env(safe-area-inset-bottom));
-    transform: translateX(-50%);
-    width: min(560px, calc(100% - 32px));
-    margin: 0;
-    z-index: 30;
-    box-shadow: 0 32px 60px rgba(15,23,42,0.28);
+    position: sticky;
+    top: clamp(16px, 5vw, 32px);
+    top: calc(clamp(16px, 5vw, 32px) + env(safe-area-inset-top, 0px));
+    margin: 0 0 32px;
+    left: auto;
+    bottom: auto;
+    transform: none;
+    width: 100%;
+    max-width: none;
+    z-index: 20;
+    box-shadow: 0 22px 44px rgba(15,23,42,0.22);
     padding: 18px 20px;
-    padding-bottom: 18px;
-    padding-bottom: calc(18px + env(safe-area-inset-bottom));
-  }
-  .museum-detail {
-    padding-bottom: 200px;
   }
   .museum-primary-action {
     min-height: 50px;
@@ -1008,7 +1005,7 @@ button.hero-quick-link {
 }
 
 @media (max-width: 600px) {
-  .museum-detail { padding-bottom: 200px; }
+  .museum-detail { padding-bottom: 72px; }
   .museum-detail.has-hero .museum-detail-container { margin-top: -48px; }
   .museum-detail-grid { gap: 24px; }
   .museum-expositions-card,
@@ -1026,7 +1023,7 @@ button.hero-quick-link {
     backdrop-filter: none;
   }
   .museum-primary-action-bar {
-    width: min(520px, calc(100% - 28px));
+    width: 100%;
     padding: 16px 18px;
   }
   .museum-primary-action-group {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -16,6 +16,14 @@
   --chip-border:rgba(31,41,55,0.08);
   --chip-active-bg:var(--accent);
   --chip-active-text:var(--accent-ink);
+  --hero-overlay-start:rgba(12,10,9,0.28);
+  --hero-overlay-mid:rgba(12,10,9,0.6);
+  --hero-overlay-end:rgba(12,10,9,0.9);
+  --hero-overlay-side:rgba(12,10,9,0.45);
+  --hero-overlay-glow:rgba(255,255,255,0.2);
+  --action-bar-bg:rgba(255,255,255,0.92);
+  --action-bar-border:rgba(31,41,55,0.14);
+  --action-bar-shadow:0 28px 46px rgba(15,23,42,0.18);
 }
 
 [data-theme='dark']{
@@ -36,6 +44,14 @@
   --chip-border:rgba(148,163,184,0.24);
   --chip-active-bg:var(--accent);
   --chip-active-text:var(--accent-ink);
+  --hero-overlay-start:rgba(2,6,23,0.42);
+  --hero-overlay-mid:rgba(2,6,23,0.7);
+  --hero-overlay-end:rgba(2,6,23,0.9);
+  --hero-overlay-side:rgba(15,23,42,0.65);
+  --hero-overlay-glow:rgba(148,163,184,0.18);
+  --action-bar-bg:rgba(15,23,42,0.88);
+  --action-bar-border:rgba(148,163,184,0.24);
+  --action-bar-shadow:0 32px 58px rgba(2,6,23,0.45);
 }
 
 *{ box-sizing:border-box }
@@ -733,7 +749,18 @@ button.hero-quick-link {
 .museum-detail-container { position: relative; z-index: 2; }
 .museum-detail.has-hero .museum-detail-container { margin-top: -140px; }
 .museum-detail-hero { position: relative; height: clamp(260px, 55vh, 420px); overflow: hidden; border-radius: 0 0 36px 36px; }
-.museum-detail-hero::after { content: ""; position: absolute; inset: 0; background: linear-gradient(180deg, rgba(12,10,9,0.35) 0%, rgba(12,10,9,0.78) 100%); z-index: 1; }
+.museum-detail-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(120% 100% at 50% 0%, var(--hero-overlay-glow) 0%, transparent 65%),
+    linear-gradient(180deg, var(--hero-overlay-start) 0%, var(--hero-overlay-mid) 55%, var(--hero-overlay-end) 100%),
+    linear-gradient(120deg, var(--hero-overlay-side) 0%, transparent 42%);
+  mix-blend-mode: normal;
+  pointer-events: none;
+  z-index: 1;
+}
 .museum-hero-image { object-fit: cover; object-position: center; filter: saturate(1.08); }
 .museum-backlink {
   display: inline-flex;
@@ -768,18 +795,143 @@ button.hero-quick-link {
   outline: 2px solid var(--accent);
   outline-offset: 3px;
 }
+.museum-primary-action-bar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  padding: clamp(16px, 2vw + 12px, 24px) clamp(20px, 4vw, 32px);
+  margin: clamp(12px, 2vw, 24px) 0 clamp(32px, 4vw, 44px);
+  border-radius: 36px;
+  background: var(--action-bar-bg);
+  border: 1px solid var(--action-bar-border);
+  box-shadow: var(--action-bar-shadow);
+  backdrop-filter: blur(16px);
+  position: relative;
+  z-index: 6;
+}
+.museum-primary-action-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+.museum-primary-action-group:empty {
+  display: none;
+}
+.museum-primary-action-utility {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  justify-content: flex-end;
+}
+.museum-primary-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 12px 26px;
+  border-radius: 999px;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.2;
+  text-decoration: none;
+  color: inherit;
+  border: 1px solid transparent;
+  box-shadow: 0 14px 26px rgba(15,23,42,0.14);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+  min-height: 52px;
+}
+.museum-primary-action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 34px rgba(15,23,42,0.18);
+}
+.museum-primary-action.primary {
+  background: var(--accent);
+  color: var(--accent-ink);
+  box-shadow: 0 18px 34px rgba(255,90,60,0.32);
+}
+.museum-primary-action.primary:hover {
+  box-shadow: 0 24px 42px rgba(255,90,60,0.38);
+}
+.museum-primary-action.primary[disabled],
+.museum-primary-action.primary[aria-disabled="true"] {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: 0 12px 22px rgba(15,23,42,0.12);
+}
+.museum-primary-action.secondary {
+  background: rgba(255,255,255,0.82);
+  border-color: var(--panel-border);
+  color: var(--text);
+}
+.museum-primary-action.secondary:hover {
+  background: rgba(255,255,255,0.96);
+}
+[data-theme='dark'] .museum-primary-action.secondary {
+  background: rgba(15,23,42,0.7);
+  border-color: var(--panel-border);
+  color: var(--text);
+}
+[data-theme='dark'] .museum-primary-action.secondary:hover {
+  background: rgba(15,23,42,0.82);
+}
+.museum-primary-action-utility .icon-button {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+}
+.museum-primary-action-utility .icon-button:not(.favorited) {
+  background: rgba(255,255,255,0.94);
+  border: 1px solid var(--panel-border);
+  box-shadow: 0 16px 30px rgba(15,23,42,0.16);
+}
+[data-theme='dark'] .museum-primary-action-utility .icon-button:not(.favorited) {
+  background: rgba(15,23,42,0.7);
+  border-color: rgba(148,163,184,0.28);
+}
+.museum-primary-action-utility .icon-button.favorited {
+  box-shadow: 0 18px 32px rgba(255,90,60,0.35);
+}
 .museum-detail-grid { display: grid; gap: 32px; grid-template-columns: minmax(0, 2.3fr) minmax(0, 1fr); align-items: start; }
 .museum-expositions-card { background: var(--panel-bg); border-radius: 32px; padding: clamp(24px, 4vw, 44px); border: 1px solid var(--panel-border); box-shadow: var(--panel-shadow); backdrop-filter: blur(14px); display: flex; flex-direction: column; gap: 24px; }
 .museum-expositions-card .detail-title { margin: 0; font-size: clamp(28px, 4vw, 40px); }
 .museum-expositions-card .detail-sub { margin-top: 6px; }
-.museum-detail-header { display: flex; gap: 16px; justify-content: space-between; align-items: flex-start; }
-.museum-detail-actions { display: flex; gap: 12px; align-items: center; }
+.museum-detail-header { display: flex; flex-direction: column; gap: 16px; align-items: flex-start; }
 .museum-expositions-heading { margin: 0; font-size: clamp(24px, 3vw, 30px); font-weight: 700; letter-spacing: -0.01em; }
 .museum-expositions-body { display: flex; flex-direction: column; gap: 16px; }
 .museum-expositions-body .events-list { gap: 16px; }
 .museum-expositions-empty { margin: 8px 0 0; color: var(--muted); }
 .museum-sidebar { position: relative; }
-.museum-sidebar-card { background: var(--info-card-bg); color: var(--info-card-text); border-radius: 32px; padding: clamp(24px, 4vw, 36px); border: 1px solid var(--panel-border); box-shadow: var(--panel-shadow); display: flex; flex-direction: column; gap: 20px; }
+.museum-sidebar-card {
+  background: linear-gradient(180deg, var(--info-card-bg) 0%, rgba(255,255,255,0.95) 100%);
+  color: var(--info-card-text);
+  border-radius: 32px;
+  padding: clamp(28px, 4vw, 40px);
+  border: 1px solid var(--panel-border);
+  box-shadow: var(--panel-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  position: relative;
+  overflow: hidden;
+}
+.museum-sidebar-card.support-card {
+  border-top: 4px solid var(--accent);
+  padding-top: clamp(32px, 5vw, 44px);
+}
+.museum-sidebar-card.support-card::before {
+  content: "";
+  display: inline-flex;
+  width: 56px;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--accent);
+  opacity: 0.85;
+  align-self: flex-start;
+  margin-bottom: 8px;
+}
 .museum-sidebar-title { margin: 0; font-size: 20px; font-weight: 700; letter-spacing: -0.01em; }
 .museum-info-links { display: flex; flex-wrap: wrap; gap: 12px; }
 .museum-info-link { display: inline-flex; align-items: center; gap: 8px; padding: 10px 18px; border-radius: 999px; font-size: 14px; font-weight: 600; background: var(--chip-bg); color: var(--info-card-text); border: 1px solid var(--chip-border); text-transform: none; transition: transform 0.15s ease, box-shadow 0.15s ease; box-shadow: 0 6px 14px rgba(15,23,42,0.08); }
@@ -803,6 +955,10 @@ button.hero-quick-link {
 
 @media (max-width: 900px) {
   .museum-detail.has-hero .museum-detail-container { margin-top: -90px; }
+  .museum-primary-action-bar {
+    border-radius: 32px;
+    margin-bottom: 32px;
+  }
 }
 
 @media (max-width: 768px) {
@@ -811,10 +967,48 @@ button.hero-quick-link {
   .museum-expositions-card,
   .museum-sidebar-card { border-radius: 28px; }
   .museum-info-links { gap: 10px; }
+  .museum-primary-action-bar {
+    grid-template-columns: 1fr;
+    gap: 14px;
+    padding: 18px 22px;
+  }
+  .museum-primary-action-group {
+    justify-content: center;
+  }
+  .museum-primary-action-utility {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 720px) {
+  .museum-primary-action-bar {
+    position: fixed;
+    left: 50%;
+    bottom: 20px;
+    bottom: calc(20px + env(safe-area-inset-bottom));
+    transform: translateX(-50%);
+    width: min(560px, calc(100% - 32px));
+    margin: 0;
+    z-index: 30;
+    box-shadow: 0 32px 60px rgba(15,23,42,0.28);
+    padding: 18px 20px;
+    padding-bottom: 18px;
+    padding-bottom: calc(18px + env(safe-area-inset-bottom));
+  }
+  .museum-detail {
+    padding-bottom: 200px;
+  }
+  .museum-primary-action {
+    min-height: 50px;
+  }
+  .museum-primary-action-utility .icon-button {
+    width: 48px;
+    height: 48px;
+  }
 }
 
 @media (max-width: 600px) {
-  .museum-detail { padding-bottom: 32px; }
+  .museum-detail { padding-bottom: 200px; }
   .museum-detail.has-hero .museum-detail-container { margin-top: -48px; }
   .museum-detail-grid { gap: 24px; }
   .museum-expositions-card,
@@ -824,13 +1018,51 @@ button.hero-quick-link {
     box-shadow: 0 14px 28px rgba(15,23,42,0.16);
     backdrop-filter: none;
   }
+  .museum-sidebar-card.support-card {
+    padding-top: 28px;
+  }
   .museum-backlink {
     box-shadow: 0 12px 24px rgba(15,23,42,0.14);
     backdrop-filter: none;
   }
-  .museum-detail-header { flex-direction: column; }
-  .museum-detail-actions { align-self: flex-end; }
+  .museum-primary-action-bar {
+    width: min(520px, calc(100% - 28px));
+    padding: 16px 18px;
+  }
+  .museum-primary-action-group {
+    gap: 10px;
+  }
+  .museum-primary-action {
+    width: 100%;
+  }
+  .museum-primary-action-utility {
+    width: 100%;
+    justify-content: space-between;
+  }
+  .museum-primary-action .affiliate-note {
+    font-size: 11px;
+    opacity: 0.8;
+  }
   .museum-info-link { width: 100%; justify-content: center; box-shadow: 0 8px 18px rgba(15,23,42,0.14); }
+}
+
+@media (max-width: 480px) {
+  .museum-primary-action-bar {
+    width: calc(100% - 24px);
+    padding: 16px;
+    border-radius: 22px;
+  }
+  .museum-primary-action-group {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .museum-primary-action-utility {
+    gap: 16px;
+  }
+  .museum-primary-action-utility .icon-button {
+    width: 46px;
+    height: 46px;
+  }
 }
 
 /* Footer space */


### PR DESCRIPTION
## Summary
- introduce a hero-adjacent action bar for ticket, website, share and favorite controls and simplify the header
- restyle the sidebar as a supporting info card and create responsive sticky CTA behaviour for small screens
- expand hero overlay styling with theme-aware gradient variables to improve readability across imagery

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdcc60243c83269c0d414abd5fd935