### PR TITLE
Add new Museum Buddy logo

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Image from 'next/image';
 import { useLanguage } from './LanguageContext';
 
 export default function Footer() {
@@ -7,8 +8,14 @@ export default function Footer() {
     <footer className="footer">
       <div className="container footer-inner">
         <div className="footer-brand">
-          <Link href="/" className="brand-square footer-logo" aria-label={t('homeLabel')}>
-            <span className="brand-letter">MB</span>
+          <Link href="/" className="brand-logo footer-logo" aria-label={t('homeLabel')}>
+            <Image
+              src="/logo.svg"
+              alt="Museum Buddy logo"
+              width={184}
+              height={70}
+              className="brand-logo-image"
+            />
           </Link>
           <div className="footer-claim">
             <span className="footer-title">MuseumBuddy</span>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Image from 'next/image';
 import Head from 'next/head';
 import { useFavorites } from './FavoritesContext';
 import { useLanguage } from './LanguageContext';
@@ -26,13 +27,17 @@ export default function Layout({ children }) {
       <header className="header">
         <nav className="navbar container">
           <div className="brand-wrap header-brand">
-            <Link href="/" className="brand-square" aria-label={t('homeLabel')}>
-              <span className="brand-letter">MB</span>
+            <Link href="/" className="brand-logo" aria-label={t('homeLabel')}>
+              <Image
+                src="/logo.svg"
+                alt="Museum Buddy logo"
+                width={168}
+                height={64}
+                priority
+                className="brand-logo-image"
+              />
             </Link>
-            <div className="brand-wordmark">
-              <span className="brand-title">MuseumBuddy</span>
-              <span className="brand-tagline">{t('heroTagline')}</span>
-            </div>
+            <span className="brand-tagline">{t('heroTagline')}</span>
           </div>
           <div className="navspacer" />
           <div className="header-actions">

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,4 +1,23 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" fill="#000"/>
-  <text x="50%" y="52%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="700" fill="#fff">MB</text>
+<svg width="420" height="160" viewBox="0 0 420 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="logo-bg" x1="210" y1="0" x2="210" y2="160" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1d3d40" />
+      <stop offset="1" stop-color="#0d1f21" />
+    </linearGradient>
+    <linearGradient id="logo-highlight" x1="92" y1="24" x2="92" y2="136" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#3cf5df" />
+      <stop offset="1" stop-color="#24cbb6" />
+    </linearGradient>
+  </defs>
+  <rect width="420" height="160" rx="36" fill="url(#logo-bg)" />
+  <g transform="translate(52 24)">
+    <rect x="0" y="0" width="60" height="112" rx="22" fill="url(#logo-highlight)" />
+    <rect x="18" y="20" width="24" height="72" rx="12" fill="#143636" opacity="0.35" />
+    <path d="M92 0h44c34 0 54 18 54 46 0 18-9.6 32-26.2 39.4C183.6 92.4 194 108.6 194 130c0 30.6-21.4 50-56 50H92V0Z" fill="url(#logo-highlight)" transform="translate(-4 -8) scale(.82)" />
+    <path d="M108 20h28c16 0 26 7.8 26 21.2 0 10.8-6 18.2-15.8 20.8 12.4 2.6 20.4 12.4 20.4 25 0 17-12.4 27-32.6 27H108V20Z" fill="url(#logo-highlight)" opacity="0.55" transform="translate(18 0)" />
+    <path d="M112 24h18c12 0 19 6 19 16 0 8.8-6.2 14.4-16.4 14.4H112V24Z" fill="#112729" />
+    <path d="M112 64h20c13.2 0 21.4 6.8 21.4 18.2 0 11.8-8.6 18.6-22.2 18.6H112V64Z" fill="#112729" />
+  </g>
+  <text x="200" y="76" fill="#d5f7f1" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-weight="600" font-size="40" letter-spacing="0.04em">Museum</text>
+  <text x="200" y="122" fill="#9eeae0" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-weight="700" font-size="44" letter-spacing="0.02em">Buddy</text>
 </svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -164,6 +164,9 @@ img { max-width: 100%; height: auto; display: block; }
 .footer-logo {
   box-shadow: none;
 }
+.footer-logo .brand-logo-image {
+  box-shadow: none;
+}
 
 .footer-claim {
   display: flex;
@@ -256,23 +259,17 @@ img { max-width: 100%; height: auto; display: block; }
   border: 1px solid var(--panel-border);
   box-shadow: var(--panel-shadow);
 }
-.brand-square {
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  width:52px;
-  height:52px;
-  border-radius:14px;
-  background:var(--accent);
-  color:var(--accent-ink);
-  font-weight:700;
-  letter-spacing:0.08em;
-  text-transform:uppercase;
-  font-size:16px;
+.brand-logo {
+  display:inline-flex;
+  line-height:0;
 }
-.brand-letter { line-height:1; }
-.brand-wordmark { display:flex; flex-direction:column; gap:4px; }
-.brand-title { font-weight:700; font-size:22px; letter-spacing:-0.01em; }
+.brand-logo-image {
+  display:block;
+  width:100%;
+  height:auto;
+  border-radius:18px;
+  box-shadow:0 20px 48px rgba(9, 28, 30, 0.35);
+}
 .brand-tagline {
   font-size:0.75rem;
   font-weight:600;
@@ -349,7 +346,6 @@ img { max-width: 100%; height: auto; display: block; }
     padding: 8px 12px;
     flex: 1 1 100%;
   }
-  .brand-title { font-size: 20px; }
   .brand-tagline { display: none; }
   .navbar {
     padding: 16px 12px;


### PR DESCRIPTION
## Summary
- replace the header and footer brand link with the new Museum Buddy logo asset
- refresh global styles to support the inline logo image and adjust the footer styling to avoid duplicate shadows
- redraw the public logo SVG to match the new brand artwork

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ce830cec988326b1fc401b03ddcd6d