### PR TITLE
Adjust spacing for affiliate note in ticket buttons

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1047,6 +1047,8 @@ button.hero-quick-link {
   }
   .museum-primary-action {
     width: 100%;
+    flex-direction: column;
+    gap: 6px;
   }
   .museum-primary-action-utility {
     width: 100%;
@@ -1267,7 +1269,7 @@ button.hero-quick-link {
   justify-content: center;
   text-align: center;
   text-decoration: none;
-  gap: 6px;
+  gap: 4px;
   min-width: 0;
   transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease, color 0.3s ease;
 }
@@ -1318,7 +1320,7 @@ button.hero-quick-link {
     position: static;
     width: auto;
     height: auto;
-    margin-top: 4px;
+    margin-top: 0;
     overflow: visible;
     clip: auto;
     white-space: normal;


### PR DESCRIPTION
## Summary
- reduce the vertical space between the Buy ticket label and the affiliate note in ticket buttons
- stack primary action button content on small screens so the affiliate label sits closer to the main text
- remove extra margin on the affiliate note when it is shown on mobile

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce41a1386c832682ddb98963f98100