### PR TITLE
Position affiliate info icon alongside ticket label

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -3,6 +3,7 @@ import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useLanguage } from './LanguageContext';
 import { useFavorites } from './FavoritesContext';
 import { shouldShowAffiliateNote } from '../lib/nonAffiliateMuseums';
+import TicketButtonAffiliateInfo from './TicketButtonAffiliateInfo';
 import TicketButtonNote from './TicketButtonNote';
 
 const FALLBACK_IMAGE = '/images/exposition-placeholder.svg';
@@ -302,16 +303,26 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
             aria-describedby={ctaDescribedBy}
             title={ticketHoverMessage}
           >
-            <span className="ticket-button__label">{t('buyTickets')}</span>
+            <span className="ticket-button__label">
+              {showAffiliateNote ? (
+                <TicketButtonAffiliateInfo infoMessage={ticketHoverMessage} />
+              ) : null}
+              <span className="ticket-button__label-text">{t('buyTickets')}</span>
+            </span>
             {ticketContext ? (
-              <TicketButtonNote affiliate={showAffiliateNote} id={ticketNoteId}>
+              <TicketButtonNote
+                affiliate={showAffiliateNote}
+                id={ticketNoteId}
+              >
                 {ticketContext}
               </TicketButtonNote>
             ) : null}
           </a>
         ) : (
           <button type="button" className="ticket-button exposition-card__cta" disabled aria-disabled="true">
-            <span className="ticket-button__label">{t('buyTickets')}</span>
+            <span className="ticket-button__label">
+              <span className="ticket-button__label-text">{t('buyTickets')}</span>
+            </span>
           </button>
         )}
       </div>

--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -7,6 +7,7 @@ import museumSummaries from '../lib/museumSummaries';
 import museumOpeningHours from '../lib/museumOpeningHours';
 import { shouldShowAffiliateNote } from '../lib/nonAffiliateMuseums';
 import formatImageCredit from '../lib/formatImageCredit';
+import TicketButtonAffiliateInfo from './TicketButtonAffiliateInfo';
 import TicketButtonNote from './TicketButtonNote';
 
 const HOVER_COLORS = ['#A7D8F0', '#77DDDD', '#F7C59F', '#D8BFD8', '#EAE0C8'];
@@ -145,15 +146,24 @@ export default function MuseumCard({ museum }) {
           className={classNames}
           title={ticketHoverMessage}
         >
-          <span className="ticket-button__label">{t('buyTickets')}</span>
-          <TicketButtonNote affiliate={showAffiliateNote}>{ticketContext}</TicketButtonNote>
+          <span className="ticket-button__label">
+            {showAffiliateNote ? (
+              <TicketButtonAffiliateInfo infoMessage={ticketHoverMessage} />
+            ) : null}
+            <span className="ticket-button__label-text">{t('buyTickets')}</span>
+          </span>
+          <TicketButtonNote affiliate={showAffiliateNote}>
+            {ticketContext}
+          </TicketButtonNote>
         </a>
       );
     }
 
     return (
       <button type="button" className={classNames} disabled aria-disabled="true">
-        <span className="ticket-button__label">{t('buyTickets')}</span>
+        <span className="ticket-button__label">
+          <span className="ticket-button__label-text">{t('buyTickets')}</span>
+        </span>
       </button>
     );
   };

--- a/components/TicketButtonAffiliateInfo.js
+++ b/components/TicketButtonAffiliateInfo.js
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+
+export default function TicketButtonAffiliateInfo({ infoMessage, className = '' }) {
+  const infoRef = useRef(null);
+  const tooltipId = useId();
+  const [isTooltipPinned, setTooltipPinned] = useState(false);
+  const hasInfo = Boolean(infoMessage);
+
+  const handleInfoToggle = useCallback(
+    (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (!hasInfo) {
+        return;
+      }
+
+      setTooltipPinned((value) => !value);
+    },
+    [hasInfo]
+  );
+
+  const handleInfoKeyDown = useCallback(
+    (event) => {
+      if (!hasInfo) {
+        return;
+      }
+
+      if (event.key === ' ' || event.key === 'Enter') {
+        event.preventDefault();
+        event.stopPropagation();
+        setTooltipPinned((value) => !value);
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        event.stopPropagation();
+        setTooltipPinned(false);
+      }
+    },
+    [hasInfo]
+  );
+
+  useEffect(() => {
+    if (!hasInfo || !isTooltipPinned) {
+      return undefined;
+    }
+
+    const handlePointerDown = (event) => {
+      if (!infoRef.current) {
+        return;
+      }
+
+      if (!infoRef.current.contains(event.target)) {
+        setTooltipPinned(false);
+      }
+    };
+
+    const handleDocumentKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        setTooltipPinned(false);
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleDocumentKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleDocumentKeyDown);
+    };
+  }, [hasInfo, isTooltipPinned]);
+
+  if (!hasInfo) {
+    return null;
+  }
+
+  const groupClassName = className
+    ? `ticket-button__affiliate-info-group ${className}`
+    : 'ticket-button__affiliate-info-group';
+
+  return (
+    <span className={groupClassName} ref={infoRef}>
+      <span
+        className="ticket-button__affiliate-info"
+        role="button"
+        tabIndex={0}
+        aria-haspopup="true"
+        aria-controls={tooltipId}
+        aria-expanded={isTooltipPinned}
+        aria-pressed={isTooltipPinned}
+        aria-label={infoMessage}
+        onClick={handleInfoToggle}
+        onKeyDown={handleInfoKeyDown}
+      >
+        <svg
+          className="ticket-button__affiliate-info-icon"
+          viewBox="0 0 20 20"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="10" cy="10" r="7.25" />
+          <path d="M10 9.25v4" />
+          <circle cx="10" cy="6.5" r="0.75" fill="currentColor" stroke="none" />
+        </svg>
+      </span>
+      <span
+        id={tooltipId}
+        role="tooltip"
+        className="ticket-button__affiliate-tooltip"
+        data-visible={isTooltipPinned ? 'true' : undefined}
+      >
+        {infoMessage}
+      </span>
+    </span>
+  );
+}

