### PR TITLE
Update branding to new Museum Buddy logo

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Image from 'next/image';
 import { useLanguage } from './LanguageContext';
 
 export default function Footer() {
@@ -7,8 +8,8 @@ export default function Footer() {
     <footer className="footer">
       <div className="container footer-inner">
         <div className="footer-brand">
-          <Link href="/" className="brand-square footer-logo" aria-label={t('homeLabel')}>
-            <span className="brand-letter">MB</span>
+          <Link href="/" className="brand-logo footer-logo" aria-label={t('homeLabel')}>
+            <Image src="/logo.svg" alt="Museum Buddy" width={208} height={70} />
           </Link>
           <div className="footer-claim">
             <span className="footer-title">MuseumBuddy</span>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Image from 'next/image';
 import Head from 'next/head';
 import { useFavorites } from './FavoritesContext';
 import { useLanguage } from './LanguageContext';
@@ -26,11 +27,17 @@ export default function Layout({ children }) {
       <header className="header">
         <nav className="navbar container">
           <div className="brand-wrap header-brand">
-            <Link href="/" className="brand-square" aria-label={t('homeLabel')}>
-              <span className="brand-letter">MB</span>
+            <Link href="/" className="brand-logo" aria-label={t('homeLabel')}>
+              <Image
+                src="/logo.svg"
+                alt="Museum Buddy"
+                width={188}
+                height={64}
+                priority
+              />
             </Link>
             <div className="brand-wordmark">
-              <span className="brand-title">MuseumBuddy</span>
+              <span className="brand-title sr-only">MuseumBuddy</span>
               <span className="brand-tagline">{t('heroTagline')}</span>
             </div>
           </div>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,4 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" fill="#000"/>
-  <text x="50%" y="52%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="700" fill="#fff">MB</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 120" role="img" aria-labelledby="logoTitle logoDesc">
+  <title id="logoTitle">Museum Buddy logo</title>
+  <desc id="logoDesc">Three bold green pillars forming the initials MB with the words Museum Buddy set in two lines.</desc>
+  <g fill="#123B32">
+    <rect x="0" y="18" width="56" height="84" rx="10" />
+    <rect x="72" y="18" width="56" height="84" rx="10" />
+    <rect x="144" y="18" width="24" height="84" rx="10" />
+    <rect x="144" y="18" width="56" height="38" rx="10" />
+    <rect x="144" y="64" width="56" height="38" rx="10" />
+  </g>
+  <g fill="#123B32" font-family="'Manrope', 'Helvetica Neue', Arial, sans-serif" font-weight="600" letter-spacing="0.02em">
+    <text x="228" y="58" font-size="40">Museum</text>
+    <text x="228" y="100" font-size="40">Buddy</text>
+  </g>
 </svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -127,6 +127,18 @@ ol {
 a { color: inherit; text-decoration: none; }
 img { max-width: 100%; height: auto; display: block; }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Layout */
 .container { max-width: 1120px; margin: 0 auto; padding: 24px; }
 .header {
@@ -256,21 +268,17 @@ img { max-width: 100%; height: auto; display: block; }
   border: 1px solid var(--panel-border);
   box-shadow: var(--panel-shadow);
 }
-.brand-square {
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  width:52px;
-  height:52px;
-  border-radius:14px;
-  background:var(--accent);
-  color:var(--accent-ink);
-  font-weight:700;
-  letter-spacing:0.08em;
-  text-transform:uppercase;
-  font-size:16px;
+.brand-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+  flex-shrink: 0;
 }
-.brand-letter { line-height:1; }
+.brand-logo img {
+  display: block;
+  height: auto;
+}
 .brand-wordmark { display:flex; flex-direction:column; gap:4px; }
 .brand-title { font-weight:700; font-size:22px; letter-spacing:-0.01em; }
 .brand-tagline {


### PR DESCRIPTION
## Summary
- replace the header and footer brand mark with the supplied Museum Buddy logo asset
- refresh the shared logo SVG to match the new branding and add hidden-text utility styling
- keep existing tagline copy while ensuring the new image is accessible via Next.js `Image`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce7eb786b88326b7735205caeb9d93