### PR TITLE
Refine museum card ticket CTA

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -135,26 +135,48 @@ export default function MuseumCard({ museum }) {
 
   const renderTicketButton = (className = '') => {
     const classNames = `ticket-button${className ? ` ${className}` : ''}`;
+    const noteId = showAffiliateNote
+      ? `ticket-note-${museum.slug || museum.id || 'cta'}`
+      : undefined;
+    const ticketLabel = t('tickets');
+    const ariaLabel = ticketContext ? `${t('buyTickets')} — ${ticketContext}` : t('buyTickets');
+    const relAttributes = ['noreferrer', 'noopener'];
+
+    if (showAffiliateNote) {
+      relAttributes.push('sponsored');
+    }
 
     if (museum.ticketUrl) {
       return (
-        <a
-          href={museum.ticketUrl}
-          target="_blank"
-          rel="noreferrer"
-          className={classNames}
-          title={ticketHoverMessage}
+        <div
+          className={`ticket-button-wrapper${showAffiliateNote ? ' ticket-button-wrapper--partner' : ''}`}
         >
-          <span className="ticket-button__label">{t('buyTickets')}</span>
-          <TicketButtonNote affiliate={showAffiliateNote}>{ticketContext}</TicketButtonNote>
-        </a>
+          <a
+            href={museum.ticketUrl}
+            target="_blank"
+            rel={relAttributes.join(' ')}
+            className={classNames}
+            title={ticketHoverMessage}
+            aria-label={ariaLabel}
+            aria-describedby={noteId || undefined}
+          >
+            <span className="ticket-button__label">{ticketLabel}</span>
+          </a>
+          {showAffiliateNote ? (
+            <TicketButtonNote affiliate id={noteId}>
+              {ticketContext}
+            </TicketButtonNote>
+          ) : null}
+        </div>
       );
     }
 
     return (
-      <button type="button" className={classNames} disabled aria-disabled="true">
-        <span className="ticket-button__label">{t('buyTickets')}</span>
-      </button>
+      <div className="ticket-button-wrapper">
+        <button type="button" className={classNames} disabled aria-disabled="true">
+          <span className="ticket-button__label">{t('buyTickets')}</span>
+        </button>
+      </div>
     );
   };
 
@@ -287,13 +309,6 @@ export default function MuseumCard({ museum }) {
           )}
         </div>
         {summary && <p className="museum-card-summary">{summary}</p>}
