### PR TITLE
Add mobile buy tickets button near hero image

### DIFF
--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -370,6 +370,7 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
   const ticketHoverMessage = showAffiliateNote ? t('ticketsAffiliateHover') : undefined;
   const primaryTicketNoteId = useId();
   const overviewTicketNoteId = useId();
+  const mobileHeroTicketNoteId = useId();
   const mobileTicketNoteId = useId();
   const mobileActionSheetId = useId();
   const mobileActionSheetTitleId = useId();
@@ -1075,6 +1076,27 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
           )}
         </div>
       )}
+
+      {hasTicketLink ? (
+        <div className="museum-mobile-hero-actions">
+          <a
+            href={ticketUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="museum-primary-action primary museum-mobile-hero-action"
+            aria-describedby={ticketContext ? mobileHeroTicketNoteId : undefined}
+            onClick={handleTicketLinkClick}
+            title={ticketHoverMessage}
+          >
+            <span className="ticket-button__label">{t('buyTickets')}</span>
+            {ticketContext ? (
+              <TicketButtonNote affiliate={showAffiliateNote} id={mobileHeroTicketNoteId}>
+                {ticketContext}
+              </TicketButtonNote>
+            ) : null}
+          </a>
+        </div>
+      ) : null}
 
       <div className="museum-detail-container">
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1157,6 +1157,9 @@ button.hero-quick-link {
   gap: var(--space-16);
   justify-content: flex-end;
 }
+.museum-mobile-hero-actions {
+  display: none;
+}
 .museum-primary-action {
   display: inline-flex;
   align-items: center;
@@ -1533,6 +1536,30 @@ button.hero-quick-link {
   .museum-map-card,
   .museum-sidebar-card { border-radius: var(--radius-md); }
   .museum-info-links { gap: 10px; }
+  .museum-mobile-hero-actions {
+    display: flex;
+    justify-content: center;
+    padding: 0 var(--space-16);
+    margin: clamp(16px, 4vw, 28px) 0;
+  }
+  .museum-mobile-hero-action {
+    width: 100%;
+    max-width: 520px;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 10px;
+    padding: 14px 22px;
+    box-shadow: 0 16px 32px rgba(15,23,42,0.16);
+  }
+  .museum-mobile-hero-action .ticket-button__label {
+    font-size: 1.05rem;
+  }
+  .museum-mobile-hero-action .ticket-button__note {
+    font-size: 0.8rem;
+    line-height: 1.35;
+    justify-content: center;
+  }
 
   .museum-mobile-actions {
     display: block;


### PR DESCRIPTION
## Summary
- add a dedicated mobile buy tickets button beneath the hero image on museum detail pages
- style the new mobile hero CTA to stretch full-width and remain readable on small screens

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1665b87e4832683986ffa72507b62