### PR TITLE
Improve mobile ticket button styling

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1048,13 +1048,23 @@ button.hero-quick-link {
   .museum-primary-action {
     width: 100%;
   }
+  .museum-primary-action.primary {
+    flex-direction: column;
+    align-items: flex-start;
+    text-align: left;
+    gap: 8px;
+  }
+  .museum-primary-action.primary > span:first-child {
+    width: 100%;
+    font-size: 16px;
+    line-height: 1.25;
+  }
   .museum-primary-action-utility {
     width: 100%;
     justify-content: space-between;
   }
   .museum-primary-action .affiliate-note {
-    font-size: 11px;
-    opacity: 0.8;
+    opacity: 0.92;
   }
   .museum-info-link { width: 100%; justify-content: center; box-shadow: 0 8px 18px rgba(15,23,42,0.14); }
 }
@@ -1296,6 +1306,26 @@ button.hero-quick-link {
     width: auto;
   }
 }
+.ticket-button > span:first-child {
+  font-size: 15px;
+  line-height: 1.2;
+}
+@media (max-width: 600px) {
+  .ticket-button {
+    width: 100%;
+    align-items: flex-start;
+    text-align: left;
+    padding: 12px 16px;
+    gap: 8px;
+    border-radius: 12px;
+  }
+  .ticket-button > span:first-child {
+    font-size: 16px;
+  }
+  .ticket-button .affiliate-note {
+    opacity: 0.92;
+  }
+}
 .ticket-button[disabled],
 .ticket-button[aria-disabled="true"] {
   opacity: 0.5;
@@ -1318,15 +1348,24 @@ button.hero-quick-link {
     position: static;
     width: auto;
     height: auto;
-    margin-top: 4px;
+    margin: 6px 0 0;
     overflow: visible;
     clip: auto;
     white-space: normal;
-    display: block;
-    font-size: 11px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
     color: var(--accent-ink);
-    font-weight: 400;
-    line-height: 1;
+    font-weight: 500;
+    line-height: 1.35;
+    letter-spacing: 0.01em;
+  }
+  .affiliate-note::before {
+    content: '\\2139';
+    font-size: 0.95em;
+    font-weight: 600;
+    opacity: 0.78;
   }
 }
 


### PR DESCRIPTION
## Summary
- align the buy ticket button text and spacing for better mobile readability
- restyle the affiliate disclosure into an inline info badge that works on small screens
- stack the museum detail primary action content vertically on phones to avoid cramped layouts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce3fd2c92c8326946654a10b44c0ec