### PR TITLE
Adjust partner ticket note size

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2119,6 +2119,7 @@ button.hero-quick-link {
   justify-content: center;
   flex-wrap: wrap;
   gap: 6px;
+  width: 100%;
   font-size: 11px;
   font-weight: 500;
   line-height: 1.2;
@@ -2131,6 +2132,7 @@ button.hero-quick-link {
 .ticket-button__note--partner {
   font-weight: 600;
   opacity: 1;
+  font-size: 0.8em;
 }
 
 .ticket-button__note-text {


### PR DESCRIPTION
## Summary
- further reduce the font size of the partner ticket note so the "Opent partnerwebsite" label appears smaller on the Koop tickets button
- ensure ticket button notes span the full button width so the "Opens official website" helper text stays centered like other labels

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d28208b2c8832688757aab54bdd028