-        <div className="museum-card-mobile-cta">
-          <div className="museum-card-mobile-actions">
-            {renderShareButton('icon-button--mobile')}
-            {renderFavoriteButton('icon-button--mobile')}
-          </div>
-          <div className="museum-card-mobile-ticket">{renderTicketButton('ticket-button--mobile')}</div>
-        </div>
         {museum.free && (
           <div className="museum-card-tags">
             <span className="tag">{t('free')}</span>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1840,10 +1840,6 @@ button.hero-quick-link {
   box-shadow: 0 24px 48px rgba(15,23,42,0.16);
 }
 
-.museum-card-mobile-cta {
-  display: none;
-}
-
 @media (min-width: 768px) {
   .museum-card {
     --card-aspect-ratio: 16 / 9;
@@ -1997,30 +1993,34 @@ button.hero-quick-link {
 
 .museum-card-actions {
   position: absolute;
-  top: 12px;
-  right: 12px;
-  display: inline-flex;
+  top: 16px;
+  right: 16px;
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 6px;
-  padding: 6px;
-  border-radius: 16px;
-  background: var(--chip-bg);
-  border: 1px solid var(--chip-border);
-  box-shadow: 0 12px 24px rgba(15,23,42,0.14);
-  backdrop-filter: blur(10px);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  gap: 12px;
+  padding: 0;
+  border-radius: 20px;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  backdrop-filter: none;
+  transition: transform 0.3s ease;
+  z-index: 2;
 }
 
 .museum-card:hover .museum-card-actions {
   transform: translateY(-2px);
-  box-shadow: 0 16px 32px rgba(15,23,42,0.18);
 }
 
 .museum-card-ticket {
   position: absolute;
-  top: 12px;
-  left: 12px;
-  z-index: 1;
+  top: 16px;
+  left: 16px;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 }
 .ticket-button {
   padding: 6px 12px;
@@ -2042,6 +2042,62 @@ button.hero-quick-link {
   gap: 4px;
   min-width: 0;
   transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease, color 0.3s ease;
+}
+
+.museum-card .ticket-button {
+  padding: 10px;
+  border-radius: 14px;
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+  box-shadow: 0 12px 26px rgba(15,23,42,0.18);
+  width: clamp(56px, 14vw, 82px);
+  min-height: clamp(56px, 14vw, 82px);
+  aspect-ratio: 1 / 1;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 2px;
+}
+
+.museum-card .ticket-button__label {
+  line-height: 1.25;
+}
+
+.ticket-button-wrapper {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  text-align: center;
+}
+
+.ticket-button-wrapper--partner .ticket-button__note {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.88);
+  color: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 12px 24px rgba(15,23,42,0.18);
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  max-width: 160px;
+  pointer-events: none;
+}
+
+.ticket-button-wrapper--partner .ticket-button__note-icon {
+  width: 12px;
+  height: 12px;
+}
+
+.ticket-button-wrapper--partner .ticket-button__note-text {
+  white-space: normal;
+}
+
+[data-theme='dark'] .ticket-button-wrapper--partner .ticket-button__note {
+  background: rgba(255, 255, 255, 0.94);
+  color: rgba(15, 23, 42, 0.88);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.26);
 }
 .ticket-button:hover {
   background: var(--accent-ink);
@@ -2132,11 +2188,6 @@ button.hero-quick-link {
     padding: 16px;
   }
 
-  .museum-card-ticket,
-  .museum-card-actions {
-    display: none;
-  }
-
   .museum-card-summary {
     font-size: 1rem;
     line-height: 1.6;
@@ -2146,43 +2197,29 @@ button.hero-quick-link {
     overflow: hidden;
   }
 
-  .museum-card-mobile-cta {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    width: 100%;
-    margin-top: 8px;
+  .museum-card-actions {
+    top: 14px;
+    right: 14px;
+    gap: 10px;
   }
 
-  .museum-card-mobile-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 12px;
-  }
-
-  .museum-card-mobile-actions .icon-button,
-  .icon-button--mobile {
-    width: 44px;
-    height: 44px;
+  .museum-card-actions .icon-button {
+    width: 40px;
+    height: 40px;
     border-radius: 14px;
   }
 
-  .museum-card-mobile-ticket {
-    width: 100%;
+  .museum-card-ticket {
+    top: 14px;
+    left: 14px;
   }
 
-  .museum-card-mobile-ticket .ticket-button,
-  .ticket-button--mobile {
-    width: 100%;
-    padding: 14px 18px;
-    font-size: 1rem;
-    box-shadow: 0 16px 32px rgba(15,23,42,0.16);
-  }
-
-  .museum-card-mobile-ticket .ticket-button__note,
-  .ticket-button--mobile .ticket-button__note {
-    font-size: 0.8rem;
-    line-height: 1.35;
+  .museum-card .ticket-button {
+    padding: 10px;
+    font-size: 0.82rem;
+    border-radius: 14px;
+    width: clamp(60px, 24vw, 86px);
+    min-height: clamp(60px, 24vw, 86px);
   }
 
   .museum-card-tags {
@@ -2260,37 +2297,45 @@ button.hero-quick-link {
 }
 
 .museum-card-actions .icon-button {
-  width: 34px;
-  height: 34px;
-  min-height: 0;
+  width: 44px;
+  height: 44px;
   padding: 0;
-  border-radius: 12px;
-  gap: 0;
-  box-shadow: none;
-}
-
-.museum-card-actions .icon-button:not(.favorited) {
-  background: transparent;
-  border: 1px solid var(--panel-border);
-  color: var(--muted);
+  border-radius: 16px;
+  background: rgba(255,255,255,0.95);
+  border: 1px solid rgba(148,163,184,0.24);
+  color: var(--text);
+  box-shadow: 0 16px 28px rgba(15,23,42,0.18);
+  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease,
+    border-color 0.2s ease;
 }
 
 .museum-card-actions .icon-button:not(.favorited):hover {
-  background: rgba(255,255,255,0.85);
-  border-color: rgba(15,23,42,0.12);
+  background: #ffffff;
+  border-color: rgba(148,163,184,0.32);
   color: var(--text);
+  box-shadow: 0 20px 36px rgba(15,23,42,0.2);
+  transform: translateY(-2px);
 }
 
-[data-theme='dark'] .museum-card-actions .icon-button:not(.favorited) {
-  background: rgba(15,23,42,0.35);
-  border-color: rgba(148,163,184,0.28);
+.museum-card-actions .icon-button.favorited {
+  background: var(--accent);
+  color: var(--accent-ink);
+  border-color: transparent;
+  box-shadow: 0 18px 32px rgba(255,90,60,0.35);
+}
+
+[data-theme='dark'] .museum-card-actions .icon-button {
+  background: rgba(15,23,42,0.88);
+  border-color: rgba(148,163,184,0.36);
   color: var(--muted);
+  box-shadow: 0 16px 28px rgba(15,23,42,0.45);
 }
 
 [data-theme='dark'] .museum-card-actions .icon-button:not(.favorited):hover {
-  background: rgba(15,23,42,0.55);
-  border-color: rgba(148,163,184,0.32);
+  background: rgba(15,23,42,0.92);
+  border-color: rgba(148,163,184,0.42);
   color: var(--text);
+  box-shadow: 0 20px 36px rgba(15,23,42,0.5);
 }
 
 .museum-card-info {


### PR DESCRIPTION
## Summary
- align the museum card share and favourite buttons vertically in the image corner with refreshed styling for light and dark themes
- resize and reposition the ticket button so it stays in the image corner across breakpoints with a compact square footprint that matches the reference layout
- highlight partner ticket links with a disclosure badge, sponsored rel metadata, and updated accessible labelling
- remove the mobile-only CTA markup so the museum card only renders one set of controls across viewports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2462ea72c8326996b4cb2bb8f5535