### PR TITLE
Position hero ticket CTA over museum hero image

### DIFF
--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -370,6 +370,7 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
   const ticketHoverMessage = showAffiliateNote ? t('ticketsAffiliateHover') : undefined;
   const primaryTicketNoteId = useId();
   const overviewTicketNoteId = useId();
+  const heroTicketNoteId = useId();
   const mobileTicketNoteId = useId();
   const mobileActionSheetId = useId();
   const mobileActionSheetTitleId = useId();
@@ -1048,6 +1049,24 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
             priority={isLandingMuseum}
             loading={isLandingMuseum ? 'eager' : 'lazy'}
           />
+          {hasTicketLink ? (
+            <a
+              href={ticketUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="museum-hero-ticket-link museum-primary-action primary"
+              aria-describedby={ticketContext ? heroTicketNoteId : undefined}
+              onClick={handleTicketLinkClick}
+              title={ticketHoverMessage}
+            >
+              <span className="ticket-button__label">{t('buyTickets')}</span>
+              {ticketContext ? (
+                <TicketButtonNote affiliate={showAffiliateNote} id={heroTicketNoteId}>
+                  {ticketContext}
+                </TicketButtonNote>
+              ) : null}
+            </a>
+          ) : null}
           {!isPublicDomainImage && hasCreditSegments && (
             <p className="museum-hero-credit" title={creditFullText || undefined}>
               {creditSegments.map((segment, index) => (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1242,6 +1242,68 @@ button.hero-quick-link {
   box-shadow: 0 12px 26px rgba(255,90,60,0.3);
 }
 
+.museum-hero-ticket-link {
+  position: absolute;
+  top: clamp(16px, 4vw, 28px);
+  left: clamp(16px, 4vw, 32px);
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.2;
+  text-decoration: none;
+  color: var(--accent-ink);
+  background: var(--accent);
+  border: 1px solid transparent;
+  box-shadow: 0 14px 30px rgba(37, 99, 235, 0.28);
+  backdrop-filter: blur(18px);
+  min-height: 0;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+.museum-hero-ticket-link .ticket-button__label {
+  font-size: 0.95rem;
+  white-space: nowrap;
+}
+.museum-hero-ticket-link .ticket-button__note {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  border: 0;
+  white-space: nowrap;
+}
+.museum-hero-ticket-link:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 34px rgba(37, 99, 235, 0.32);
+}
+.museum-hero-ticket-link:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 0 0 2px var(--focus-ring-outline), 0 0 0 5px var(--focus-ring-shadow),
+    0 20px 38px rgba(37, 99, 235, 0.3);
+}
+[data-theme='dark'] .museum-hero-ticket-link {
+  background: rgba(37, 99, 235, 0.92);
+  color: var(--accent-ink);
+  box-shadow: 0 16px 36px rgba(2, 6, 23, 0.58);
+}
+[data-theme='dark'] .museum-hero-ticket-link:hover {
+  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.66);
+}
+[data-theme='dark'] .museum-hero-ticket-link:focus-visible {
+  box-shadow: 0 0 0 2px var(--focus-ring-outline),
+    0 0 0 5px var(--focus-ring-shadow),
+    0 22px 40px rgba(2, 6, 23, 0.66);
+}
+
 .museum-mobile-actions {
   display: none;
 }
@@ -1533,7 +1595,17 @@ button.hero-quick-link {
   .museum-map-card,
   .museum-sidebar-card { border-radius: var(--radius-md); }
   .museum-info-links { gap: 10px; }
-
+  .museum-hero-ticket-link {
+    top: clamp(12px, 5vw, 20px);
+    left: clamp(12px, 5vw, 20px);
+    padding: 8px 14px;
+    gap: 6px;
+    font-size: 13px;
+    box-shadow: 0 12px 26px rgba(37, 99, 235, 0.28);
+  }
+  .museum-hero-ticket-link .ticket-button__label {
+    font-size: 0.9rem;
+  }
   .museum-mobile-actions {
     display: block;
     position: fixed;
@@ -1715,6 +1787,19 @@ button.hero-quick-link {
   [data-theme='dark'] .museum-mobile-actions__close:hover {
     background: rgba(15,23,42,0.82);
     box-shadow: 0 16px 32px rgba(0,0,0,0.45);
+  }
+}
+
+@media (max-width: 480px) {
+  .museum-hero-ticket-link {
+    top: clamp(10px, 6vw, 18px);
+    left: clamp(10px, 6vw, 18px);
+    padding: 7px 12px;
+    font-size: 12px;
+    gap: 4px;
+  }
+  .museum-hero-ticket-link .ticket-button__label {
+    font-size: 0.85rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- move the hero ticket call-to-action into the museum hero image so it appears in the top-left corner on all viewports
- add compact accent styling and responsive sizing tweaks so the hero CTA stays small on desktop and mobile while keeping the affiliate note accessible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1665b87e4832683986ffa72507b62