### PR TITLE
Remove legacy hero styles that reintroduced fixed aspect ratio

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -789,6 +789,13 @@ button.hero-quick-link {
   .hero { grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr); }
 }
 
+@media (max-width: 900px) {
+  .hero {
+    aspect-ratio: auto;
+    --hero-aspect: auto;
+  }
+}
+
 @media (max-width: 768px) {
   .hero { margin-top: 20px; padding: clamp(24px, 6vw, 40px); border-radius: 28px; }
   .hero-card { border-radius: 20px; }
@@ -1189,36 +1196,6 @@ button.hero-quick-link {
 .link-accent { color: var(--accent); }
 
 /* Afbeeldingen */
-.hero {
-  position: relative;
-  width: 100%;
-  --hero-aspect: 4 / 3;
-  aspect-ratio: var(--hero-aspect);
-  border-radius: 16px;
-  overflow: hidden;
-  margin: 12px 0 16px;
-  background: var(--surface);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.hero:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 18px 36px rgba(15,23,42,0.14);
-}
-
-@media (min-width: 768px) {
-  .hero {
-    --hero-aspect: 16 / 9;
-  }
-}
-
-.hero img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
-
 .image-credit {
   margin: 10px 20px 0;
   padding: 0;


### PR DESCRIPTION
## Summary
- delete an outdated hero selector that reapplied a fixed aspect ratio and cropped the homepage hero content on small screens

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce6925e08c8326bc009c4c8054f636