### PR TITLE
Shrink ticket CTA footprint

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1159,59 +1159,64 @@ button.hero-quick-link {
 }
 .museum-primary-action {
   display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-8);
-  padding: var(--space-8) var(--space-24);
-  border-radius: var(--radius-md);
-  font-size: 15px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  padding: 3px 10px;
+  border-radius: 8px;
+  font-size: 0.7rem;
   font-weight: 600;
-  line-height: 1.2;
+  line-height: 1.15;
   text-decoration: none;
   color: inherit;
   border: 1px solid transparent;
-  box-shadow: 0 8px 24px rgba(15,23,42,0.14);
+  box-shadow: 0 3px 12px rgba(15,23,42,0.12);
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-  min-height: 48px;
+  min-height: 0;
+  width: fit-content;
+  max-width: 100%;
+  text-align: left;
 }
 
 .museum-primary-action .ticket-button__label,
 .museum-primary-action .ticket-button__note {
-  align-self: baseline;
+  width: 100%;
+  justify-content: flex-start;
+  text-align: left;
 }
 .museum-primary-action:hover {
   transform: translateY(-1px);
-  box-shadow: 0 12px 28px rgba(15,23,42,0.18);
+  box-shadow: 0 10px 26px rgba(15,23,42,0.16);
 }
 .museum-primary-action:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--focus-ring-outline),
     0 0 0 5px var(--focus-ring-shadow),
