### PR TITLE
Make museum card ticket CTA more compact and square

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -287,13 +287,6 @@ export default function MuseumCard({ museum }) {
           )}
         </div>
         {summary && <p className="museum-card-summary">{summary}</p>}
-        <div className="museum-card-mobile-cta">
-          <div className="museum-card-mobile-actions">
-            {renderShareButton('icon-button--mobile')}
-            {renderFavoriteButton('icon-button--mobile')}
-          </div>
-          <div className="museum-card-mobile-ticket">{renderTicketButton('ticket-button--mobile')}</div>
-        </div>
         {museum.free && (
           <div className="museum-card-tags">
             <span className="tag">{t('free')}</span>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -9,6 +9,11 @@
   --accent:#2563eb;
   --accent-ink:#ffffff;
   --surface:#ffffff;
+  --ticket-shadow:0 12px 26px rgba(15,23,42,0.16);
+  --ticket-shadow-hover:0 16px 32px rgba(15,23,42,0.18);
+  --ticket-shadow-active:0 10px 20px rgba(15,23,42,0.14);
+  --ticket-note-bg:rgba(255,255,255,0.18);
+  --ticket-note-bg-strong:rgba(255,255,255,0.26);
   --panel-bg:rgba(255,255,255,0.95);
   --panel-border:rgba(31,41,55,0.08);
   --panel-shadow:0 12px 32px rgba(15,23,42,0.12);
@@ -48,6 +53,11 @@
   --accent:#f97316;
   --accent-ink:#0b1220;
   --surface:#1f2937;
+  --ticket-shadow:0 12px 26px rgba(2,6,23,0.32);
+  --ticket-shadow-hover:0 16px 32px rgba(2,6,23,0.36);
+  --ticket-shadow-active:0 10px 22px rgba(2,6,23,0.28);
+  --ticket-note-bg:rgba(255,255,255,0.2);
+  --ticket-note-bg-strong:rgba(255,255,255,0.28);
   --panel-bg:rgba(15,23,42,0.92);
   --panel-border:rgba(148,163,184,0.18);
   --panel-shadow:0 14px 36px rgba(2,6,23,0.45);
@@ -1840,10 +1850,6 @@ button.hero-quick-link {
   box-shadow: 0 24px 48px rgba(15,23,42,0.16);
 }
 
-.museum-card-mobile-cta {
-  display: none;
-}
-
 @media (min-width: 768px) {
   .museum-card {
     --card-aspect-ratio: 16 / 9;
@@ -2022,47 +2028,70 @@ button.hero-quick-link {
   left: 12px;
   z-index: 1;
 }
+.museum-card-ticket .ticket-button {
+  padding: 14px 16px;
+  border-radius: 12px;
+  align-items: stretch;
+  text-align: left;
+  gap: 8px;
+  width: clamp(128px, 28vw, 176px);
+  min-height: clamp(118px, 26vw, 150px);
+  justify-content: space-between;
+}
+.museum-card-ticket .ticket-button__label {
+  line-height: 1.3;
+}
+.museum-card-ticket .ticket-button__note {
+  width: 100%;
+  align-self: stretch;
+  text-align: left;
+  justify-content: flex-start;
+  gap: 6px;
+  line-height: 1.25;
+  padding: 4px 8px;
+  border-radius: 10px;
+}
 .ticket-button {
-  padding: 6px 12px;
+  padding: 10px 16px;
   border: none;
-  border-radius: 8px;
+  border-radius: 10px;
   background: var(--accent);
   color: var(--accent-ink);
-  font-size: 14px;
-  font-weight: 600;
-  letter-spacing: 0.025em;
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
   cursor: pointer;
-  box-shadow: 0 12px 24px rgba(15,23,42,0.14);
+  box-shadow: var(--ticket-shadow);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   text-align: center;
   text-decoration: none;
-  gap: 4px;
+  gap: 6px;
   min-width: 0;
-  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease, color 0.3s ease;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 .ticket-button:hover {
-  background: var(--accent-ink);
-  color: var(--accent);
   transform: translateY(-2px);
-  box-shadow: 0 18px 30px rgba(15,23,42,0.18);
+  box-shadow: var(--ticket-shadow-hover);
 }
 .ticket-button:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--focus-ring-outline),
     0 0 0 5px var(--focus-ring-shadow),
-    0 18px 32px rgba(15,23,42,0.22);
+    var(--ticket-shadow-hover);
 }
 .ticket-button:active {
   transform: translateY(0);
-  box-shadow: 0 12px 22px rgba(15,23,42,0.16);
+  box-shadow: var(--ticket-shadow-active);
 }
 .museum-info-links .ticket-button {
   width: 100%;
   padding: 12px 20px;
-  box-shadow: 0 12px 24px rgba(15,23,42,0.14);
+  box-shadow: var(--ticket-shadow);
+  align-items: center;
+  text-align: center;
 }
 @media (min-width: 601px) {
   .museum-info-links .ticket-button {
@@ -2075,41 +2104,50 @@ button.hero-quick-link {
   pointer-events: none;
   cursor: not-allowed;
 }
+.ticket-button__label {
+  line-height: 1.25;
+  letter-spacing: 0.01em;
+}
+
 .ticket-button__note {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-wrap: wrap;
-  gap: 6px;
-  font-size: 11px;
-  font-weight: 500;
+  gap: 5px;
+  font-size: 0.7rem;
+  font-weight: 600;
   line-height: 1.2;
   color: inherit;
-  opacity: 0.92;
   text-align: center;
   max-width: 100%;
+  background: var(--ticket-note-bg);
+  padding: 2px 8px 3px;
+  border-radius: 999px;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.18);
 }
 
 .ticket-button__note--partner {
-  font-weight: 600;
-  opacity: 1;
+  background: var(--ticket-note-bg-strong);
 }
 
 .ticket-button__note-text {
   display: inline;
   white-space: normal;
+  letter-spacing: 0.02em;
 }
 
 .ticket-button__note-icon {
-  width: 12px;
-  height: 12px;
+  width: 11px;
+  height: 11px;
   flex-shrink: 0;
+  color: currentColor;
 }
 
 [data-theme='dark'] .ticket-button:focus-visible {
   box-shadow: 0 0 0 2px var(--focus-ring-outline),
     0 0 0 5px var(--focus-ring-shadow),
-    0 20px 34px rgba(255,120,79,0.34);
+    var(--ticket-shadow-hover);
 }
 
 @media (max-width: 600px) {
@@ -2132,9 +2170,50 @@ button.hero-quick-link {
     padding: 16px;
   }
 
-  .museum-card-ticket,
+  .museum-card-ticket {
+    top: 8px;
+    left: 8px;
+  }
+
+  .museum-card-ticket .ticket-button {
+    padding: 10px 12px;
+    font-size: 0.82rem;
+    border-radius: 10px;
+    box-shadow: var(--ticket-shadow);
+    gap: 6px;
+    width: min(48vw, 140px);
+    min-height: 112px;
+  }
+
+  .museum-card-ticket .ticket-button__label {
+    line-height: 1.25;
+  }
+
+  .museum-card-ticket .ticket-button__note {
+    font-size: 0.64rem;
+    line-height: 1.3;
+    padding: 3px 6px;
+    border-radius: 8px;
+  }
+
   .museum-card-actions {
-    display: none;
+    top: 8px;
+    right: 8px;
+    padding: 4px 3px;
+    gap: 3px;
+    border-radius: 11px;
+    flex-direction: column;
+  }
+
+  .museum-card .museum-card-actions .icon-button {
+    width: 28px;
+    height: 28px;
+    border-radius: 10px;
+  }
+
+  .museum-card .museum-card-actions .icon-button svg {
+    width: 14px;
+    height: 14px;
   }
 
   .museum-card-summary {
@@ -2144,45 +2223,6 @@ button.hero-quick-link {
     -webkit-line-clamp: 4;
     -webkit-box-orient: vertical;
     overflow: hidden;
-  }
-
-  .museum-card-mobile-cta {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    width: 100%;
-    margin-top: 8px;
-  }
-
-  .museum-card-mobile-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 12px;
-  }
-
-  .museum-card-mobile-actions .icon-button,
-  .icon-button--mobile {
-    width: 44px;
-    height: 44px;
-    border-radius: 14px;
-  }
-
-  .museum-card-mobile-ticket {
-    width: 100%;
-  }
-
-  .museum-card-mobile-ticket .ticket-button,
-  .ticket-button--mobile {
-    width: 100%;
-    padding: 14px 18px;
-    font-size: 1rem;
-    box-shadow: 0 16px 32px rgba(15,23,42,0.16);
-  }
-
-  .museum-card-mobile-ticket .ticket-button__note,
-  .ticket-button--mobile .ticket-button__note {
-    font-size: 0.8rem;
-    line-height: 1.35;
   }
 
   .museum-card-tags {
@@ -2718,6 +2758,8 @@ button.hero-quick-link {
 .exposition-card__cta {
   width: 100%;
   justify-content: center;
+  align-items: center;
+  text-align: center;
   font-size: 13px;
   font-weight: 600;
   box-shadow: 0 8px 22px rgba(15,23,42,0.16);


### PR DESCRIPTION
## Summary
- restore the ticket CTA to use the existing accent palette while updating shared shadows and note tints
- add museum card specific layout rules so the overlay ticket button keeps a compact, square footprint on desktop and mobile

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d176228578832691950d753129bdec