### PR TITLE
Adjust mobile header layout

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -345,11 +345,25 @@ img { max-width: 100%; height: auto; display: block; }
 }
 
 @media (max-width: 600px) {
-  .header-brand { padding: 8px 12px; }
+  .header-brand {
+    padding: 8px 12px;
+    flex: 1 1 100%;
+  }
   .brand-title { font-size: 20px; }
   .brand-tagline { display: none; }
-  .navbar { padding: 16px 12px; }
-  .header-actions { gap: 8px; }
+  .navbar {
+    padding: 16px 12px;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .navspacer { display: none; }
+  .header-actions {
+    gap: 8px;
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+  .header-actions > * { flex: 0 0 auto; }
   .header {
     backdrop-filter: none;
     background: var(--bg);


### PR DESCRIPTION
## Summary
- allow the header navigation to wrap on small screens so the brand fits cleanly
- hide the spacer and spread the action buttons across the full width on mobile to avoid overflow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce678bf2288326aaceb881bd35d9b1