### PR TITLE
Refine museum card ticket control sizing

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -222,7 +222,7 @@ export default function MuseumCard({ museum }) {
             </span>
           </div>
         </Link>
-        <div className="museum-card-ticket">{renderTicketButton()}</div>
+        <div className="museum-card-ticket">{renderTicketButton('ticket-button--card')}</div>
         <div className="museum-card-actions">
           {renderShareButton()}
           {renderFavoriteButton()}
@@ -292,7 +292,9 @@ export default function MuseumCard({ museum }) {
             {renderShareButton('icon-button--mobile')}
             {renderFavoriteButton('icon-button--mobile')}
           </div>
-          <div className="museum-card-mobile-ticket">{renderTicketButton('ticket-button--mobile')}</div>
+          <div className="museum-card-mobile-ticket">
+            {renderTicketButton('ticket-button--card ticket-button--mobile')}
+          </div>
         </div>
         {museum.free && (
           <div className="museum-card-tags">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1997,8 +1997,8 @@ button.hero-quick-link {
 
 .museum-card-actions {
   position: absolute;
-  top: 12px;
-  right: 12px;
+  top: 16px;
+  right: 16px;
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -2018,9 +2018,49 @@ button.hero-quick-link {
 
 .museum-card-ticket {
   position: absolute;
-  top: 12px;
-  left: 12px;
+  top: 16px;
+  left: 16px;
   z-index: 1;
+  display: flex;
+}
+
+.ticket-button--card {
+  display: inline-grid;
+  grid-auto-flow: row;
+  align-content: center;
+  justify-items: start;
+  width: clamp(120px, 18vw, 136px);
+  min-height: 44px;
+  padding: 6px 14px;
+  border-radius: 14px;
+  gap: 2px;
+  text-align: left;
+  line-height: 1.1;
+}
+
+.ticket-button--card .ticket-button__label {
+  width: 100%;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.ticket-button--card .ticket-button__note {
+  width: 100%;
+  justify-content: flex-start;
+  font-size: 0.7rem;
+  line-height: 1.2;
+  gap: 4px;
+  text-align: left;
+}
+
+.ticket-button--card .ticket-button__note-icon {
+  width: 11px;
+  height: 11px;
+}
+
+.ticket-button--card .ticket-button__note-text {
+  flex: 1;
 }
 .ticket-button {
   padding: 6px 12px;


### PR DESCRIPTION
## Summary
- enforce a dedicated `ticket-button--card` variant so the museum card CTA lands at the requested dimensions and top-left position
- apply the same card-specific styling to the mobile CTA while keeping the share and favorite controls anchored in the top-right corner

## Testing
- npm install *(fails: registry blocks access to @capacitor/app)*

------
https://chatgpt.com/codex/tasks/task_e_68d2532362a48326aa113df3dae49fa9