### PR TITLE
Streamline Museum Buddy header iconography

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Image from 'next/image';
 import { useLanguage } from './LanguageContext';
 
 export default function Footer() {
@@ -7,11 +8,17 @@ export default function Footer() {
     <footer className="footer">
       <div className="container footer-inner">
         <div className="footer-brand">
-          <Link href="/" className="brand-square footer-logo" aria-label={t('homeLabel')}>
-            <span className="brand-letter">MB</span>
+          <Link href="/" className="brand-logo footer-logo" aria-label={t('homeLabel')}>
+            <Image
+              src="/logo.svg"
+              alt="Museum Buddy"
+              width={96}
+              height={96}
+              className="brand-logo-image"
+            />
           </Link>
           <div className="footer-claim">
-            <span className="footer-title">MuseumBuddy</span>
+            <span className="footer-title">Museum Buddy</span>
             <span className="footer-tagline">{t('heroTagline')}</span>
             <p className="footer-claim-text">{t('heroSubtitle')}</p>
           </div>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import Head from 'next/head';
+import Image from 'next/image';
 import { useFavorites } from './FavoritesContext';
 import { useLanguage } from './LanguageContext';
 import { useTheme } from './ThemeContext';
@@ -26,13 +27,16 @@ export default function Layout({ children }) {
       <header className="header">
         <nav className="navbar container">
           <div className="brand-wrap header-brand">
-            <Link href="/" className="brand-square" aria-label={t('homeLabel')}>
-              <span className="brand-letter">MB</span>
+            <Link href="/" className="brand-logo" aria-label={t('homeLabel')}>
+              <Image
+                src="/logo.svg"
+                alt="Museum Buddy"
+                width={72}
+                height={72}
+                priority
+                className="brand-logo-image"
+              />
             </Link>
-            <div className="brand-wordmark">
-              <span className="brand-title">MuseumBuddy</span>
-              <span className="brand-tagline">{t('heroTagline')}</span>
-            </div>
           </div>
           <div className="navspacer" />
           <div className="header-actions">

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,4 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" fill="#000"/>
-  <text x="50%" y="52%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="700" fill="#fff">MB</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="logo-title">
+  <title id="logo-title">Museum Buddy</title>
+  <g fill="#0f3d33">
+    <path d="M48 8 10 30h76Z" />
+    <rect x="18" y="36" width="12" height="38" rx="4" />
+    <rect x="42" y="36" width="12" height="38" rx="4" />
+    <rect x="66" y="36" width="12" height="38" rx="4" />
+    <rect x="16" y="78" width="64" height="10" rx="4" />
+  </g>
 </svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -248,86 +248,74 @@ img { max-width: 100%; height: auto; display: block; }
 }
 
 /* Header brand */
-.brand-wrap { display:flex; align-items:center; gap:12px; }
+.brand-wrap { display:flex; align-items:center; }
 .header-brand {
-  padding: 10px 16px;
+  padding: 6px 10px;
   background: var(--surface);
-  border-radius: 18px;
+  border-radius: 12px;
   border: 1px solid var(--panel-border);
-  box-shadow: var(--panel-shadow);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.16);
 }
-.brand-square {
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  width:52px;
-  height:52px;
-  border-radius:14px;
-  background:var(--accent);
-  color:var(--accent-ink);
-  font-weight:700;
-  letter-spacing:0.08em;
-  text-transform:uppercase;
-  font-size:16px;
-}
-.brand-letter { line-height:1; }
-.brand-wordmark { display:flex; flex-direction:column; gap:4px; }
-.brand-title { font-weight:700; font-size:22px; letter-spacing:-0.01em; }
-.brand-tagline {
-  font-size:0.75rem;
-  font-weight:600;
-  letter-spacing:0.24em;
-  text-transform:uppercase;
-  color:var(--muted);
+.brand-logo {
+  display: inline-flex;
+  align-items: center;
 }
 
+.brand-logo-image {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+.header-brand .brand-logo-image { max-width: 72px; }
+.footer-logo .brand-logo-image { max-width: 88px; }
+
 /* Header actions */
-.header-actions { display:flex; align-items:center; gap:14px; }
+.header-actions { display:flex; align-items:center; gap:12px; }
 .lang-select,
 .contrast-toggle {
   display:flex;
   align-items:center;
-  gap:4px;
+  gap:3px;
   background:none;
   border:none;
-  font-size:14px;
+  font-size:13px;
   cursor:pointer;
   color: var(--text);
 }
-.lang-select svg { width:12px; height:8px; }
-.contrast-toggle svg { width:20px; height:20px; }
+.lang-select svg { width:10px; height:6px; }
+.contrast-toggle svg { width:18px; height:18px; }
 .filters-trigger {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 18px;
-  border-radius: 999px;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 12px;
   border: none;
   background: var(--accent);
   color: var(--accent-ink);
   font-weight: 600;
-  font-size: 14px;
+  font-size: 13px;
   cursor: pointer;
-  box-shadow: 0 14px 28px rgba(255, 90, 60, 0.28);
+  box-shadow: 0 12px 26px rgba(255, 90, 60, 0.24);
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
-.filters-trigger svg { width: 18px; height: 18px; }
-.filters-trigger:hover { transform: translateY(-1px); box-shadow: 0 18px 32px rgba(255, 90, 60, 0.34); }
+.filters-trigger svg { width: 16px; height: 16px; }
+.filters-trigger:hover { transform: translateY(-1px); box-shadow: 0 16px 30px rgba(255, 90, 60, 0.3); }
 .filters-trigger:focus-visible { outline: 2px solid var(--accent-ink); outline-offset: 3px; }
 .filters-trigger span { white-space: nowrap; }
 .header-icon {
   background:none;
   border:none;
   padding:0;
-  width:32px;
-  height:32px;
+  width:28px;
+  height:28px;
   display:flex;
   align-items:center;
   justify-content:center;
   cursor:pointer;
   position:relative;
 }
-.header-icon svg { width:20px; height:20px; }
+.header-icon svg { width:18px; height:18px; }
 .header-icon .favorite-count {
   position:absolute;
   top:-4px;
@@ -335,9 +323,9 @@ img { max-width: 100%; height: auto; display: block; }
   background:var(--accent);
   color:var(--accent-ink);
   border-radius:9999px;
-  min-width:16px;
-  height:16px;
-  font-size:12px;
+  min-width:14px;
+  height:14px;
+  font-size:11px;
   display:flex;
   align-items:center;
   justify-content:center;
@@ -346,11 +334,9 @@ img { max-width: 100%; height: auto; display: block; }
 
 @media (max-width: 600px) {
   .header-brand {
-    padding: 8px 12px;
-    flex: 1 1 100%;
+    padding: 6px 10px;
+    flex: 0 0 auto;
   }
-  .brand-title { font-size: 20px; }
-  .brand-tagline { display: none; }
   .navbar {
     padding: 16px 12px;
     gap: 12px;


### PR DESCRIPTION
## Summary
- remove the text wordmark in the header and resize the logo asset for a compact fit
- shrink action icons, language/contrast toggles, and filter button styling to reduce visual weight
- replace the logo SVG with a simplified, text-free emblem and adjust footer sizing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce77bc9a888326822e01667400db04