### PR TITLE
Add affiliate tooltip info to ticket buttons

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -304,7 +304,11 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
           >
             <span className="ticket-button__label">{t('buyTickets')}</span>
             {ticketContext ? (
-              <TicketButtonNote affiliate={showAffiliateNote} id={ticketNoteId}>
+              <TicketButtonNote
+                affiliate={showAffiliateNote}
+                id={ticketNoteId}
+                infoMessage={ticketHoverMessage}
+              >
                 {ticketContext}
               </TicketButtonNote>
             ) : null}

--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -146,7 +146,9 @@ export default function MuseumCard({ museum }) {
           title={ticketHoverMessage}
         >
           <span className="ticket-button__label">{t('buyTickets')}</span>
-          <TicketButtonNote affiliate={showAffiliateNote}>{ticketContext}</TicketButtonNote>
+          <TicketButtonNote affiliate={showAffiliateNote} infoMessage={ticketHoverMessage}>
+            {ticketContext}
+          </TicketButtonNote>
         </a>
       );
     }

--- a/components/TicketButtonNote.js
+++ b/components/TicketButtonNote.js
@@ -1,13 +1,79 @@
-export default function TicketButtonNote({ affiliate = false, showIcon = true, children, id }) {
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+
+export default function TicketButtonNote({
+  affiliate = false,
+  showIcon = true,
+  infoMessage,
+  children,
+  id,
+}) {
+  const noteRef = useRef(null);
+  const tooltipId = useId();
+  const [isTooltipPinned, setTooltipPinned] = useState(false);
+
+  const shouldShowIcon = affiliate || showIcon;
+  const shouldShowInfo = Boolean(affiliate && infoMessage);
+  const noteClassName = `ticket-button__note${affiliate ? ' ticket-button__note--partner' : ''}`;
+
+  const handleInfoToggle = useCallback((event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (shouldShowInfo) {
+      setTooltipPinned((value) => !value);
+    }
+  }, [shouldShowInfo]);
+
+  const handleInfoKeyDown = useCallback((event) => {
+    if (!shouldShowInfo) {
+      return;
+    }
+
+    if (event.key === ' ' || event.key === 'Enter') {
+      event.preventDefault();
+      event.stopPropagation();
+      setTooltipPinned((value) => !value);
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopPropagation();
+      setTooltipPinned(false);
+    }
+  }, [shouldShowInfo]);
+
+  useEffect(() => {
+    if (!shouldShowInfo || !isTooltipPinned) {
+      return undefined;
+    }
+
+    const handlePointerDown = (event) => {
+      if (!noteRef.current) {
+        return;
+      }
+
+      if (!noteRef.current.contains(event.target)) {
+        setTooltipPinned(false);
+      }
+    };
+
+    const handleDocumentKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        setTooltipPinned(false);
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleDocumentKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleDocumentKeyDown);
+    };
+  }, [isTooltipPinned, shouldShowInfo]);
+
   if (!children) {
     return null;
   }
 
