### PR TITLE
Restyle ticket call-to-action

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1158,60 +1158,66 @@ button.hero-quick-link {
   justify-content: flex-end;
 }
 .museum-primary-action {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-8);
-  padding: var(--space-8) var(--space-24);
+  display: inline-grid;
+  grid-auto-rows: min-content;
+  align-content: center;
+  justify-items: start;
+  gap: calc(var(--space-8) - 2px);
+  padding: calc(var(--space-8) - 2px) calc(var(--space-24) - 4px);
   border-radius: var(--radius-md);
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 600;
-  line-height: 1.2;
+  line-height: 1.25;
   text-decoration: none;
   color: inherit;
   border: 1px solid transparent;
-  box-shadow: 0 8px 24px rgba(15,23,42,0.14);
+  box-shadow: 0 6px 20px rgba(15,23,42,0.12);
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-  min-height: 48px;
+  min-height: 44px;
+  width: min(100%, 320px);
+  max-width: 100%;
+  text-align: left;
 }
 
 .museum-primary-action .ticket-button__label,
 .museum-primary-action .ticket-button__note {
-  align-self: baseline;
+  width: 100%;
+  justify-content: flex-start;
+  text-align: left;
 }
 .museum-primary-action:hover {
   transform: translateY(-1px);
-  box-shadow: 0 12px 28px rgba(15,23,42,0.18);
+  box-shadow: 0 10px 26px rgba(15,23,42,0.16);
 }
 .museum-primary-action:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--focus-ring-outline),
     0 0 0 5px var(--focus-ring-shadow),
-    0 14px 30px rgba(15,23,42,0.2);
+    0 12px 26px rgba(15,23,42,0.18);
 }
 .museum-primary-action:active {
   transform: translateY(0);
-  box-shadow: 0 6px 18px rgba(15,23,42,0.16);
+  box-shadow: 0 6px 18px rgba(15,23,42,0.14);
 }
 .museum-primary-action.primary {
   background: var(--accent);
   color: var(--accent-ink);
-  box-shadow: 0 10px 28px rgba(255,90,60,0.26);
+  box-shadow: 0 8px 24px rgba(255,90,60,0.24);
 }
 .museum-primary-action.primary:focus-visible {
   box-shadow: 0 0 0 2px var(--focus-ring-outline),
     0 0 0 5px var(--focus-ring-shadow),
-    0 14px 32px rgba(255,90,60,0.3);
+    0 12px 28px rgba(255,90,60,0.28);
 }
 .museum-primary-action.primary:hover {
-  box-shadow: 0 16px 34px rgba(255,90,60,0.32);
+  box-shadow: 0 12px 30px rgba(255,90,60,0.3);
 }
 .museum-primary-action.primary[disabled],
 .museum-primary-action.primary[aria-disabled="true"] {
   opacity: 0.55;
   cursor: not-allowed;
   transform: none;
-  box-shadow: 0 6px 18px rgba(15,23,42,0.12);
+  box-shadow: 0 6px 18px rgba(15,23,42,0.1);
 }
 .museum-primary-action.secondary {
   background: rgba(255,255,255,0.88);
@@ -2068,44 +2074,46 @@ button.hero-quick-link {
 .ticket-button {
   padding: 6px 12px;
   border: none;
-  border-radius: 8px;
+  border-radius: 10px;
   background: var(--accent);
   color: var(--accent-ink);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
   letter-spacing: 0.025em;
   cursor: pointer;
-  box-shadow: 0 12px 24px rgba(15,23,42,0.14);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
+  box-shadow: 0 10px 22px rgba(15,23,42,0.12);
+  display: inline-grid;
+  grid-auto-rows: min-content;
+  align-content: center;
+  justify-items: center;
   text-align: center;
   text-decoration: none;
   gap: 4px;
   min-width: 0;
+  width: fit-content;
+  max-width: 100%;
   transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease, color 0.3s ease;
 }
 .ticket-button:hover {
   background: var(--accent-ink);
   color: var(--accent);
-  transform: translateY(-2px);
-  box-shadow: 0 18px 30px rgba(15,23,42,0.18);
+  transform: translateY(-1px);
+  box-shadow: 0 14px 24px rgba(15,23,42,0.16);
 }
 .ticket-button:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--focus-ring-outline),
     0 0 0 5px var(--focus-ring-shadow),
-    0 18px 32px rgba(15,23,42,0.22);
+    0 12px 24px rgba(15,23,42,0.18);
 }
 .ticket-button:active {
   transform: translateY(0);
-  box-shadow: 0 12px 22px rgba(15,23,42,0.16);
+  box-shadow: 0 8px 18px rgba(15,23,42,0.15);
 }
 .museum-info-links .ticket-button {
-  width: 100%;
-  padding: 12px 20px;
-  box-shadow: 0 12px 24px rgba(15,23,42,0.14);
+  width: min(100%, 320px);
+  padding: 10px 18px;
+  box-shadow: 0 10px 22px rgba(15,23,42,0.12);
 }
 @media (min-width: 601px) {
   .museum-info-links .ticket-button {
@@ -2122,7 +2130,8 @@ button.hero-quick-link {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: 4px;
+  line-height: 1.2;
 }
 
 .ticket-button__label-text {
@@ -2133,11 +2142,11 @@ button.hero-quick-link {
   align-items: center;
   justify-content: center;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 4px;
   width: 100%;
-  font-size: 0.66rem;
+  font-size: 0.64rem;
   font-weight: 400;
-  line-height: 1.25;
+  line-height: 1.2;
   color: inherit;
   opacity: 0.92;
   text-align: center;
@@ -2148,7 +2157,7 @@ button.hero-quick-link {
 .ticket-button__note--partner {
   font-weight: 400;
   opacity: 1;
-  font-size: 0.8em;
+  font-size: 0.6rem;
 }
 
 .ticket-button__note-text {


### PR DESCRIPTION
## Summary
- restyled the museum ticket CTA to use a compact inline-grid layout with reduced spacing, softer shadows and left-aligned text so it feels lighter while staying in place
- tightened the shared ticket button styling and info-link variant by shrinking typography, gaps and width to keep all copy visible without the button feeling oversized

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2b7f0c9088326af0c387c05049798