### PR TITLE
Improve MuseumCard mobile layout

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -86,6 +86,78 @@ export default function MuseumCard({ museum }) {
     triggerFavoriteBounce();
   };
 
+  const renderShareButton = (className = '') => (
+    <button
+      type="button"
+      className={`icon-button${className ? ` ${className}` : ''}`}
+      aria-label={t('share')}
+      onClick={shareMuseum}
+    >
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7" />
+        <path d="M16 6l-4-4-4 4" />
+        <path d="M12 2v14" />
+      </svg>
+    </button>
+  );
+
+  const renderFavoriteButton = (className = '') => (
+    <button
+      type="button"
+      className={`icon-button${isFavorite ? ' favorited' : ''}${
+        isFavoriteBouncing ? ' icon-button--bounce' : ''
+      }${className ? ` ${className}` : ''}`}
+      aria-label={t('save')}
+      aria-pressed={isFavorite}
+      onClick={handleFavorite}
+    >
+      <svg
+        viewBox="0 0 24 24"
+        fill={isFavorite ? 'currentColor' : 'none'}
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M21 8.25c0 4.556-9 11.25-9 11.25S3 12.806 3 8.25a5.25 5.25 0 0 1 9-3.676A5.25 5.25 0 0 1 21 8.25Z" />
+      </svg>
+    </button>
+  );
+
+  const renderTicketButton = (className = '') => {
+    const classNames = `ticket-button${className ? ` ${className}` : ''}`;
+
+    if (museum.ticketUrl) {
+      return (
+        <a
+          href={museum.ticketUrl}
+          target="_blank"
+          rel="noreferrer"
+          className={classNames}
+          title={ticketHoverMessage}
+        >
+          <span className="ticket-button__label">{t('buyTickets')}</span>
+          <TicketButtonNote affiliate={showAffiliateNote}>{ticketContext}</TicketButtonNote>
+        </a>
+      );
+    }
+
+    return (
+      <button type="button" className={classNames} disabled aria-disabled="true">
+        <span className="ticket-button__label">{t('buyTickets')}</span>
+      </button>
+    );
+  };
+
   const shareMuseum = async () => {
     if (typeof window === 'undefined') return;
 
@@ -150,54 +222,10 @@ export default function MuseumCard({ museum }) {
             </span>
           </div>
         </Link>
-        <div className="museum-card-ticket">
-          {museum.ticketUrl ? (
-            <a
-              href={museum.ticketUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="ticket-button"
-              title={ticketHoverMessage}
-            >
-              <span className="ticket-button__label">{t('buyTickets')}</span>
-              <TicketButtonNote affiliate={showAffiliateNote}>
-                {ticketContext}
-              </TicketButtonNote>
-            </a>
-          ) : (
-            <button type="button" className="ticket-button" disabled aria-disabled="true">
-              <span className="ticket-button__label">{t('buyTickets')}</span>
-            </button>
-          )}
-        </div>
+        <div className="museum-card-ticket">{renderTicketButton()}</div>
         <div className="museum-card-actions">
-          <button className="icon-button" aria-label={t('share')} onClick={shareMuseum}>
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7" />
-              <path d="M16 6l-4-4-4 4" />
-              <path d="M12 2v14" />
-            </svg>
-          </button>
-          <button
-            className={`icon-button${isFavorite ? ' favorited' : ''}${
-              isFavoriteBouncing ? ' icon-button--bounce' : ''
-            }`}
-            aria-label={t('save')}
-            aria-pressed={isFavorite}
-            onClick={handleFavorite}
-          >
-            <svg
-              viewBox="0 0 24 24"
-              fill={isFavorite ? 'currentColor' : 'none'}
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <path d="M21 8.25c0 4.556-9 11.25-9 11.25S3 12.806 3 8.25a5.25 5.25 0 0 1 9-3.676A5.25 5.25 0 0 1 21 8.25Z" />
-            </svg>
-          </button>
+          {renderShareButton()}
+          {renderFavoriteButton()}
         </div>
       </div>
       {!isPublicDomainImage && museum.image && hasCreditSegments && (
@@ -259,6 +287,13 @@ export default function MuseumCard({ museum }) {
           )}
         </div>
         {summary && <p className="museum-card-summary">{summary}</p>}
+        <div className="museum-card-mobile-cta">
+          <div className="museum-card-mobile-actions">
+            {renderShareButton('icon-button--mobile')}
+            {renderFavoriteButton('icon-button--mobile')}
+          </div>
+          <div className="museum-card-mobile-ticket">{renderTicketButton('ticket-button--mobile')}</div>
+        </div>
         {museum.free && (
           <div className="museum-card-tags">
             <span className="tag">{t('free')}</span>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -174,7 +174,11 @@ img { max-width: 100%; height: auto; display: block; }
 .spacing-pad-block-16 { padding-block: var(--space-16); }
 
 /* Layout */
-.container { max-width: 1120px; margin: 0 auto; padding: 24px; }
+.container {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: clamp(16px, 5vw, 24px);
+}
 .header {
   position: sticky; top: 0; z-index: 20;
   background: var(--bg);
@@ -270,6 +274,37 @@ img { max-width: 100%; height: auto; display: block; }
   margin: 0;
   font-size: 0.85rem;
   line-height: 1.7;
+}
+
+@media (max-width: 600px) {
+  .footer-inner {
+    align-items: center;
+    text-align: center;
+    gap: 24px;
+    padding: 32px 0;
+  }
+
+  .footer-brand {
+    align-items: center;
+    text-align: center;
+  }
+
+  .footer-claim-text {
+    max-width: none;
+  }
+
+  .footer-meta {
+    align-items: center;
+    text-align: center;
+  }
+
+  .footer-links {
+    justify-content: center;
+  }
+
+  .footer-smallprint {
+    max-width: none;
+  }
 }
 
 @media (min-width: 768px) {
@@ -398,23 +433,72 @@ img { max-width: 100%; height: auto; display: block; }
   .brand-title { font-size: 20px; }
   .brand-tagline { display: none; }
   .navbar {
-    padding: 16px 12px;
+    padding: clamp(12px, 3.5vw, 16px) clamp(16px, 5vw, 18px);
     gap: 12px;
     flex-wrap: wrap;
   }
   .navspacer { display: none; }
   .header-actions {
-    gap: 8px;
     width: 100%;
-    justify-content: space-between;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 12px;
+    align-items: stretch;
   }
-  .header-actions > * { flex: 0 0 auto; }
+  .header-actions > * {
+    width: 100%;
+  }
+  .filters-trigger {
+    grid-column: 1 / -1;
+    width: 100%;
+    justify-content: center;
+    padding: 12px;
+    font-size: 15px;
+  }
+  .filters-trigger span {
+    display: inline;
+  }
+  .filters-trigger svg {
+    width: 20px;
+    height: 20px;
+  }
+  .lang-select,
+  .contrast-toggle,
+  .header-icon {
+    justify-content: center;
+    border-radius: 14px;
+    padding: 10px 12px;
+    background: var(--surface);
+    border: 1px solid var(--panel-border);
+    box-shadow: var(--panel-shadow);
+    min-height: 44px;
+  }
+  .lang-select,
+  .contrast-toggle {
+    gap: 6px;
+    font-size: 0.9rem;
+  }
+  .lang-select svg {
+    width: 14px;
+    height: 8px;
+  }
+  .header-icon {
+    height: 44px;
+    width: 100%;
+  }
+  .header-icon svg,
+  .contrast-toggle svg {
+    width: 20px;
+    height: 20px;
+  }
+  .header-icon .favorite-count {
+    top: 6px;
+    right: 10px;
+  }
   .header {
     backdrop-filter: none;
     background: var(--bg);
   }
-  .filters-trigger span { display: none; }
 }
 
 @media (max-width: 420px) {
@@ -855,6 +939,19 @@ button.hero-quick-link {
   .hero { gap: var(--space-24); padding: var(--space-24); border-radius: var(--radius-md); }
   .hero::before { background-position: center 46%; }
   .hero-card { padding: var(--space-16); }
+  .hero-content {
+    align-items: center;
+    text-align: center;
+  }
+  .hero-actions {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .hero-quick-link {
+    width: 100%;
+    justify-content: center;
+  }
 }
 
 @media (max-width: 480px) {
@@ -1662,6 +1759,12 @@ button.hero-quick-link {
 /* Footer space */
 .section { margin: 24px 0; }
 .count { color: var(--muted); margin: 8px 0 16px; }
+
+@media (max-width: 600px) {
+  .count {
+    text-align: center;
+  }
+}
 .link-accent { color: var(--accent); }
 
 /* Afbeeldingen */
@@ -1707,6 +1810,17 @@ button.hero-quick-link {
   color: var(--accent);
 }
 
+@media (max-width: 600px) {
+  .image-credit {
+    margin: 12px 20px 0;
+    font-size: 0.72rem;
+    line-height: 1.4;
+    white-space: normal;
+    overflow: visible;
+    text-overflow: initial;
+  }
+}
+
 /* MuseumCard component */
 .museum-card {
   --card-aspect-ratio: 4 / 3;
@@ -1724,6 +1838,10 @@ button.hero-quick-link {
 .museum-card:hover {
   transform: translateY(-6px);
   box-shadow: 0 24px 48px rgba(15,23,42,0.16);
+}
+
+.museum-card-mobile-cta {
+  display: none;
 }
 
 @media (min-width: 768px) {
@@ -1992,6 +2110,84 @@ button.hero-quick-link {
   box-shadow: 0 0 0 2px var(--focus-ring-outline),
     0 0 0 5px var(--focus-ring-shadow),
     0 20px 34px rgba(255,120,79,0.34);
+}
+
+@media (max-width: 600px) {
+  .museum-card {
+    border-radius: 20px;
+    box-shadow: 0 14px 30px rgba(15,23,42,0.12);
+  }
+
+  .museum-card:hover {
+    transform: none;
+    box-shadow: 0 14px 30px rgba(15,23,42,0.12);
+  }
+
+  .museum-card-info {
+    padding: 20px 20px 24px;
+    gap: 16px;
+  }
+
+  .museum-card-overlay {
+    padding: 16px;
+  }
+
+  .museum-card-ticket,
+  .museum-card-actions {
+    display: none;
+  }
+
+  .museum-card-summary {
+    font-size: 1rem;
+    line-height: 1.6;
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .museum-card-mobile-cta {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: 100%;
+    margin-top: 8px;
+  }
+
+  .museum-card-mobile-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+  }
+
+  .museum-card-mobile-actions .icon-button,
+  .icon-button--mobile {
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+  }
+
+  .museum-card-mobile-ticket {
+    width: 100%;
+  }
+
+  .museum-card-mobile-ticket .ticket-button,
+  .ticket-button--mobile {
+    width: 100%;
+    padding: 14px 18px;
+    font-size: 1rem;
+    box-shadow: 0 16px 32px rgba(15,23,42,0.16);
+  }
+
+  .museum-card-mobile-ticket .ticket-button__note,
+  .ticket-button--mobile .ticket-button__note {
+    font-size: 0.8rem;
+    line-height: 1.35;
+  }
+
+  .museum-card-tags {
+    margin-top: 0;
+  }
 }
 
 .icon-button {


### PR DESCRIPTION
## Summary
- refactor the MuseumCard buttons to support both desktop overlays and a dedicated mobile utility panel
- add responsive styles that swap in the mobile-friendly ticket and action layout, enlarge touch targets, and clamp long summaries on phones
- allow image credits to wrap so attribution remains readable on narrow screens

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@capacitor%2Fapp)*

------
https://chatgpt.com/codex/tasks/task_e_68d160188cc88326a0e1eb598a7c00bc