### PR TITLE
Adjust partner ticket note size

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2131,6 +2131,7 @@ button.hero-quick-link {
 .ticket-button__note--partner {
   font-weight: 600;
   opacity: 1;
+  font-size: 0.9em;
 }
 
 .ticket-button__note-text {


### PR DESCRIPTION
## Summary
- reduce the font size of the partner ticket note so the "Opent partnerwebsite" label appears smaller on the Koop tickets button

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d28208b2c8832688757aab54bdd028