### PR TITLE
Adjust museum card ticket control layout

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1997,8 +1997,8 @@ button.hero-quick-link {
 
 .museum-card-actions {
   position: absolute;
-  top: 12px;
-  right: 12px;
+  top: 16px;
+  right: 16px;
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -2018,9 +2018,35 @@ button.hero-quick-link {
 
 .museum-card-ticket {
   position: absolute;
-  top: 12px;
-  left: 12px;
+  top: 16px;
+  left: 16px;
   z-index: 1;
+}
+
+.museum-card-ticket .ticket-button {
+  width: 136px;
+  min-width: 136px;
+  height: 44px;
+  padding: 8px 16px;
+  border-radius: 14px;
+  gap: 2px;
+  align-items: flex-start;
+  text-align: left;
+}
+
+.museum-card-ticket .ticket-button__label {
+  width: 100%;
+  font-size: 0.95rem;
+  line-height: 1.1;
+  letter-spacing: 0.01em;
+}
+
+.museum-card-ticket .ticket-button__note {
+  width: 100%;
+  justify-content: flex-start;
+  font-size: 0.7rem;
+  line-height: 1.1;
+  opacity: 0.9;
 }
 .ticket-button {
   padding: 6px 12px;


### PR DESCRIPTION
## Summary
- align the buy ticket button positioning with the design reference and match the requested footprint
- keep the share and favorite controls anchored in the upper right corner for consistency with the mockup

## Testing
- not run (npm install was blocked in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d2532362a48326aa113df3dae49fa9