-  const noteClassName = `ticket-button__note${affiliate ? ' ticket-button__note--partner' : ''}`;
-  const shouldShowIcon = affiliate || showIcon;
-
   return (
-    <span className={noteClassName} id={id}>
+    <span className={noteClassName} id={id} ref={noteRef}>
       {shouldShowIcon ? (
         <svg
           className="ticket-button__note-icon"
@@ -25,6 +91,45 @@ export default function TicketButtonNote({ affiliate = false, showIcon = true, c
         </svg>
       ) : null}
       <span className="ticket-button__note-text">{children}</span>
+      {shouldShowInfo ? (
+        <span className="ticket-button__affiliate-info-group">
+          <span
+            className="ticket-button__affiliate-info"
+            role="button"
+            tabIndex={0}
+            aria-haspopup="true"
+            aria-controls={tooltipId}
+            aria-expanded={isTooltipPinned}
+            aria-pressed={isTooltipPinned}
+            aria-label={infoMessage}
+            onClick={handleInfoToggle}
+            onKeyDown={handleInfoKeyDown}
+          >
+            <svg
+              className="ticket-button__affiliate-info-icon"
+              viewBox="0 0 20 20"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="10" cy="10" r="7.25" />
+              <path d="M10 9.25v4" />
+              <circle cx="10" cy="6.5" r="0.75" fill="currentColor" stroke="none" />
+            </svg>
+          </span>
+          <span
+            id={tooltipId}
+            role="tooltip"
+            className="ticket-button__affiliate-tooltip"
+            data-visible={isTooltipPinned ? 'true' : undefined}
+          >
+            {infoMessage}
+          </span>
+        </span>
+      ) : null}
     </span>
   );
 }

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -1092,7 +1092,11 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
             >
               <span className="ticket-button__label">{t('buyTickets')}</span>
               {ticketContext ? (
-                <TicketButtonNote affiliate={showAffiliateNote} id={primaryTicketNoteId}>
+                <TicketButtonNote
+                  affiliate={showAffiliateNote}
+                  id={primaryTicketNoteId}
+                  infoMessage={ticketHoverMessage}
+                >
                   {ticketContext}
                 </TicketButtonNote>
               ) : null}
@@ -1520,7 +1524,11 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
                   >
                     <span className="ticket-button__label">{t('buyTickets')}</span>
                     {ticketContext ? (
-                      <TicketButtonNote affiliate={showAffiliateNote} id={mobileTicketNoteId}>
+                      <TicketButtonNote
+                        affiliate={showAffiliateNote}
+                        id={mobileTicketNoteId}
+                        infoMessage={ticketHoverMessage}
+                      >
                         {ticketContext}
                       </TicketButtonNote>
                     ) : null}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2132,6 +2132,7 @@ button.hero-quick-link {
   opacity: 0.92;
   text-align: center;
   max-width: 100%;
+  position: relative;
 }
 
 .ticket-button__note--partner {
@@ -2149,6 +2150,109 @@ button.hero-quick-link {
   width: 12px;
   height: 12px;
   flex-shrink: 0;
+}
+
+.ticket-button__affiliate-info-group {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.ticket-button__affiliate-info {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  cursor: pointer;
+  color: inherit;
+  background: transparent;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease,
+    transform 0.2s ease;
+}
+
+.ticket-button__affiliate-info:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(255,255,255,0.65), 0 0 0 4px rgba(15,23,42,0.38);
+}
+
+.ticket-button__affiliate-info:hover {
+  background: rgba(15,23,42,0.12);
+}
+
+.ticket-button__affiliate-info:active {
+  transform: translateY(1px);
+}
+
+.ticket-button__affiliate-info-icon {
+  width: 12px;
+  height: 12px;
+}
+
+.ticket-button__affiliate-tooltip {
+  position: absolute;
+  bottom: calc(100% + 12px);
+  left: 50%;
+  transform: translate(-50%, 4px);
+  background: rgba(15,23,42,0.92);
+  color: #ffffff;
+  padding: 8px 12px;
+  border-radius: 10px;
+  box-shadow: 0 12px 24px rgba(15,23,42,0.2);
+  font-size: 0.75rem;
+  line-height: 1.35;
+  width: max-content;
+  max-width: min(260px, 80vw);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 30;
+  text-align: left;
+}
+
+.ticket-button__affiliate-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: rgba(15,23,42,0.92) transparent transparent transparent;
+}
+
+.ticket-button:hover .ticket-button__affiliate-tooltip,
+.ticket-button:focus-within .ticket-button__affiliate-tooltip,
+.ticket-button__affiliate-tooltip[data-visible='true'] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+  pointer-events: auto;
+}
+
+[data-theme='dark'] .ticket-button__affiliate-info {
+  border-color: rgba(255,255,255,0.7);
+}
+
+[data-theme='dark'] .ticket-button__affiliate-info:hover {
+  background: rgba(255,255,255,0.16);
+}
+
+[data-theme='dark'] .ticket-button__affiliate-info:focus-visible {
+  box-shadow: 0 0 0 2px rgba(255,255,255,0.85), 0 0 0 5px rgba(255,120,79,0.6);
+}
+
+[data-theme='dark'] .ticket-button__affiliate-tooltip {
+  background: rgba(248,250,252,0.95);
+  color: #0f172a;
+  box-shadow: 0 18px 28px rgba(15,23,42,0.28);
+}
+
+[data-theme='dark'] .ticket-button__affiliate-tooltip::after {
+  border-color: rgba(248,250,252,0.95) transparent transparent transparent;
 }
 
 [data-theme='dark'] .ticket-button:focus-visible {

--- a/tests/ticketCta.test.cjs
+++ b/tests/ticketCta.test.cjs
@@ -28,6 +28,7 @@ const legacyTooltipPattern = /title={t\('affiliateLink'\)}/;
 const legacyNotePattern = /className="affiliate-note"/;
 const newNotePattern = /TicketButtonNote/;
 const hoverTitlePattern = /title={ticketHoverMessage}/;
+const infoMessagePattern = /infoMessage={ticketHoverMessage}/;
 
 for (const file of files) {
   const content = fs.readFileSync(file, 'utf8');
@@ -35,6 +36,7 @@ for (const file of files) {
   assert(!legacyNotePattern.test(content), `Legacy affiliate note class found in ${file}`);
   assert(newNotePattern.test(content), `Ticket note missing in ${file}`);
   assert(hoverTitlePattern.test(content), `Affiliate hover title missing in ${file}`);
+  assert(infoMessagePattern.test(content), `Affiliate info tooltip missing in ${file}`);
 }
 
 console.log('Ticket CTA copy tests passed.');


### PR DESCRIPTION
## Summary
- add an info icon and tooltip to ticket buttons that explains affiliate commissions on hover or click
- style the new tooltip for light and dark themes and close it when clicking outside
- extend CTA tests to cover the new tooltip prop usage
- update the tooltip logic so it only toggles when affiliate info is available, stays accessible to assistive tech, and can also be dismissed with Escape

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2936966d883268f54b0a04c2509c1