### PR TITLE
Improve museum card image loading performance

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -32,7 +32,20 @@ function getHoverColor(slug, id) {
   return HOVER_COLORS[index];
 }
 
-export default function MuseumCard({ museum }) {
+function createBlurDataUrl(color) {
+  if (typeof color !== 'string' || !color) {
+    return 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 20"%3E%3Crect width="32" height="20" fill="%23e2e8f0" /%3E%3C/svg%3E';
+  }
+
+  const normalized = color.startsWith('#') ? color : `#${color}`;
+  const sanitized = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(normalized)
+    ? normalized
+    : '#e2e8f0';
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 20"><rect width="32" height="20" fill="${sanitized}" /></svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+export default function MuseumCard({ museum, priority = false }) {
   if (!museum) return null;
 
   const { favorites, toggleFavorite } = useFavorites();
@@ -42,6 +55,7 @@ export default function MuseumCard({ museum }) {
     () => getHoverColor(museum.slug, museum.id),
     [museum.slug, museum.id]
   );
+  const blurDataUrl = useMemo(() => createBlurDataUrl(hoverColor), [hoverColor]);
 
   const summary = museumSummaries[museum.slug]?.[lang] || museum.summary;
   const hours = museumOpeningHours[museum.slug]?.[lang];
@@ -237,6 +251,11 @@ export default function MuseumCard({ museum }) {
               sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
               className="museum-card-media"
               style={{ objectFit: 'cover' }}
+              placeholder="blur"
+              blurDataURL={blurDataUrl}
+              priority={priority}
+              loading={priority ? 'eager' : 'lazy'}
+              quality={70}
             />
           )}
           <div className="museum-card-overlay" aria-hidden="true">

--- a/pages/favorites.js
+++ b/pages/favorites.js
@@ -23,9 +23,9 @@ export default function FavoritesPage() {
             <>
               <h2 className="page-title">{t('favoriteMuseums')}</h2>
               <ul className="grid" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-                {museumFavorites.map((m) => (
+                {museumFavorites.map((m, index) => (
                   <li key={`m-${m.id}`}>
-                    <MuseumCard museum={m} />
+                    <MuseumCard museum={m} priority={index < 3} />
                   </li>
                 ))}
               </ul>

--- a/pages/index.js
+++ b/pages/index.js
@@ -475,7 +475,7 @@ export default function Home({ initialMuseums = [], initialError = null }) {
         <p>{t('noResults')}</p>
       ) : (
         <ul className="grid" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-          {results.map((m) => (
+          {results.map((m, index) => (
             <li key={m.id}>
               <MuseumCard
                 museum={{
@@ -489,6 +489,7 @@ export default function Home({ initialMuseums = [], initialError = null }) {
                   imageCredit: museumImageCredits[m.slug],
                   ticketUrl: m.ticket_affiliate_url || museumTicketUrls[m.slug] || m.website_url,
                 }}
+                priority={index < 6}
               />
             </li>
           ))}


### PR DESCRIPTION
## Summary
- add generated blur placeholders and tuned quality settings for museum card images
- prioritize the first batch of cards on list pages so above-the-fold photos load eagerly
- extend the same optimized behavior to the favorites grid

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d64be142248326b705fb27d7ca9cd0