### PR TITLE
Tighten mobile museum card overlays further

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -287,13 +287,6 @@ export default function MuseumCard({ museum }) {
           )}
         </div>
         {summary && <p className="museum-card-summary">{summary}</p>}
-        <div className="museum-card-mobile-cta">
-          <div className="museum-card-mobile-actions">
-            {renderShareButton('icon-button--mobile')}
-            {renderFavoriteButton('icon-button--mobile')}
-          </div>
-          <div className="museum-card-mobile-ticket">{renderTicketButton('ticket-button--mobile')}</div>
-        </div>
         {museum.free && (
           <div className="museum-card-tags">
             <span className="tag">{t('free')}</span>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1840,10 +1840,6 @@ button.hero-quick-link {
   box-shadow: 0 24px 48px rgba(15,23,42,0.16);
 }
 
-.museum-card-mobile-cta {
-  display: none;
-}
-
 @media (min-width: 768px) {
   .museum-card {
     --card-aspect-ratio: 16 / 9;
@@ -2101,8 +2097,8 @@ button.hero-quick-link {
 }
 
 .ticket-button__note-icon {
-  width: 12px;
-  height: 12px;
+  width: 11px;
+  height: 11px;
   flex-shrink: 0;
 }
 
@@ -2132,9 +2128,47 @@ button.hero-quick-link {
     padding: 16px;
   }
 
-  .museum-card-ticket,
+  .museum-card-ticket {
+    top: 8px;
+    left: 8px;
+  }
+
+  .museum-card-ticket .ticket-button {
+    padding: 5px 9px;
+    font-size: 0.78rem;
+    border-radius: 9px;
+    box-shadow: 0 10px 20px rgba(15,23,42,0.12);
+    gap: 3px;
+    max-width: min(60vw, 168px);
+  }
+
+  .museum-card-ticket .ticket-button__label {
+    line-height: 1.1;
+  }
+
+  .museum-card-ticket .ticket-button__note {
+    font-size: 0.68rem;
+    line-height: 1.2;
+  }
+
   .museum-card-actions {
-    display: none;
+    top: 8px;
+    right: 8px;
+    padding: 4px 3px;
+    gap: 3px;
+    border-radius: 11px;
+    flex-direction: column;
+  }
+
+  .museum-card .museum-card-actions .icon-button {
+    width: 28px;
+    height: 28px;
+    border-radius: 10px;
+  }
+
+  .museum-card .museum-card-actions .icon-button svg {
+    width: 14px;
+    height: 14px;
   }
 
   .museum-card-summary {
@@ -2144,45 +2178,6 @@ button.hero-quick-link {
     -webkit-line-clamp: 4;
     -webkit-box-orient: vertical;
     overflow: hidden;
-  }
-
-  .museum-card-mobile-cta {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    width: 100%;
-    margin-top: 8px;
-  }
-
-  .museum-card-mobile-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 12px;
-  }
-
-  .museum-card-mobile-actions .icon-button,
-  .icon-button--mobile {
-    width: 44px;
-    height: 44px;
-    border-radius: 14px;
-  }
-
-  .museum-card-mobile-ticket {
-    width: 100%;
-  }
-
-  .museum-card-mobile-ticket .ticket-button,
-  .ticket-button--mobile {
-    width: 100%;
-    padding: 14px 18px;
-    font-size: 1rem;
-    box-shadow: 0 16px 32px rgba(15,23,42,0.16);
-  }
-
-  .museum-card-mobile-ticket .ticket-button__note,
-  .ticket-button--mobile .ticket-button__note {
-    font-size: 0.8rem;
-    line-height: 1.35;
   }
 
   .museum-card-tags {


### PR DESCRIPTION
## Summary
- cap the mobile ticket button width with tighter padding and label leading so it wraps sooner
- stack the share and favorite controls vertically on mobile with smaller buttons to shrink their footprint

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d176228578832691950d753129bdec