### PR TITLE
Align museum card actions with image on mobile

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -287,13 +287,6 @@ export default function MuseumCard({ museum }) {
           )}
         </div>
         {summary && <p className="museum-card-summary">{summary}</p>}
-        <div className="museum-card-mobile-cta">
-          <div className="museum-card-mobile-actions">
-            {renderShareButton('icon-button--mobile')}
-            {renderFavoriteButton('icon-button--mobile')}
-          </div>
-          <div className="museum-card-mobile-ticket">{renderTicketButton('ticket-button--mobile')}</div>
-        </div>
         {museum.free && (
           <div className="museum-card-tags">
             <span className="tag">{t('free')}</span>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1840,10 +1840,6 @@ button.hero-quick-link {
   box-shadow: 0 24px 48px rgba(15,23,42,0.16);
 }
 
-.museum-card-mobile-cta {
-  display: none;
-}
-
 @media (min-width: 768px) {
   .museum-card {
     --card-aspect-ratio: 16 / 9;
@@ -2132,9 +2128,41 @@ button.hero-quick-link {
     padding: 16px;
   }
 
-  .museum-card-ticket,
+  .museum-card-ticket {
+    top: 10px;
+    left: 10px;
+  }
+
+  .museum-card-ticket .ticket-button {
+    padding: 10px 14px;
+    font-size: 0.95rem;
+    border-radius: 12px;
+    box-shadow: 0 14px 28px rgba(15,23,42,0.16);
+    gap: 6px;
+  }
+
+  .museum-card-ticket .ticket-button__note {
+    font-size: 0.75rem;
+    line-height: 1.3;
+  }
+
   .museum-card-actions {
-    display: none;
+    top: 10px;
+    right: 10px;
+    padding: 8px;
+    gap: 8px;
+    border-radius: 14px;
+  }
+
+  .museum-card-actions .icon-button {
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+  }
+
+  .museum-card-actions .icon-button svg {
+    width: 20px;
+    height: 20px;
   }
 
   .museum-card-summary {
@@ -2144,45 +2172,6 @@ button.hero-quick-link {
     -webkit-line-clamp: 4;
     -webkit-box-orient: vertical;
     overflow: hidden;
-  }
-
-  .museum-card-mobile-cta {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    width: 100%;
-    margin-top: 8px;
-  }
-
-  .museum-card-mobile-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 12px;
-  }
-
-  .museum-card-mobile-actions .icon-button,
-  .icon-button--mobile {
-    width: 44px;
-    height: 44px;
-    border-radius: 14px;
-  }
-
-  .museum-card-mobile-ticket {
-    width: 100%;
-  }
-
-  .museum-card-mobile-ticket .ticket-button,
-  .ticket-button--mobile {
-    width: 100%;
-    padding: 14px 18px;
-    font-size: 1rem;
-    box-shadow: 0 16px 32px rgba(15,23,42,0.16);
-  }
-
-  .museum-card-mobile-ticket .ticket-button__note,
-  .ticket-button--mobile .ticket-button__note {
-    font-size: 0.8rem;
-    line-height: 1.35;
   }
 
   .museum-card-tags {


### PR DESCRIPTION
## Summary
- keep the museum card ticket and action buttons integrated with the card image on mobile layouts
- remove the redundant mobile CTA markup and update responsive styles for the overlay buttons

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d176228578832691950d753129bdec