### PR TITLE
Update typography and accent styling

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,12 +1,12 @@
 import { useEffect } from 'react';
-import { Inter, Montserrat } from 'next/font/google';
+import { Inter, Manrope } from 'next/font/google';
 import '../styles/globals.css';
 import Layout from '../components/Layout';
 import { FavoritesProvider } from '../components/FavoritesContext';
 import { LanguageProvider } from '../components/LanguageContext';
 import { ThemeProvider } from '../components/ThemeContext';
 
-const titleFont = Montserrat({
+const titleFont = Manrope({
   subsets: ['latin'],
   weight: ['400', '500', '600', '700'],
   display: 'swap',

--- a/public/images/exposition-placeholder.svg
+++ b/public/images/exposition-placeholder.svg
@@ -8,8 +8,8 @@
       <stop offset="100%" stop-color="#cbd5f5" />
     </linearGradient>
     <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#ff784f" stop-opacity="0.9" />
-      <stop offset="100%" stop-color="#ff5a3c" stop-opacity="0.95" />
+      <stop offset="0%" stop-color="#2563eb" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#1d4ed8" stop-opacity="0.95" />
     </linearGradient>
   </defs>
   <rect width="800" height="560" fill="url(#bg)" rx="36" />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,10 +1,10 @@
 :root{
   --bg:#f8f9fb;
   --body-bg:#eef1f6;
-  --text:#1f2937;
-  --muted:#667085;
+  --text:#111827;
+  --muted:#4b5563;
   --border:#d9dde3;
-  --accent:#ff5a3c;
+  --accent:#2563eb;
   --accent-ink:#ffffff;
   --surface:#ffffff;
   --panel-bg:rgba(255,255,255,0.95);
@@ -41,7 +41,7 @@
   --text:#e2e8f0;
   --muted:#94a3b8;
   --border:#1f2937;
-  --accent:#ff784f;
+  --accent:#f97316;
   --accent-ink:#0b1220;
   --surface:#1f2937;
   --panel-bg:rgba(15,23,42,0.92);
@@ -72,8 +72,8 @@ body {
   font-family: var(--font-body), system-ui, -apple-system, "Segoe UI", Ubuntu, Cantarell, "Noto Sans", "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
   font-weight: 400;
   font-size: 16px;
-  line-height: 1.75;
-  letter-spacing: 0.01em;
+  line-height: 1.5;
+  letter-spacing: 0.005em;
 }
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--font-title), var(--font-body), system-ui, -apple-system, "Segoe UI", sans-serif;
@@ -83,40 +83,45 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 h1 {
-  font-size: clamp(2.75rem, 1.6vw + 2.3rem, 3.5rem);
-  line-height: 1.1;
+  font-size: 2.25rem;
+  line-height: 2.75rem;
   letter-spacing: -0.02em;
   margin-top: 0.5em;
 }
 
 h2 {
-  font-size: clamp(2.1rem, 1.2vw + 1.7rem, 2.8rem);
-  line-height: 1.18;
-  letter-spacing: -0.015em;
-}
-
-h3 {
-  font-size: clamp(1.65rem, 1vw + 1.3rem, 2.2rem);
-  line-height: 1.22;
+  font-size: 1.5rem;
+  line-height: 2rem;
   letter-spacing: -0.01em;
 }
 
+h3 {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+  letter-spacing: -0.008em;
+}
+
 h4 {
-  font-size: 1.5rem;
-  line-height: 1.3;
-  letter-spacing: -0.005em;
+  font-size: 1.125rem;
+  line-height: 1.625rem;
+  letter-spacing: -0.004em;
 }
 
 h5 {
-  font-size: 1.25rem;
-  line-height: 1.35;
+  font-size: 1rem;
+  line-height: 1.5rem;
 }
 
 h6 {
-  font-size: 1.125rem;
-  line-height: 1.4;
-  letter-spacing: 0.02em;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+small {
+  font-size: 0.875rem;
+  line-height: 1.4285;
 }
 
 p {
@@ -330,11 +335,11 @@ img { max-width: 100%; height: auto; display: block; }
   font-weight: 600;
   font-size: 14px;
   cursor: pointer;
-  box-shadow: 0 14px 28px rgba(255, 90, 60, 0.28);
+  box-shadow: 0 14px 28px rgba(37, 99, 235, 0.28);
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 .filters-trigger svg { width: 18px; height: 18px; }
-.filters-trigger:hover { transform: translateY(-1px); box-shadow: 0 18px 32px rgba(255, 90, 60, 0.34); }
+.filters-trigger:hover { transform: translateY(-1px); box-shadow: 0 18px 32px rgba(37, 99, 235, 0.34); }
 .filters-trigger:focus-visible { outline: 2px solid var(--accent-ink); outline-offset: 3px; }
 .filters-trigger span { white-space: nowrap; }
 .header-icon {
@@ -764,11 +769,11 @@ button.hero-quick-link {
   background: var(--accent);
   color: var(--accent-ink);
   border-color: transparent;
-  box-shadow: 0 16px 28px rgba(255, 90, 60, 0.3);
+  box-shadow: 0 16px 28px rgba(37, 99, 235, 0.3);
 }
 .filters-sheet__apply:hover {
   transform: translateY(-1px);
-  box-shadow: 0 22px 34px rgba(255, 90, 60, 0.36);
+  box-shadow: 0 22px 34px rgba(37, 99, 235, 0.36);
 }
 
 @media (max-width: 720px) {
@@ -1127,14 +1132,14 @@ button.hero-quick-link {
 .museum-tab:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
-  box-shadow: 0 14px 26px rgba(255, 90, 60, 0.22);
+  box-shadow: 0 14px 26px rgba(37, 99, 235, 0.22);
 }
 .museum-tab.is-active,
 .museum-tab[aria-selected='true'] {
   background: var(--accent);
   color: var(--accent-ink);
   border-color: transparent;
-  box-shadow: 0 14px 30px rgba(255, 90, 60, 0.28);
+  box-shadow: 0 14px 30px rgba(37, 99, 235, 0.28);
 }
 [data-theme='dark'] .museum-tab {
   background: rgba(15, 23, 42, 0.7);
@@ -1147,7 +1152,7 @@ button.hero-quick-link {
 [data-theme='dark'] .museum-tab.is-active,
 [data-theme='dark'] .museum-tab[aria-selected='true'] {
   color: var(--accent-ink);
-  box-shadow: 0 18px 32px rgba(255, 120, 79, 0.34);
+  box-shadow: 0 18px 32px rgba(249, 115, 22, 0.34);
 }
 .museum-tabpanel {
   display: block;


### PR DESCRIPTION
## Summary
- swap the Montserrat title font for Manrope while keeping the existing CSS custom properties intact
- recalibrate the global typography scale, default body color, and accent palette to meet the requested sizing and contrast targets
- update accent-driven shadows and the placeholder illustration gradient so CTA components use the refreshed brand color

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d04cb98e788326a1507aea56b0290f