### PR TITLE
Fix mobile hero search bar visibility

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -789,6 +789,13 @@ button.hero-quick-link {
   .hero { grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr); }
 }
 
+@media (max-width: 900px) {
+  .hero {
+    aspect-ratio: auto;
+    --hero-aspect: auto;
+  }
+}
+
 @media (max-width: 768px) {
   .hero { margin-top: 20px; padding: clamp(24px, 6vw, 40px); border-radius: 28px; }
   .hero-card { border-radius: 20px; }


### PR DESCRIPTION
## Summary
- allow the hero section to grow naturally on viewports below 900px so the search form stays visible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce6925e08c8326bc009c4c8054f636