--- a/components/TicketButtonNote.js
+++ b/components/TicketButtonNote.js
@@ -1,10 +1,15 @@
-export default function TicketButtonNote({ affiliate = false, showIcon = true, children, id }) {
+export default function TicketButtonNote({
+  affiliate = false,
+  showIcon = true,
+  children,
+  id,
+}) {
+  const shouldShowIcon = affiliate || showIcon;
+  const noteClassName = `ticket-button__note${affiliate ? ' ticket-button__note--partner' : ''}`;
+
   if (!children) {
     return null;
   }
-
-  const noteClassName = `ticket-button__note${affiliate ? ' ticket-button__note--partner' : ''}`;
-  const shouldShowIcon = affiliate || showIcon;
 
   return (
     <span className={noteClassName} id={id}>

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -10,6 +10,7 @@ import { useLanguage } from '../../components/LanguageContext';
 import { useFavorites } from '../../components/FavoritesContext';
 import FiltersSheet from '../../components/FiltersSheet';
 import FiltersPopover from '../../components/FiltersPopover';
+import TicketButtonAffiliateInfo from '../../components/TicketButtonAffiliateInfo';
 import TicketButtonNote from '../../components/TicketButtonNote';
 import museumImages from '../../lib/museumImages';
 import museumImageCredits from '../../lib/museumImageCredits';
@@ -1090,16 +1091,26 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
               onClick={handleTicketLinkClick}
               title={ticketHoverMessage}
             >
-              <span className="ticket-button__label">{t('buyTickets')}</span>
+              <span className="ticket-button__label">
+                {showAffiliateNote ? (
+                  <TicketButtonAffiliateInfo infoMessage={ticketHoverMessage} />
+                ) : null}
+                <span className="ticket-button__label-text">{t('buyTickets')}</span>
+              </span>
               {ticketContext ? (
-                <TicketButtonNote affiliate={showAffiliateNote} id={primaryTicketNoteId}>
+                <TicketButtonNote
+                  affiliate={showAffiliateNote}
+                  id={primaryTicketNoteId}
+                >
                   {ticketContext}
                 </TicketButtonNote>
               ) : null}
             </a>
           ) : (
             <button type="button" className="museum-primary-action primary" disabled aria-disabled="true">
-              <span className="ticket-button__label">{t('buyTickets')}</span>
+              <span className="ticket-button__label">
+                <span className="ticket-button__label-text">{t('buyTickets')}</span>
+              </span>
             </button>
           )}
 
@@ -1518,9 +1529,17 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
                     aria-describedby={ticketContext ? mobileTicketNoteId : undefined}
                     title={ticketHoverMessage}
                   >
-                    <span className="ticket-button__label">{t('buyTickets')}</span>
+                    <span className="ticket-button__label">
+                      {showAffiliateNote ? (
+                        <TicketButtonAffiliateInfo infoMessage={ticketHoverMessage} />
+                      ) : null}
+                      <span className="ticket-button__label-text">{t('buyTickets')}</span>
+                    </span>
                     {ticketContext ? (
-                      <TicketButtonNote affiliate={showAffiliateNote} id={mobileTicketNoteId}>
+                      <TicketButtonNote
+                        affiliate={showAffiliateNote}
+                        id={mobileTicketNoteId}
+                      >
                         {ticketContext}
                       </TicketButtonNote>
                     ) : null}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2118,6 +2118,16 @@ button.hero-quick-link {
   pointer-events: none;
   cursor: not-allowed;
 }
+.ticket-button__label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.ticket-button__label-text {
+  display: inline;
+}
 .ticket-button__note {
   display: inline-flex;
   align-items: center;
@@ -2132,6 +2142,7 @@ button.hero-quick-link {
   opacity: 0.92;
   text-align: center;
   max-width: 100%;
+  position: relative;
 }
 
 .ticket-button__note--partner {
@@ -2149,6 +2160,109 @@ button.hero-quick-link {
   width: 12px;
   height: 12px;
   flex-shrink: 0;
+}
+
+.ticket-button__affiliate-info-group {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.ticket-button__affiliate-info {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  cursor: pointer;
+  color: inherit;
+  background: transparent;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease,
+    transform 0.2s ease;
+}
+
+.ticket-button__affiliate-info:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(255,255,255,0.65), 0 0 0 4px rgba(15,23,42,0.38);
+}
+
+.ticket-button__affiliate-info:hover {
+  background: rgba(15,23,42,0.12);
+}
+
+.ticket-button__affiliate-info:active {
+  transform: translateY(1px);
+}
+
+.ticket-button__affiliate-info-icon {
+  width: 12px;
+  height: 12px;
+}
+
+.ticket-button__affiliate-tooltip {
+  position: absolute;
+  bottom: calc(100% + 12px);
+  left: 50%;
+  transform: translate(-50%, 4px);
+  background: rgba(15,23,42,0.92);
+  color: #ffffff;
+  padding: 8px 12px;
+  border-radius: 10px;
+  box-shadow: 0 12px 24px rgba(15,23,42,0.2);
+  font-size: 0.75rem;
+  line-height: 1.35;
+  width: max-content;
+  max-width: min(260px, 80vw);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 30;
+  text-align: left;
+}
+
+.ticket-button__affiliate-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: rgba(15,23,42,0.92) transparent transparent transparent;
+}
+
+.ticket-button:hover .ticket-button__affiliate-tooltip,
+.ticket-button:focus-within .ticket-button__affiliate-tooltip,
+.ticket-button__affiliate-tooltip[data-visible='true'] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+  pointer-events: auto;
+}
+
+[data-theme='dark'] .ticket-button__affiliate-info {
+  border-color: rgba(255,255,255,0.7);
+}
+
+[data-theme='dark'] .ticket-button__affiliate-info:hover {
+  background: rgba(255,255,255,0.16);
+}
+
+[data-theme='dark'] .ticket-button__affiliate-info:focus-visible {
+  box-shadow: 0 0 0 2px rgba(255,255,255,0.85), 0 0 0 5px rgba(255,120,79,0.6);
+}
+
+[data-theme='dark'] .ticket-button__affiliate-tooltip {
+  background: rgba(248,250,252,0.95);
+  color: #0f172a;
+  box-shadow: 0 18px 28px rgba(15,23,42,0.28);
+}
+
+[data-theme='dark'] .ticket-button__affiliate-tooltip::after {
+  border-color: rgba(248,250,252,0.95) transparent transparent transparent;
 }
 
 [data-theme='dark'] .ticket-button:focus-visible {

--- a/tests/ticketCta.test.cjs
+++ b/tests/ticketCta.test.cjs
@@ -28,6 +28,7 @@ const legacyTooltipPattern = /title={t\('affiliateLink'\)}/;
 const legacyNotePattern = /className="affiliate-note"/;
 const newNotePattern = /TicketButtonNote/;
 const hoverTitlePattern = /title={ticketHoverMessage}/;
+const affiliateInfoPattern = /TicketButtonAffiliateInfo infoMessage={ticketHoverMessage}/;
 
 for (const file of files) {
   const content = fs.readFileSync(file, 'utf8');
@@ -35,6 +36,7 @@ for (const file of files) {
   assert(!legacyNotePattern.test(content), `Legacy affiliate note class found in ${file}`);
   assert(newNotePattern.test(content), `Ticket note missing in ${file}`);
   assert(hoverTitlePattern.test(content), `Affiliate hover title missing in ${file}`);
+  assert(affiliateInfoPattern.test(content), `Affiliate info tooltip missing in ${file}`);
 }
 
 console.log('Ticket CTA copy tests passed.');


### PR DESCRIPTION
## Summary
- add a reusable TicketButtonAffiliateInfo component that owns the tooltip toggle logic and renders beside the CTA text
- update museum and exposition ticket buttons (desktop and mobile) to place the affiliate info icon to the left of the “Buy tickets” label while keeping the supporting note intact
- tweak ticket button styles and tests to accommodate the new label layout and component usage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2936966d883268f54b0a04c2509c1