### PR TITLE
Use local map photos for Moco and Micropia

### DIFF
--- a/lib/museumImages.js
+++ b/lib/museumImages.js
@@ -12,10 +12,8 @@ const museumImages = {
   'huis-marseille-amsterdam': '/images/Huis Marseille_Hans Luthart.jpg',
   'joods-museum-amsterdam': '/images/Joods Historisch Museum_Michele Ahin.jpg',
   'kattenkabinet-amsterdam': '/images/KattenKabinet_Taylor Dahlin.jpg',
-  'micropia-museum-amsterdam':
-    'https://upload.wikimedia.org/wikipedia/commons/b/b9/Micropia_Museum_Amsterdam_5.jpg',
-  'moco-museum-amsterdam':
-    'https://upload.wikimedia.org/wikipedia/commons/e/e1/Moco_Museum_Amsterdam_THEONE.jpg',
+  'micropia-museum-amsterdam': '/images/micropia-museum-amsterdam.jpg',
+  'moco-museum-amsterdam': '/images/moco-museum-amsterdam.jpg',
   'museum-van-loon-amsterdam': '/images/Van Loon_ Willem van Valkenburg.jpg',
   'nemo-science-museum-amsterdam': '/images/NEMO_Randy Connolly.jpg',
   'nxt-museum-amsterdam': '/images/Nxt Museum_Rob Oo.jpg',


### PR DESCRIPTION
## Summary
- update the museum image mapping to point Moco and Micropia to bundled local photos so they appear on the map

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d14fef42e083269de7fc0af3ba6d63