### PR TITLE
Show Anne Frank museum image credit

### DIFF
--- a/lib/museumImageCredits.js
+++ b/lib/museumImageCredits.js
@@ -32,7 +32,6 @@ const museumImageCredits = {
     author: 'Photo Collection Anne Frank House',
     license: 'Public Domain Mark',
     source: 'Anne Frank House',
-    isPublicDomain: true,
   },
   'body-worlds-amsterdam': {
     prefix: 'Fotocredit',


### PR DESCRIPTION
## Summary
- ensure the Anne Frank museum image displays its photo credit information instead of being suppressed for public domain images

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d155136d508326af0fb24e5463d9bd