### PR TITLE
Tune ticket helper text styles

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1174,6 +1174,11 @@ button.hero-quick-link {
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
   min-height: 48px;
 }
+
+.museum-primary-action .ticket-button__label,
+.museum-primary-action .ticket-button__note {
+  align-self: baseline;
+}
 .museum-primary-action:hover {
   transform: translateY(-1px);
   box-shadow: 0 12px 28px rgba(15,23,42,0.18);
@@ -2119,9 +2124,10 @@ button.hero-quick-link {
   justify-content: center;
   flex-wrap: wrap;
   gap: 6px;
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 1.2;
+  width: 100%;
+  font-size: 0.66rem;
+  font-weight: 400;
+  line-height: 1.25;
   color: inherit;
   opacity: 0.92;
   text-align: center;
@@ -2129,8 +2135,9 @@ button.hero-quick-link {
 }
 
 .ticket-button__note--partner {
-  font-weight: 600;
+  font-weight: 400;
   opacity: 1;
+  font-size: 0.8em;
 }
 
 .ticket-button__note-text {


### PR DESCRIPTION
## Summary
- soften the ticket button note text by reducing its size and returning it to normal weight so the partner helper copy reads lighter
- align the museum primary action label and helper note on the same baseline so "Opens official website" lines up with "Buy tickets"

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d28208b2c8832688757aab54bdd028