### PR TITLE
Add immersive hover experience to museum cards

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -186,34 +186,37 @@ export default function MuseumCard({ museum }) {
           </button>
         </div>
       </div>
-      <dl className="image-credit">
-        <div className="image-credit-row">
-          <dt className="image-credit-term">{t('museumLabel')}</dt>
-          <dd className="image-credit-definition">{museum.title}</dd>
-        </div>
-        <div className="image-credit-row">
-          <dt className="image-credit-term">{t('imageCreditLabel')}</dt>
-          <dd className="image-credit-definition">
-            {museum.imageCredit ? (
+      <p className="image-credit">
+        <span className="image-credit-label">{t('imageCreditLabel')}</span>
+        <span aria-hidden="true" className="image-credit-separator">•</span>
+        {museum.imageCredit ? (
+          <>
+            <span className="image-credit-definition">
+              {museum.imageCredit.author}
+              {museum.imageCredit.license ? `, ${museum.imageCredit.license}` : ''}
+            </span>
+            {museum.imageCredit.source && (
               <>
-                {museum.imageCredit.author}
-                {museum.imageCredit.license ? `, ${museum.imageCredit.license}` : ''}
-                {museum.imageCredit.source && (
-                  <>
-                    {' '}
-                    {t('via')}{' '}
-                    <a href={museum.imageCredit.url} target="_blank" rel="noreferrer">
-                      {museum.imageCredit.source}
-                    </a>
-                  </>
+                <span aria-hidden="true" className="image-credit-divider">•</span>
+                {museum.imageCredit.url ? (
+                  <a
+                    className="image-credit-link"
+                    href={museum.imageCredit.url}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {museum.imageCredit.source}
+                  </a>
+                ) : (
+                  <span className="image-credit-definition">{museum.imageCredit.source}</span>
                 )}
               </>
-            ) : (
-              t('unknown')
             )}
-          </dd>
-        </div>
-      </dl>
+          </>
+        ) : (
+          <span className="image-credit-definition">{t('unknown')}</span>
+        )}
+      </p>
       <div className="museum-card-info">
         <h3 className="museum-card-title">
           <Link

--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -136,26 +136,6 @@ export default function MuseumCard({ museum }) {
             </span>
           </div>
         </Link>
-        <div className="image-credit">
-          {t('museumLabel')}: {museum.title} — {t('imageCreditLabel')}:
-          {museum.imageCredit ? (
-            <>
-              {museum.imageCredit.author}
-              {museum.imageCredit.license ? `, ${museum.imageCredit.license}` : ''}
-              {museum.imageCredit.source && (
-                <>
-                  {' '}
-                  {t('via')}{' '}
-                  <a href={museum.imageCredit.url} target="_blank" rel="noreferrer">
-                    {museum.imageCredit.source}
-                  </a>
-                </>
-              )}
-            </>
-          ) : (
-            t('unknown')
-          )}
-        </div>
         <div className="museum-card-ticket">
           {museum.ticketUrl ? (
             <a
@@ -206,6 +186,34 @@ export default function MuseumCard({ museum }) {
           </button>
         </div>
       </div>
+      <dl className="image-credit">
+        <div className="image-credit-row">
+          <dt className="image-credit-term">{t('museumLabel')}</dt>
+          <dd className="image-credit-definition">{museum.title}</dd>
+        </div>
+        <div className="image-credit-row">
+          <dt className="image-credit-term">{t('imageCreditLabel')}</dt>
+          <dd className="image-credit-definition">
+            {museum.imageCredit ? (
+              <>
+                {museum.imageCredit.author}
+                {museum.imageCredit.license ? `, ${museum.imageCredit.license}` : ''}
+                {museum.imageCredit.source && (
+                  <>
+                    {' '}
+                    {t('via')}{' '}
+                    <a href={museum.imageCredit.url} target="_blank" rel="noreferrer">
+                      {museum.imageCredit.source}
+                    </a>
+                  </>
+                )}
+              </>
+            ) : (
+              t('unknown')
+            )}
+          </dd>
+        </div>
+      </dl>
       <div className="museum-card-info">
         <h3 className="museum-card-title">
           <Link

--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -113,7 +113,7 @@ export default function MuseumCard({ museum }) {
       <div className="museum-card-image">
         <Link
           href={{ pathname: '/museum/[slug]', query: { slug: museum.slug } }}
-          style={{ display: 'block', width: '100%', height: '100%', position: 'relative' }}
+          className="museum-card-media-link"
           aria-label={`${t('view')} ${museum.title}`}
         >
           {museum.image && (
@@ -122,12 +122,22 @@ export default function MuseumCard({ museum }) {
               alt={museum.title}
               fill
               sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+              className="museum-card-media"
               style={{ objectFit: 'cover' }}
             />
           )}
+          <div className="museum-card-overlay" aria-hidden="true">
+            <span className="museum-card-overlay-label">{t('view')}</span>
+            <span className="museum-card-overlay-icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M5 12h14" />
+                <path d="M13 6l6 6-6 6" />
+              </svg>
+            </span>
+          </div>
         </Link>
         <div className="image-credit">
-          {t('museumLabel')}: {museum.title} — {t('imageCreditLabel')}: 
+          {t('museumLabel')}: {museum.title} — {t('imageCreditLabel')}:
           {museum.imageCredit ? (
             <>
               {museum.imageCredit.author}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1206,45 +1206,51 @@ button.hero-quick-link {
 }
 
 .image-credit {
-  margin: 8px 20px 0;
+  margin: 10px 20px 0;
   padding: 0;
-  color: var(--muted);
-  display: grid;
-  row-gap: 2px;
-  font-size: 0.64rem;
-  line-height: 1.35;
+  color: rgba(15, 23, 42, 0.6);
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 0.75rem;
+  line-height: 1.45;
+  letter-spacing: 0.01em;
 }
 
 [data-theme='dark'] .image-credit {
   color: rgba(203, 213, 225, 0.75);
 }
 
-.image-credit-row {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  column-gap: 8px;
-  align-items: baseline;
-}
-
-.image-credit-term {
-  margin: 0;
+.image-credit-label {
+  font-size: 0.68rem;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-weight: 500;
-  color: rgba(15, 23, 42, 0.45);
+  letter-spacing: 0.16em;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.5);
 }
 
-[data-theme='dark'] .image-credit-term {
-  color: rgba(203, 213, 225, 0.55);
+[data-theme='dark'] .image-credit-label {
+  color: rgba(203, 213, 225, 0.6);
+}
+
+.image-credit-separator,
+.image-credit-divider {
+  color: rgba(15, 23, 42, 0.4);
+  font-size: 0.65rem;
+}
+
+[data-theme='dark'] .image-credit-separator,
+[data-theme='dark'] .image-credit-divider {
+  color: rgba(148, 163, 184, 0.6);
 }
 
 .image-credit-definition {
   margin: 0;
-  letter-spacing: 0.01em;
   color: inherit;
 }
 
-.image-credit-definition a {
+.image-credit-link {
   color: inherit;
   text-decoration: underline;
   text-decoration-thickness: 1px;
@@ -1252,8 +1258,8 @@ button.hero-quick-link {
   text-decoration-skip-ink: auto;
 }
 
-.image-credit-definition a:hover,
-.image-credit-definition a:focus-visible {
+.image-credit-link:hover,
+.image-credit-link:focus-visible {
   color: var(--accent);
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1206,13 +1206,63 @@ button.hero-quick-link {
 }
 
 .image-credit {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  padding: 4px 8px;
-  font-size: 12px;
+  margin: 16px 20px 0;
+  padding: 12px 16px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.65));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
   color: var(--muted);
+  display: grid;
+  gap: 10px;
+  font-size: 0.75rem;
+  line-height: 1.45;
+}
+
+[data-theme='dark'] .image-credit {
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.85), rgba(15, 23, 42, 0.72));
+  border-color: rgba(148, 163, 184, 0.18);
+  box-shadow: 0 14px 32px rgba(2, 6, 23, 0.35);
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.image-credit-row {
+  display: grid;
+  grid-template-columns: minmax(0, auto) minmax(0, 1fr);
+  gap: 4px 12px;
+}
+
+.image-credit-term {
+  margin: 0;
+  font-size: 0.65rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+[data-theme='dark'] .image-credit-term {
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.image-credit-definition {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.01em;
+  color: inherit;
+}
+
+.image-credit-definition a {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: rgba(102, 112, 133, 0.4);
+  transition: color 0.2s ease;
+}
+
+.image-credit-definition a:hover,
+.image-credit-definition a:focus-visible {
+  color: var(--accent);
+  text-decoration-color: rgba(255, 90, 60, 0.65);
 }
 
 /* MuseumCard component */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1206,48 +1206,40 @@ button.hero-quick-link {
 }
 
 .image-credit {
-  margin: 16px 20px 0;
-  padding: 12px 16px;
-  border-radius: 14px;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.65));
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+  margin: 8px 20px 0;
+  padding: 0;
   color: var(--muted);
   display: grid;
-  gap: 10px;
-  font-size: 0.75rem;
-  line-height: 1.45;
+  row-gap: 2px;
+  font-size: 0.64rem;
+  line-height: 1.35;
 }
 
 [data-theme='dark'] .image-credit {
-  background: linear-gradient(135deg, rgba(30, 41, 59, 0.85), rgba(15, 23, 42, 0.72));
-  border-color: rgba(148, 163, 184, 0.18);
-  box-shadow: 0 14px 32px rgba(2, 6, 23, 0.35);
-  color: rgba(226, 232, 240, 0.82);
+  color: rgba(203, 213, 225, 0.75);
 }
 
 .image-credit-row {
   display: grid;
-  grid-template-columns: minmax(0, auto) minmax(0, 1fr);
-  gap: 4px 12px;
+  grid-template-columns: auto 1fr;
+  column-gap: 8px;
+  align-items: baseline;
 }
 
 .image-credit-term {
   margin: 0;
-  font-size: 0.65rem;
-  letter-spacing: 0.16em;
   text-transform: uppercase;
-  font-weight: 600;
-  color: rgba(15, 23, 42, 0.6);
+  letter-spacing: 0.08em;
+  font-weight: 500;
+  color: rgba(15, 23, 42, 0.45);
 }
 
 [data-theme='dark'] .image-credit-term {
-  color: rgba(226, 232, 240, 0.7);
+  color: rgba(203, 213, 225, 0.55);
 }
 
 .image-credit-definition {
   margin: 0;
-  font-size: 0.75rem;
   letter-spacing: 0.01em;
   color: inherit;
 }
@@ -1255,14 +1247,14 @@ button.hero-quick-link {
 .image-credit-definition a {
   color: inherit;
   text-decoration: underline;
-  text-decoration-color: rgba(102, 112, 133, 0.4);
-  transition: color 0.2s ease;
+  text-decoration-thickness: 1px;
+  text-decoration-color: currentColor;
+  text-decoration-skip-ink: auto;
 }
 
 .image-credit-definition a:hover,
 .image-credit-definition a:focus-visible {
   color: var(--accent);
-  text-decoration-color: rgba(255, 90, 60, 0.65);
 }
 
 /* MuseumCard component */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1314,6 +1314,77 @@ button.hero-quick-link {
   overflow: hidden;
 }
 
+.museum-card-media-link {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  border-radius: inherit;
+}
+
+.museum-card-media {
+  transition: transform 0.6s cubic-bezier(0.19, 1, 0.22, 1), filter 0.6s ease;
+  will-change: transform;
+}
+
+.museum-card-overlay {
+  position: absolute;
+  inset: 0;
+  padding: 20px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.35) 45%, rgba(15, 23, 42, 0.68) 100%);
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.35s ease, transform 0.35s ease;
+  pointer-events: none;
+  color: #fff;
+}
+
+.museum-card-overlay-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  font-size: 0.95rem;
+  padding: 12px 18px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.25);
+}
+
+.museum-card-overlay-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--hover-bg, rgba(255, 255, 255, 0.85));
+  color: rgba(15, 23, 42, 0.9);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.35);
+}
+
+.museum-card-overlay-icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.museum-card:hover .museum-card-overlay {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.museum-card:hover .museum-card-media {
+  transform: scale(1.06);
+  filter: saturate(1.08) contrast(1.05);
+}
+
 .museum-card-actions {
   position: absolute;
   top: 12px;
@@ -1541,14 +1612,15 @@ button.hero-quick-link {
 .museum-card-info {
   padding: 20px;
   background: var(--surface);
-  transition: background 0.3s ease;
+  transition: opacity 0.35s ease, transform 0.35s ease;
   display: flex;
   flex-direction: column;
   gap: 14px;
 }
 
 .museum-card:hover .museum-card-info {
-  background: var(--hover-bg, var(--surface));
+  opacity: 0.94;
+  transform: translateY(4px);
 }
 
 .museum-card-title {


### PR DESCRIPTION
## Summary
- add a CTA overlay with icon to museum card imagery to modernize hover states
- animate museum card media and info sections for a subtle focus shift on hover

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce43937da48326b777c3ec05aa8195