### PR TITLE
Improve mobile layout responsiveness

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -174,7 +174,11 @@ img { max-width: 100%; height: auto; display: block; }
 .spacing-pad-block-16 { padding-block: var(--space-16); }
 
 /* Layout */
-.container { max-width: 1120px; margin: 0 auto; padding: 24px; }
+.container {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: clamp(16px, 5vw, 24px);
+}
 .header {
   position: sticky; top: 0; z-index: 20;
   background: var(--bg);
@@ -270,6 +274,37 @@ img { max-width: 100%; height: auto; display: block; }
   margin: 0;
   font-size: 0.85rem;
   line-height: 1.7;
+}
+
+@media (max-width: 600px) {
+  .footer-inner {
+    align-items: center;
+    text-align: center;
+    gap: 24px;
+    padding: 32px 0;
+  }
+
+  .footer-brand {
+    align-items: center;
+    text-align: center;
+  }
+
+  .footer-claim-text {
+    max-width: none;
+  }
+
+  .footer-meta {
+    align-items: center;
+    text-align: center;
+  }
+
+  .footer-links {
+    justify-content: center;
+  }
+
+  .footer-smallprint {
+    max-width: none;
+  }
 }
 
 @media (min-width: 768px) {
@@ -398,23 +433,72 @@ img { max-width: 100%; height: auto; display: block; }
   .brand-title { font-size: 20px; }
   .brand-tagline { display: none; }
   .navbar {
-    padding: 16px 12px;
+    padding: clamp(12px, 3.5vw, 16px) clamp(16px, 5vw, 18px);
     gap: 12px;
     flex-wrap: wrap;
   }
   .navspacer { display: none; }
   .header-actions {
-    gap: 8px;
     width: 100%;
-    justify-content: space-between;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 12px;
+    align-items: stretch;
   }
-  .header-actions > * { flex: 0 0 auto; }
+  .header-actions > * {
+    width: 100%;
+  }
+  .filters-trigger {
+    grid-column: 1 / -1;
+    width: 100%;
+    justify-content: center;
+    padding: 12px;
+    font-size: 15px;
+  }
+  .filters-trigger span {
+    display: inline;
+  }
+  .filters-trigger svg {
+    width: 20px;
+    height: 20px;
+  }
+  .lang-select,
+  .contrast-toggle,
+  .header-icon {
+    justify-content: center;
+    border-radius: 14px;
+    padding: 10px 12px;
+    background: var(--surface);
+    border: 1px solid var(--panel-border);
+    box-shadow: var(--panel-shadow);
+    min-height: 44px;
+  }
+  .lang-select,
+  .contrast-toggle {
+    gap: 6px;
+    font-size: 0.9rem;
+  }
+  .lang-select svg {
+    width: 14px;
+    height: 8px;
+  }
+  .header-icon {
+    height: 44px;
+    width: 100%;
+  }
+  .header-icon svg,
+  .contrast-toggle svg {
+    width: 20px;
+    height: 20px;
+  }
+  .header-icon .favorite-count {
+    top: 6px;
+    right: 10px;
+  }
   .header {
     backdrop-filter: none;
     background: var(--bg);
   }
-  .filters-trigger span { display: none; }
 }
 
 @media (max-width: 420px) {
@@ -855,6 +939,19 @@ button.hero-quick-link {
   .hero { gap: var(--space-24); padding: var(--space-24); border-radius: var(--radius-md); }
   .hero::before { background-position: center 46%; }
   .hero-card { padding: var(--space-16); }
+  .hero-content {
+    align-items: center;
+    text-align: center;
+  }
+  .hero-actions {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .hero-quick-link {
+    width: 100%;
+    justify-content: center;
+  }
 }
 
 @media (max-width: 480px) {
@@ -1662,6 +1759,12 @@ button.hero-quick-link {
 /* Footer space */
 .section { margin: 24px 0; }
 .count { color: var(--muted); margin: 8px 0 16px; }
+
+@media (max-width: 600px) {
+  .count {
+    text-align: center;
+  }
+}
 .link-accent { color: var(--accent); }
 
 /* Afbeeldingen */


### PR DESCRIPTION
## Summary
- use fluid container padding to give the layout more room on narrow screens
- restyle the header action area on small viewports so the filter button spans the row and icons become touch-friendly tiles
- stack the hero quick actions and center hero text, and tidy up footer/count alignment for phones

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@capacitor%2Fapp)*

------
https://chatgpt.com/codex/tasks/task_e_68d160188cc88326a0e1eb598a7c00bc