### PR TITLE
Add external link icon to official ticket note

### DIFF
--- a/components/TicketButtonNote.js
+++ b/components/TicketButtonNote.js
@@ -1,33 +1,30 @@
-export default function TicketButtonNote({ affiliate = false, children, id }) {
+export default function TicketButtonNote({ affiliate = false, showIcon = true, children, id }) {
   if (!children) {
     return null;
   }
 
   const noteClassName = `ticket-button__note${affiliate ? ' ticket-button__note--partner' : ''}`;
+  const shouldShowIcon = affiliate || showIcon;
 
   return (
     <span className={noteClassName} id={id}>
-      {affiliate ? (
-        <>
-          <svg
-            className="ticket-button__note-icon"
-            viewBox="0 0 20 20"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M11.25 2.75h6v6" />
-            <path d="M17.25 2.75 9.5 10.5" />
-            <path d="M6.5 5.5H2.75v11.75h11.75V13" />
-          </svg>
-          <span className="ticket-button__note-text">{children}</span>
-        </>
-      ) : (
-        <span className="ticket-button__note-text">{children}</span>
-      )}
+      {shouldShowIcon ? (
+        <svg
+          className="ticket-button__note-icon"
+          viewBox="0 0 20 20"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M11.25 2.75h6v6" />
+          <path d="M17.25 2.75 9.5 10.5" />
+          <path d="M6.5 5.5H2.75v11.75h11.75V13" />
+        </svg>
+      ) : null}
+      <span className="ticket-button__note-text">{children}</span>
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- always render the external-link icon in TicketButtonNote so official-site links also show the indicator

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d291c505248326b9debdc195d135fd