### PR TITLE
Fix museum detail image credit markup

### DIFF
--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -469,24 +469,25 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
 
               {(heroImage || imageCredit) && (
                 <div className="museum-info-credit">
-                  <span className="museum-info-credit-label">{t('imageCreditLabel')}:</span>{' '}
-                  {imageCredit ? (
-                    <>
-                      {imageCredit.author || t('unknown')}
-                      {imageCredit.license ? `, ${imageCredit.license}` : ''}
-                      {imageCredit.source && (
-                        <>
-                          {' '}
-                          {t('via')}{' '}
-                          <a href={imageCredit.url} target="_blank" rel="noreferrer">
-                            {imageCredit.source}
-                          </a>
-                        </>
-                      )}
-                    </>
-                  ) : (
-                    t('unknown')
-                  )}
+                  <span className="museum-info-credit-label">{t('imageCreditLabel')}:</span>
+                  <span className="museum-info-credit-value">
+                    {imageCredit ? (
+                      <span className="museum-info-credit-content">
+                        <span>{imageCredit.author || t('unknown')}</span>
+                        {imageCredit.license && <span>, {imageCredit.license}</span>}
+                        {imageCredit.source && (
+                          <span className="museum-info-credit-source">
+                            {t('via')}
+                            <a href={imageCredit.url} target="_blank" rel="noreferrer">
+                              {imageCredit.source}
+                            </a>
+                          </span>
+                        )}
+                      </span>
+                    ) : (
+                      t('unknown')
+                    )}
+                  </span>
                 </div>
               )}
             </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1116,6 +1116,10 @@ button.hero-quick-link {
 .museum-info-credit { margin: 12px 0 0; font-size: 12px; color: rgba(0,0,0,0.6); line-height: 1.5; }
 [data-theme='dark'] .museum-info-credit { color: rgba(226,232,240,0.7); }
 .museum-info-credit-label { font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; }
+.museum-info-credit-value { margin-left: 4px; display: inline-flex; flex-wrap: wrap; gap: 4px; }
+.museum-info-credit-content { display: inline-flex; flex-wrap: wrap; gap: 4px; }
+.museum-info-credit-content > span:first-child { margin-left: 0; }
+.museum-info-credit-source { display: inline-flex; align-items: center; gap: 4px; }
 .museum-info-credit a { color: inherit; text-decoration: underline; }
 
 @media (max-width: 1200px) {


### PR DESCRIPTION
## Summary
- restructure the museum detail image credit JSX to avoid ambiguous fragments
- add styles for the updated image credit structure to preserve spacing and layout

## Testing
- npm run build *(fails: Next.js cannot download Google Fonts in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d03af49f188326a86b2733f580db6d