-    0 14px 30px rgba(15,23,42,0.2);
+    0 12px 26px rgba(15,23,42,0.18);
 }
 .museum-primary-action:active {
   transform: translateY(0);
-  box-shadow: 0 6px 18px rgba(15,23,42,0.16);
+  box-shadow: 0 6px 18px rgba(15,23,42,0.14);
 }
 .museum-primary-action.primary {
   background: var(--accent);
   color: var(--accent-ink);
-  box-shadow: 0 10px 28px rgba(255,90,60,0.26);
+  box-shadow: 0 8px 24px rgba(255,90,60,0.24);
 }
 .museum-primary-action.primary:focus-visible {
   box-shadow: 0 0 0 2px var(--focus-ring-outline),
     0 0 0 5px var(--focus-ring-shadow),
-    0 14px 32px rgba(255,90,60,0.3);
+    0 12px 28px rgba(255,90,60,0.28);
 }
 .museum-primary-action.primary:hover {
-  box-shadow: 0 16px 34px rgba(255,90,60,0.32);
+  box-shadow: 0 12px 30px rgba(255,90,60,0.3);
 }
 .museum-primary-action.primary[disabled],
 .museum-primary-action.primary[aria-disabled="true"] {
   opacity: 0.55;
   cursor: not-allowed;
   transform: none;
-  box-shadow: 0 6px 18px rgba(15,23,42,0.12);
+  box-shadow: 0 6px 18px rgba(15,23,42,0.1);
 }
 .museum-primary-action.secondary {
   background: rgba(255,255,255,0.88);
@@ -2028,22 +2033,21 @@ button.hero-quick-link {
 }
 
 .ticket-button--card {
-  display: grid;
-  grid-auto-rows: min-content;
-  align-content: center;
-  justify-items: start;
-  width: clamp(120px, 38vw, 136px);
-  min-height: 44px;
-  padding: 6px 16px;
-  border-radius: 14px;
-  gap: 2px;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: clamp(88px, 32vw, 108px);
+  min-height: 0;
+  padding: 3px 9px;
+  border-radius: 8px;
+  gap: 1px;
   text-align: left;
-  line-height: 1.1;
+  line-height: 1.08;
 }
 
 .ticket-button--card .ticket-button__label {
   width: 100%;
-  font-size: 0.95rem;
+  font-size: 0.8rem;
   font-weight: 600;
   letter-spacing: 0.01em;
 }
@@ -2051,65 +2055,66 @@ button.hero-quick-link {
 .ticket-button--card .ticket-button__note {
   width: 100%;
   justify-content: flex-start;
-  font-size: 0.72rem;
-  line-height: 1.2;
-  gap: 4px;
+  font-size: 0.58rem;
+  line-height: 1.12;
+  gap: 2px;
   text-align: left;
 }
 
 .ticket-button--card .ticket-button__note-icon {
-  width: 11px;
-  height: 11px;
+  width: 9px;
+  height: 9px;
 }
 
 .ticket-button--card .ticket-button__note-text {
   flex: 1;
 }
 .ticket-button {
-  padding: 6px 12px;
+  padding: 3px 9px;
   border: none;
-  border-radius: 8px;
+  border-radius: 7px;
   background: var(--accent);
   color: var(--accent-ink);
-  font-size: 14px;
+  font-size: 0.7rem;
   font-weight: 600;
-  letter-spacing: 0.025em;
+  letter-spacing: 0.015em;
   cursor: pointer;
-  box-shadow: 0 12px 24px rgba(15,23,42,0.14);
-  display: flex;
+  box-shadow: 0 6px 14px rgba(15,23,42,0.12);
+  display: inline-flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   text-align: center;
   text-decoration: none;
-  gap: 4px;
+  gap: 1px;
   min-width: 0;
+  width: fit-content;
+  max-width: 100%;
   transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease, color 0.3s ease;
 }
 .ticket-button:hover {
   background: var(--accent-ink);
   color: var(--accent);
-  transform: translateY(-2px);
-  box-shadow: 0 18px 30px rgba(15,23,42,0.18);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(15,23,42,0.16);
 }
 .ticket-button:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--focus-ring-outline),
     0 0 0 5px var(--focus-ring-shadow),
-    0 18px 32px rgba(15,23,42,0.22);
+    0 10px 20px rgba(15,23,42,0.18);
 }
 .ticket-button:active {
   transform: translateY(0);
-  box-shadow: 0 12px 22px rgba(15,23,42,0.16);
+  box-shadow: 0 6px 16px rgba(15,23,42,0.15);
 }
 .museum-info-links .ticket-button {
-  width: 100%;
-  padding: 12px 20px;
-  box-shadow: 0 12px 24px rgba(15,23,42,0.14);
+  width: fit-content;
+  padding: 3px 9px;
+  box-shadow: 0 6px 14px rgba(15,23,42,0.12);
 }
 @media (min-width: 601px) {
   .museum-info-links .ticket-button {
-    width: auto;
+    width: fit-content;
   }
 }
 .ticket-button[disabled],
@@ -2122,7 +2127,8 @@ button.hero-quick-link {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: 2px;
+  line-height: 1.05;
 }
 
 .ticket-button__label-text {
@@ -2133,13 +2139,13 @@ button.hero-quick-link {
   align-items: center;
   justify-content: center;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 2px;
   width: 100%;
-  font-size: 0.66rem;
+  font-size: 0.55rem;
   font-weight: 400;
-  line-height: 1.25;
+  line-height: 1.1;
   color: inherit;
-  opacity: 0.92;
+  opacity: 0.88;
   text-align: center;
   max-width: 100%;
   position: relative;
@@ -2148,7 +2154,7 @@ button.hero-quick-link {
 .ticket-button__note--partner {
   font-weight: 400;
   opacity: 1;
-  font-size: 0.8em;
+  font-size: 0.5rem;
 }
 
 .ticket-button__note-text {
@@ -2157,8 +2163,8 @@ button.hero-quick-link {
 }
 
 .ticket-button__note-icon {
-  width: 12px;
-  height: 12px;
+  width: 9px;
+  height: 9px;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Summary
- further compressed the museum ticket CTA with tighter padding, smaller typography and lighter shadows while keeping its placement and copy intact
- slimmed the shared ticket button, card variant and info-link usage with reduced widths, typography and icon sizing so every instance renders as small as possible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2b7f0c9088326af0c387c05049798