### PR TITLE
Remove legacy hero styles that reintroduced fixed aspect ratio

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -789,6 +789,13 @@ button.hero-quick-link {
   .hero { grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr); }
 }
 
+@media (max-width: 900px) {
+  .hero {
+    aspect-ratio: auto;
+    --hero-aspect: auto;
+  }
+}
+
 @media (max-width: 768px) {
   .hero { margin-top: 20px; padding: clamp(24px, 6vw, 40px); border-radius: 28px; }
   .hero-card { border-radius: 20px; }
@@ -798,6 +805,40 @@ button.hero-quick-link {
   .hero { gap: 24px; padding: 24px; border-radius: 24px; }
   .hero::before { background-position: center; }
   .hero-card { padding: 20px; }
+}
+
+@media (max-width: 480px) {
+  .hero-card {
+    padding: 16px;
+    border-radius: 18px;
+    gap: 12px;
+    background: rgba(248, 250, 252, 0.9);
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.16);
+  }
+  .hero-search {
+    gap: 12px;
+  }
+  .hero-input {
+    padding: 12px 14px;
+    font-size: 15px;
+    border-radius: 12px;
+    background: rgba(248, 250, 252, 0.95);
+    border: 1px solid rgba(148, 163, 184, 0.32);
+  }
+  .hero-actions {
+    gap: 8px;
+  }
+  .hero-quick-link {
+    padding: 8px 12px;
+    font-size: 13px;
+    border-radius: 10px;
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.14);
+  }
+  .hero-quick-link svg {
+    width: 14px;
+    height: 14px;
+  }
 }
 
 /* Tags */
@@ -1189,36 +1230,6 @@ button.hero-quick-link {
 .link-accent { color: var(--accent); }
 
 /* Afbeeldingen */
-.hero {
-  position: relative;
-  width: 100%;
-  --hero-aspect: 4 / 3;
-  aspect-ratio: var(--hero-aspect);
-  border-radius: 16px;
-  overflow: hidden;
-  margin: 12px 0 16px;
-  background: var(--surface);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.hero:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 18px 36px rgba(15,23,42,0.14);
-}
-
-@media (min-width: 768px) {
-  .hero {
-    --hero-aspect: 16 / 9;
-  }
-}
-
-.hero img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
-
 .image-credit {
   margin: 10px 20px 0;
   padding: 0;


### PR DESCRIPTION
## Summary
- delete an outdated hero selector that reapplied a fixed aspect ratio and cropped the homepage hero content on small screens
- tighten the hero search panel on phones by reducing padding, gaps, and control surface sizes so it sits more comfortably on small viewports

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68ce6925e08c8326bc009c4c8054f636