### PR TITLE
Update site branding with new Museum Buddy logo

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Image from 'next/image';
 import { useLanguage } from './LanguageContext';
 
 export default function Footer() {
@@ -7,11 +8,17 @@ export default function Footer() {
     <footer className="footer">
       <div className="container footer-inner">
         <div className="footer-brand">
-          <Link href="/" className="brand-square footer-logo" aria-label={t('homeLabel')}>
-            <span className="brand-letter">MB</span>
+          <Link href="/" className="brand-logo footer-logo" aria-label={t('homeLabel')}>
+            <Image
+              src="/logo.svg"
+              alt="Museum Buddy"
+              width={180}
+              height={52}
+              className="brand-logo-image"
+            />
           </Link>
           <div className="footer-claim">
-            <span className="footer-title">MuseumBuddy</span>
+            <span className="footer-title">Museum Buddy</span>
             <span className="footer-tagline">{t('heroTagline')}</span>
             <p className="footer-claim-text">{t('heroSubtitle')}</p>
           </div>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import Head from 'next/head';
+import Image from 'next/image';
 import { useFavorites } from './FavoritesContext';
 import { useLanguage } from './LanguageContext';
 import { useTheme } from './ThemeContext';
@@ -26,11 +27,18 @@ export default function Layout({ children }) {
       <header className="header">
         <nav className="navbar container">
           <div className="brand-wrap header-brand">
-            <Link href="/" className="brand-square" aria-label={t('homeLabel')}>
-              <span className="brand-letter">MB</span>
+            <Link href="/" className="brand-logo" aria-label={t('homeLabel')}>
+              <Image
+                src="/logo.svg"
+                alt="Museum Buddy"
+                width={180}
+                height={52}
+                priority
+                className="brand-logo-image"
+              />
             </Link>
             <div className="brand-wordmark">
-              <span className="brand-title">MuseumBuddy</span>
+              <span className="brand-title">Museum Buddy</span>
               <span className="brand-tagline">{t('heroTagline')}</span>
             </div>
           </div>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,4 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" fill="#000"/>
-  <text x="50%" y="52%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="700" fill="#fff">MB</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 120" role="img" aria-labelledby="logo-title">
+  <title id="logo-title">Museum Buddy</title>
+  <g fill="#0f3d33">
+    <rect x="0" y="16" width="68" height="88" rx="14" />
+    <rect x="84" y="16" width="68" height="88" rx="14" />
+    <rect x="168" y="16" width="32" height="88" rx="14" />
+    <rect x="208" y="16" width="48" height="40" rx="14" />
+    <rect x="208" y="64" width="48" height="40" rx="14" />
+  </g>
+  <g fill="#0f3d33" font-family="'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif" font-weight="600" letter-spacing="0.02em">
+    <text x="280" y="56" font-size="36">Museum</text>
+    <text x="280" y="96" font-size="36">Buddy</text>
+  </g>
 </svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -256,21 +256,18 @@ img { max-width: 100%; height: auto; display: block; }
   border: 1px solid var(--panel-border);
   box-shadow: var(--panel-shadow);
 }
-.brand-square {
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  width:52px;
-  height:52px;
-  border-radius:14px;
-  background:var(--accent);
-  color:var(--accent-ink);
-  font-weight:700;
-  letter-spacing:0.08em;
-  text-transform:uppercase;
-  font-size:16px;
+.brand-logo {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 0;
 }
-.brand-letter { line-height:1; }
+
+.brand-logo-image {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-width: 180px;
+}
 .brand-wordmark { display:flex; flex-direction:column; gap:4px; }
 .brand-title { font-weight:700; font-size:22px; letter-spacing:-0.01em; }
 .brand-tagline {


### PR DESCRIPTION
## Summary
- replace the square MB placeholder with the new Museum Buddy logo in the header and footer
- refresh branding copy and styles so the wider wordmark fits the existing layout
- add an accessible SVG version of the new Museum Buddy logo to `public/logo.svg`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce77bc9a888326822e01667400db04