### PR TITLE
Add affiliate disclosure to ticket buttons

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -141,11 +141,14 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
   const ticketHoverMessage = showAffiliateNote ? t('ticketsAffiliateDisclosure') : undefined;
   const ticketContext = showAffiliateNote
     ? [
-        <span key="partner" className="ticket-button__note-line">
-          {t('ticketsViaPartner')}
+        <span key="intro" className="ticket-button__note-line">
+          {t('ticketsAffiliateIntro')}
         </span>,
         <span key="disclosure" className="ticket-button__note-line ticket-button__note-disclosure">
           {t('ticketsAffiliateDisclosure')}
+        </span>,
+        <span key="prices" className="ticket-button__note-line ticket-button__note-disclosure">
+          {t('ticketsAffiliatePricesMayVary')}
         </span>,
       ]
     : null;
@@ -306,6 +309,16 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
             ))}
           </ul>
         )}
+        {ticketContext ? (
+          <TicketButtonNote
+            affiliate={showAffiliateNote}
+            showIcon={false}
+            id={ticketNoteId}
+            className="exposition-card__affiliate-note"
+          >
+            {ticketContext}
+          </TicketButtonNote>
+        ) : null}
       </div>
       <div className="exposition-card__footer">
         {buyUrl ? (
@@ -332,24 +345,22 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
                   />
                 </svg>
               </span>
-              <span className="ticket-button__label-text">{t('buyTickets')}</span>
-              {showAffiliateNote ? (
-                <span className="ticket-button__badge">
-                  {t('ticketsPartnerBadge')}
-                  <span className="sr-only"> — {t('ticketsViaPartner')}</span>
-                </span>
-              ) : null}
-            </a>
-            {ticketContext ? (
-              <TicketButtonNote
-                affiliate={showAffiliateNote}
-                showIcon={false}
-                id={ticketNoteId}
-                className="ticket-button__overlay-note"
+              <span
+                className={
+                  showAffiliateNote
+                    ? 'ticket-button__label ticket-button__label--stacked'
+                    : 'ticket-button__label'
+                }
               >
-                {ticketContext}
-              </TicketButtonNote>
-            ) : null}
+                <span className="ticket-button__label-text">{t('buyTickets')}</span>
+                {showAffiliateNote ? (
+                  <span className="ticket-button__badge">
+                    {t('ticketsPartnerBadge')}
+                    <span className="sr-only"> — {t('ticketsAffiliateIntro')}</span>
+                  </span>
+                ) : null}
+              </span>
+            </a>
           </Fragment>
         ) : (
           <button
@@ -358,6 +369,18 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
             disabled
             aria-disabled="true"
           >
+            <span className="ticket-button__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M4.5 7.75a1.75 1.75 0 0 1 1.75-1.75h4.5v2a1.75 1.75 0 1 0 0 3.5v2h-4.5A1.75 1.75 0 0 1 4.5 11.75v-4Z"
+                  fill="currentColor"
+                />
+                <path
+                  d="M13.25 16.25v-2a1.75 1.75 0 1 0 0-3.5v-2h4.5a1.75 1.75 0 0 1 1.75 1.75v4a1.75 1.75 0 0 1-1.75 1.75h-4.5Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
             <span className="ticket-button__label">
               <span className="ticket-button__label-text">{t('buyTickets')}</span>
             </span>

--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -1,9 +1,8 @@
 import Image from 'next/image';
-import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { Fragment, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useLanguage } from './LanguageContext';
 import { useFavorites } from './FavoritesContext';
 import { shouldShowAffiliateNote } from '../lib/nonAffiliateMuseums';
-import TicketButtonAffiliateInfo from './TicketButtonAffiliateInfo';
 import TicketButtonNote from './TicketButtonNote';
 
 const FALLBACK_IMAGE = '/images/exposition-placeholder.svg';
@@ -149,11 +148,11 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
           {t('ticketsAffiliateDisclosure')}
         </span>,
       ]
-    : [
-        <span key="official" className="ticket-button__note-line">
-          {t('ticketsViaOfficialSite')}
-        </span>,
-      ];
+    : null;
+  const ticketRel = showAffiliateNote ? 'sponsored noopener noreferrer' : 'noopener noreferrer';
+  const ticketAriaLabel = showAffiliateNote
+    ? `${t('buyTickets')} — ${t('ticketsAffiliateDisclosure')}`
+    : t('buyTickets');
   const ticketNoteId = useId();
   const ctaDescribedBy = ticketContext ? ticketNoteId : undefined;
 
@@ -237,7 +236,7 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
 
   return (
     <article
-      className={`exposition-card${isFavoriteBouncing ? ' is-bouncing' : ''} rounded-xl border border-slate-200 bg-white shadow-sm transition duration-200 hover:shadow-lg dark:border-slate-700/60 dark:bg-slate-900`}
+      className={`exposition-card${isFavoriteBouncing ? ' is-bouncing' : ''}`}
     >
       <div className={mediaClassName} aria-busy={!isImageLoaded}>
         {!isImageLoaded && (
@@ -310,33 +309,52 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
       </div>
       <div className="exposition-card__footer">
         {buyUrl ? (
-          <a
-            href={buyUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="ticket-button exposition-card__cta inline-flex items-center justify-center font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-sky-500 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
-            aria-describedby={ctaDescribedBy}
-            title={ticketHoverMessage}
-          >
-            <span className="ticket-button__label">
-              {showAffiliateNote ? (
-                <TicketButtonAffiliateInfo infoMessage={ticketHoverMessage} />
-              ) : null}
+          <Fragment>
+            <a
+              href={buyUrl}
+              target="_blank"
+              rel={ticketRel}
+              className="ticket-button exposition-card__cta"
+              aria-describedby={ctaDescribedBy}
+              title={ticketHoverMessage}
+              aria-label={ticketAriaLabel}
+              data-affiliate={showAffiliateNote ? 'true' : undefined}
+            >
+              <span className="ticket-button__icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path
+                    d="M4.5 7.75a1.75 1.75 0 0 1 1.75-1.75h4.5v2a1.75 1.75 0 1 0 0 3.5v2h-4.5A1.75 1.75 0 0 1 4.5 11.75v-4Z"
+                    fill="currentColor"
+                  />
+                  <path
+                    d="M13.25 16.25v-2a1.75 1.75 0 1 0 0-3.5v-2h4.5a1.75 1.75 0 0 1 1.75 1.75v4a1.75 1.75 0 0 1-1.75 1.75h-4.5Z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
               <span className="ticket-button__label-text">{t('buyTickets')}</span>
-            </span>
+              {showAffiliateNote ? (
+                <span className="ticket-button__badge">
+                  {t('ticketsPartnerBadge')}
+                  <span className="sr-only"> — {t('ticketsViaPartner')}</span>
+                </span>
+              ) : null}
+            </a>
             {ticketContext ? (
               <TicketButtonNote
                 affiliate={showAffiliateNote}
+                showIcon={false}
                 id={ticketNoteId}
+                className="ticket-button__overlay-note"
               >
                 {ticketContext}
               </TicketButtonNote>
             ) : null}
-          </a>
+          </Fragment>
         ) : (
           <button
             type="button"
-            className="ticket-button exposition-card__cta inline-flex items-center justify-center font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-sky-500 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+            className="ticket-button exposition-card__cta"
             disabled
             aria-disabled="true"
           >

--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -139,8 +139,21 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
   const sourceUrl = exposition.bron_url || null;
   const buyUrl = primaryAffiliateUrl || fallbackTicketUrl || sourceUrl;
   const showAffiliateNote = Boolean(primaryAffiliateUrl) && (!slug || shouldShowAffiliateNote(slug));
-  const ticketContext = t(showAffiliateNote ? 'ticketsViaPartner' : 'ticketsViaOfficialSite');
-  const ticketHoverMessage = showAffiliateNote ? t('ticketsAffiliateHover') : undefined;
+  const ticketHoverMessage = showAffiliateNote ? t('ticketsAffiliateDisclosure') : undefined;
+  const ticketContext = showAffiliateNote
+    ? [
+        <span key="partner" className="ticket-button__note-line">
+          {t('ticketsViaPartner')}
+        </span>,
+        <span key="disclosure" className="ticket-button__note-line ticket-button__note-disclosure">
+          {t('ticketsAffiliateDisclosure')}
+        </span>,
+      ]
+    : [
+        <span key="official" className="ticket-button__note-line">
+          {t('ticketsViaOfficialSite')}
+        </span>,
+      ];
   const ticketNoteId = useId();
   const ctaDescribedBy = ticketContext ? ticketNoteId : undefined;
 

--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -7,7 +7,6 @@ import museumSummaries from '../lib/museumSummaries';
 import museumOpeningHours from '../lib/museumOpeningHours';
 import { shouldShowAffiliateNote } from '../lib/nonAffiliateMuseums';
 import formatImageCredit from '../lib/formatImageCredit';
-import TicketButtonAffiliateInfo from './TicketButtonAffiliateInfo';
 import TicketButtonNote from './TicketButtonNote';
 
 const HOVER_COLORS = ['#A7D8F0', '#77DDDD', '#F7C59F', '#D8BFD8', '#EAE0C8'];
@@ -71,11 +70,11 @@ export default function MuseumCard({ museum, priority = false }) {
           {t('ticketsAffiliateDisclosure')}
         </span>,
       ]
-    : [
-        <span key="official" className="ticket-button__note-line">
-          {t('ticketsViaOfficialSite')}
-        </span>,
-      ];
+    : null;
+  const ticketRel = showAffiliateNote ? 'sponsored noopener noreferrer' : 'noopener noreferrer';
+  const ticketAriaLabel = showAffiliateNote
+    ? `${t('buyTickets')} — ${t('ticketsAffiliateDisclosure')}`
+    : t('buyTickets');
 
   const imageCredit = museum.imageCredit;
   const isPublicDomainImage = Boolean(imageCredit?.isPublicDomain);
@@ -162,41 +161,55 @@ export default function MuseumCard({ museum, priority = false }) {
   );
 
   const renderTicketButton = (className = '') => {
-    const baseClasses = [
-      'ticket-button',
-      'inline-flex',
-      'items-center',
-      'justify-center',
-      'font-medium',
-      'transition',
-      'focus-visible:outline-none',
-      'focus-visible:ring-2',
-      'focus-visible:ring-offset-2',
-      'focus-visible:ring-sky-500',
-      'focus-visible:ring-offset-white',
-      'dark:focus-visible:ring-offset-slate-900',
-    ];
+    const baseClasses = ['ticket-button'];
     const classNames = className ? `${baseClasses.join(' ')} ${className}` : baseClasses.join(' ');
 
     if (museum.ticketUrl) {
       return (
-        <a
-          href={museum.ticketUrl}
-          target="_blank"
-          rel="noreferrer"
-          className={classNames}
-          title={ticketHoverMessage}
-        >
-          <span className="ticket-button__label">
-            {showAffiliateNote ? (
-              <TicketButtonAffiliateInfo infoMessage={ticketHoverMessage} />
-            ) : null}
+        <Fragment>
+          <a
+            href={museum.ticketUrl}
+            target="_blank"
+            rel={ticketRel}
+            className={classNames}
+            title={ticketHoverMessage}
+            aria-label={ticketAriaLabel}
+            data-affiliate={showAffiliateNote ? 'true' : undefined}
+          >
+            <span className="ticket-button__icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M4.5 7.75a1.75 1.75 0 0 1 1.75-1.75h4.5v2a1.75 1.75 0 1 0 0 3.5v2h-4.5A1.75 1.75 0 0 1 4.5 11.75v-4Z"
+                  fill="currentColor"
+                />
+                <path
+                  d="M13.25 16.25v-2a1.75 1.75 0 1 0 0-3.5v-2h4.5a1.75 1.75 0 0 1 1.75 1.75v4a1.75 1.75 0 0 1-1.75 1.75h-4.5Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
             <span className="ticket-button__label-text">{t('buyTickets')}</span>
-          </span>
-          <TicketButtonNote affiliate={showAffiliateNote}>
-            {ticketContext}
-          </TicketButtonNote>
-        </a>
+            {showAffiliateNote ? (
+              <span className="ticket-button__badge">
+                {t('ticketsPartnerBadge')}
+                <span className="sr-only"> — {t('ticketsViaPartner')}</span>
+              </span>
+            ) : null}
+          </a>
+          {ticketContext ? (
+            <TicketButtonNote
+              affiliate={showAffiliateNote}
+              showIcon={false}
+              className="ticket-button__overlay-note"
+            >
+              {ticketContext}
+            </TicketButtonNote>
+          ) : null}
+        </Fragment>
       );
     }
 
@@ -246,10 +259,7 @@ export default function MuseumCard({ museum, priority = false }) {
   };
 
   return (
-    <article
-      className="museum-card group rounded-xl border border-slate-200 bg-white shadow-sm transition duration-200 hover:shadow-lg dark:border-slate-700/60 dark:bg-slate-900"
-      style={{ '--hover-bg': hoverColor }}
-    >
+    <article className="museum-card" style={{ '--hover-bg': hoverColor }}>
       <div className="museum-card-image">
         <Link
           href={{ pathname: '/museum/[slug]', query: { slug: museum.slug } }}
@@ -313,7 +323,7 @@ export default function MuseumCard({ museum, priority = false }) {
         </p>
       )}
       <div className="museum-card-info">
-        <h3 className="museum-card-title text-slate-900 dark:text-slate-100">
+        <h3 className="museum-card-title">
           <Link
             href={{ pathname: '/museum/[slug]', query: { slug: museum.slug } }}
             style={{ color: 'inherit', textDecoration: 'none' }}

--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -61,8 +61,21 @@ export default function MuseumCard({ museum, priority = false }) {
   const hours = museumOpeningHours[museum.slug]?.[lang];
   const locationText = [museum.city, museum.province].filter(Boolean).join(', ');
   const showAffiliateNote = Boolean(museum.ticketUrl) && shouldShowAffiliateNote(museum.slug);
-  const ticketContext = t(showAffiliateNote ? 'ticketsViaPartner' : 'ticketsViaOfficialSite');
-  const ticketHoverMessage = showAffiliateNote ? t('ticketsAffiliateHover') : undefined;
+  const ticketHoverMessage = showAffiliateNote ? t('ticketsAffiliateDisclosure') : undefined;
+  const ticketContext = showAffiliateNote
+    ? [
+        <span key="partner" className="ticket-button__note-line">
+          {t('ticketsViaPartner')}
+        </span>,
+        <span key="disclosure" className="ticket-button__note-line ticket-button__note-disclosure">
+          {t('ticketsAffiliateDisclosure')}
+        </span>,
+      ]
+    : [
+        <span key="official" className="ticket-button__note-line">
+          {t('ticketsViaOfficialSite')}
+        </span>,
+      ];
 
   const imageCredit = museum.imageCredit;
   const isPublicDomainImage = Boolean(imageCredit?.isPublicDomain);

--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import Image from 'next/image';
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useFavorites } from './FavoritesContext';
 import { useLanguage } from './LanguageContext';
 import museumSummaries from '../lib/museumSummaries';
@@ -60,14 +60,18 @@ export default function MuseumCard({ museum, priority = false }) {
   const hours = museumOpeningHours[museum.slug]?.[lang];
   const locationText = [museum.city, museum.province].filter(Boolean).join(', ');
   const showAffiliateNote = Boolean(museum.ticketUrl) && shouldShowAffiliateNote(museum.slug);
+  const ticketNoteId = useId();
   const ticketHoverMessage = showAffiliateNote ? t('ticketsAffiliateDisclosure') : undefined;
   const ticketContext = showAffiliateNote
     ? [
-        <span key="partner" className="ticket-button__note-line">
-          {t('ticketsViaPartner')}
+        <span key="intro" className="ticket-button__note-line">
+          {t('ticketsAffiliateIntro')}
         </span>,
         <span key="disclosure" className="ticket-button__note-line ticket-button__note-disclosure">
           {t('ticketsAffiliateDisclosure')}
+        </span>,
+        <span key="prices" className="ticket-button__note-line ticket-button__note-disclosure">
+          {t('ticketsAffiliatePricesMayVary')}
         </span>,
       ]
     : null;
@@ -165,6 +169,16 @@ export default function MuseumCard({ museum, priority = false }) {
     const classNames = className ? `${baseClasses.join(' ')} ${className}` : baseClasses.join(' ');
 
     if (museum.ticketUrl) {
+      const labelClassName = showAffiliateNote
+        ? 'ticket-button__label ticket-button__label--stacked'
+        : 'ticket-button__label';
+      const partnerBadge = showAffiliateNote ? (
+        <span className="ticket-button__badge">
+          {t('ticketsPartnerBadge')}
+          <span className="sr-only"> — {t('ticketsAffiliateIntro')}</span>
+        </span>
+      ) : null;
+
       return (
         <Fragment>
           <a
@@ -174,6 +188,7 @@ export default function MuseumCard({ museum, priority = false }) {
             className={classNames}
             title={ticketHoverMessage}
             aria-label={ticketAriaLabel}
+            aria-describedby={showAffiliateNote ? ticketNoteId : undefined}
             data-affiliate={showAffiliateNote ? 'true' : undefined}
           >
             <span className="ticket-button__icon" aria-hidden="true">
@@ -192,29 +207,33 @@ export default function MuseumCard({ museum, priority = false }) {
                 />
               </svg>
             </span>
-            <span className="ticket-button__label-text">{t('buyTickets')}</span>
-            {showAffiliateNote ? (
-              <span className="ticket-button__badge">
-                {t('ticketsPartnerBadge')}
-                <span className="sr-only"> — {t('ticketsViaPartner')}</span>
-              </span>
-            ) : null}
+            <span className={labelClassName}>
+              <span className="ticket-button__label-text">{t('buyTickets')}</span>
+              {partnerBadge}
+            </span>
           </a>
-          {ticketContext ? (
-            <TicketButtonNote
-              affiliate={showAffiliateNote}
-              showIcon={false}
-              className="ticket-button__overlay-note"
-            >
-              {ticketContext}
-            </TicketButtonNote>
-          ) : null}
         </Fragment>
       );
     }
 
     return (
       <button type="button" className={classNames} disabled aria-disabled="true">
+        <span className="ticket-button__icon" aria-hidden="true">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M4.5 7.75a1.75 1.75 0 0 1 1.75-1.75h4.5v2a1.75 1.75 0 1 0 0 3.5v2h-4.5A1.75 1.75 0 0 1 4.5 11.75v-4Z"
+              fill="currentColor"
+            />
+            <path
+              d="M13.25 16.25v-2a1.75 1.75 0 1 0 0-3.5v-2h4.5a1.75 1.75 0 0 1 1.75 1.75v4a1.75 1.75 0 0 1-1.75 1.75h-4.5Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
         <span className="ticket-button__label">
           <span className="ticket-button__label-text">{t('buyTickets')}</span>
         </span>
@@ -361,6 +380,16 @@ export default function MuseumCard({ museum, priority = false }) {
             <span className="tag">{t('free')}</span>
           </div>
         )}
+        {ticketContext ? (
+          <TicketButtonNote
+            affiliate={showAffiliateNote}
+            showIcon={false}
+            id={ticketNoteId}
+            className="museum-card__affiliate-note"
+          >
+            {ticketContext}
+          </TicketButtonNote>
+        ) : null}
       </div>
     </article>
   );

--- a/components/TicketButtonNote.js
+++ b/components/TicketButtonNote.js
@@ -2,12 +2,15 @@ import { Children, cloneElement, isValidElement } from 'react';
 
 export default function TicketButtonNote({
   affiliate = false,
-  showIcon = true,
+  showIcon,
   children,
   id,
+  className = '',
 }) {
-  const shouldShowIcon = affiliate || showIcon;
-  const noteClassName = `ticket-button__note${affiliate ? ' ticket-button__note--partner' : ''}`;
+  const shouldShowIcon = typeof showIcon === 'boolean' ? showIcon : affiliate;
+  const noteClassName = ['ticket-button__note', affiliate ? 'ticket-button__note--partner' : '', className]
+    .filter(Boolean)
+    .join(' ');
 
   const childArray = Children.toArray(children).filter(
     (child) => child !== null && child !== undefined && child !== false

--- a/components/TicketButtonNote.js
+++ b/components/TicketButtonNote.js
@@ -1,3 +1,5 @@
+import { Children, cloneElement, isValidElement } from 'react';
+
 export default function TicketButtonNote({
   affiliate = false,
   showIcon = true,
@@ -7,9 +9,27 @@ export default function TicketButtonNote({
   const shouldShowIcon = affiliate || showIcon;
   const noteClassName = `ticket-button__note${affiliate ? ' ticket-button__note--partner' : ''}`;
 
-  if (!children) {
+  const childArray = Children.toArray(children).filter(
+    (child) => child !== null && child !== undefined && child !== false
+  );
+
+  if (childArray.length === 0) {
     return null;
   }
+
+  const noteLines = childArray.map((child, index) => {
+    if (isValidElement(child)) {
+      return cloneElement(child, {
+        key: child.key ?? `ticket-note-line-${index}`,
+      });
+    }
+
+    return (
+      <span key={`ticket-note-line-${index}`} className="ticket-button__note-line">
+        {child}
+      </span>
+    );
+  });
 
   return (
     <span className={noteClassName} id={id}>
@@ -29,7 +49,7 @@ export default function TicketButtonNote({
           <path d="M6.5 5.5H2.75v11.75h11.75V13" />
         </svg>
       ) : null}
-      <span className="ticket-button__note-text">{children}</span>
+      <span className="ticket-button__note-text">{noteLines}</span>
     </span>
   );
 }

--- a/lib/translations.js
+++ b/lib/translations.js
@@ -90,6 +90,7 @@ const translations = {
     location: 'Location',
     ticketsViaOfficialSite: 'Opens official website',
     ticketsViaPartner: 'Opens partner website',
+    ticketsPartnerBadge: 'Partner',
     ticketsAffiliateHover: 'MuseumBuddy may receive a commission when you buy via this partner.',
     ticketsAffiliateDisclosure:
       'Partner link — MuseumBuddy may receive a commission when you buy via this link.',
@@ -196,6 +197,7 @@ const translations = {
     location: 'Locatie',
     ticketsViaOfficialSite: 'Opent officiële website',
     ticketsViaPartner: 'Opent partnerwebsite',
+    ticketsPartnerBadge: 'Partner',
     ticketsAffiliateHover: 'MuseumBuddy ontvangt mogelijk een commissie wanneer je via deze partner koopt.',
     ticketsAffiliateDisclosure:
       'Partnerlink — MuseumBuddy ontvangt mogelijk commissie bij aankoop via deze link.',

--- a/lib/translations.js
+++ b/lib/translations.js
@@ -92,8 +92,9 @@ const translations = {
     ticketsViaPartner: 'Opens partner website',
     ticketsPartnerBadge: 'Partner',
     ticketsAffiliateHover: 'MuseumBuddy may receive a commission when you buy via this partner.',
-    ticketsAffiliateDisclosure:
-      'Partner link — MuseumBuddy may receive a commission when you buy via this link.',
+    ticketsAffiliateIntro: 'You buy tickets via an affiliate partner.',
+    ticketsAffiliateDisclosure: 'MuseumBuddy may receive a commission when you buy via this link.',
+    ticketsAffiliatePricesMayVary: 'Prices may vary.',
     breadcrumbsLabel: 'Breadcrumbs',
     breadcrumbMuseums: 'Museums',
     breadcrumbExhibitions: 'Exhibitions',
@@ -199,8 +200,9 @@ const translations = {
     ticketsViaPartner: 'Opent partnerwebsite',
     ticketsPartnerBadge: 'Partner',
     ticketsAffiliateHover: 'MuseumBuddy ontvangt mogelijk een commissie wanneer je via deze partner koopt.',
-    ticketsAffiliateDisclosure:
-      'Partnerlink — MuseumBuddy ontvangt mogelijk commissie bij aankoop via deze link.',
+    ticketsAffiliateIntro: 'Je koopt tickets via een affiliate partner.',
+    ticketsAffiliateDisclosure: 'MuseumBuddy ontvangt mogelijk commissie bij aankoop via deze link.',
+    ticketsAffiliatePricesMayVary: 'Prijzen kunnen afwijken.',
     breadcrumbsLabel: 'Kruimelpad',
     breadcrumbMuseums: 'Musea',
     breadcrumbExhibitions: 'Tentoonstellingen',

--- a/lib/translations.js
+++ b/lib/translations.js
@@ -91,6 +91,8 @@ const translations = {
     ticketsViaOfficialSite: 'Opens official website',
     ticketsViaPartner: 'Opens partner website',
     ticketsAffiliateHover: 'MuseumBuddy may receive a commission when you buy via this partner.',
+    ticketsAffiliateDisclosure:
+      'Partner link — MuseumBuddy may receive a commission when you buy via this link.',
     breadcrumbsLabel: 'Breadcrumbs',
     breadcrumbMuseums: 'Museums',
     breadcrumbExhibitions: 'Exhibitions',
@@ -195,6 +197,8 @@ const translations = {
     ticketsViaOfficialSite: 'Opent officiële website',
     ticketsViaPartner: 'Opent partnerwebsite',
     ticketsAffiliateHover: 'MuseumBuddy ontvangt mogelijk een commissie wanneer je via deze partner koopt.',
+    ticketsAffiliateDisclosure:
+      'Partnerlink — MuseumBuddy ontvangt mogelijk commissie bij aankoop via deze link.',
     breadcrumbsLabel: 'Kruimelpad',
     breadcrumbMuseums: 'Musea',
     breadcrumbExhibitions: 'Tentoonstellingen',

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -10,7 +10,6 @@ import { useLanguage } from '../../components/LanguageContext';
 import { useFavorites } from '../../components/FavoritesContext';
 import FiltersSheet from '../../components/FiltersSheet';
 import FiltersPopover from '../../components/FiltersPopover';
-import TicketButtonAffiliateInfo from '../../components/TicketButtonAffiliateInfo';
 import TicketButtonNote from '../../components/TicketButtonNote';
 import museumImages from '../../lib/museumImages';
 import museumImageCredits from '../../lib/museumImageCredits';
@@ -373,7 +372,7 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
         { key: 'partner', message: t('ticketsViaPartner'), disclosure: false },
         { key: 'disclosure', message: t('ticketsAffiliateDisclosure'), disclosure: true },
       ]
-    : [{ key: 'official', message: t('ticketsViaOfficialSite'), disclosure: false }];
+    : [];
 
   const createTicketNote = (prefix) => {
     if (!ticketNoteDefinitions.length) {
@@ -394,6 +393,10 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
   const primaryTicketNoteId = useId();
   const overviewTicketNoteId = useId();
   const mobileTicketNoteId = useId();
+  const ticketRel = showAffiliateNote ? 'sponsored noopener noreferrer' : 'noopener noreferrer';
+  const ticketAriaLabel = showAffiliateNote
+    ? `${t('buyTickets')} — ${t('ticketsAffiliateDisclosure')}`
+    : t('buyTickets');
   const mobileActionSheetId = useId();
   const mobileActionSheetTitleId = useId();
   const locationLines = getLocationLines(resolvedMuseum);
@@ -1104,41 +1107,72 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
         <div className="museum-primary-action-bar">
         <div className="museum-primary-action-group">
           {hasTicketLink ? (
-            <a
-              href={ticketUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="museum-primary-action primary inline-flex items-center justify-center rounded-full border border-transparent bg-sky-600 px-5 py-3 text-sm font-semibold text-white shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:bg-sky-500 dark:text-slate-900 dark:focus-visible:ring-offset-slate-900"
-              aria-describedby={ticketContext ? primaryTicketNoteId : undefined}
-              onClick={handleTicketLinkClick}
-              title={ticketHoverMessage}
-            >
-              <span className="ticket-button__label">
-                {showAffiliateNote ? (
-                  <TicketButtonAffiliateInfo infoMessage={ticketHoverMessage} />
-                ) : null}
+            <div className="museum-primary-action-stack">
+              <a
+                href={ticketUrl}
+                target="_blank"
+                rel={ticketRel}
+                className="museum-primary-action primary"
+                aria-describedby={ticketContext ? primaryTicketNoteId : undefined}
+                onClick={handleTicketLinkClick}
+                title={ticketHoverMessage}
+                aria-label={ticketAriaLabel}
+                data-affiliate={showAffiliateNote ? 'true' : undefined}
+              >
+                <span className="ticket-button__icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M4.5 7.75a1.75 1.75 0 0 1 1.75-1.75h4.5v2a1.75 1.75 0 1 0 0 3.5v2h-4.5A1.75 1.75 0 0 1 4.5 11.75v-4Z"
+                      fill="currentColor"
+                    />
+                    <path
+                      d="M13.25 16.25v-2a1.75 1.75 0 1 0 0-3.5v-2h4.5a1.75 1.75 0 0 1 1.75 1.75v4a1.75 1.75 0 0 1-1.75 1.75h-4.5Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
                 <span className="ticket-button__label-text">{t('buyTickets')}</span>
-              </span>
+                {showAffiliateNote ? (
+                  <span className="ticket-button__badge">
+                    {t('ticketsPartnerBadge')}
+                    <span className="sr-only"> — {t('ticketsViaPartner')}</span>
+                  </span>
+                ) : null}
+              </a>
               {ticketContext ? (
                 <TicketButtonNote
                   affiliate={showAffiliateNote}
+                  showIcon={false}
                   id={primaryTicketNoteId}
+                  className="museum-primary-action__note"
                 >
                   {createTicketNote('primary-ticket-note')}
                 </TicketButtonNote>
               ) : null}
-            </a>
+            </div>
           ) : (
-            <button
-              type="button"
-              className="museum-primary-action primary inline-flex items-center justify-center rounded-full border border-transparent bg-slate-300 px-5 py-3 text-sm font-semibold text-slate-600 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 dark:bg-slate-700 dark:text-slate-200 dark:focus-visible:ring-offset-slate-900"
-              disabled
-              aria-disabled="true"
-            >
-              <span className="ticket-button__label">
+            <div className="museum-primary-action-stack">
+              <button
+                type="button"
+                className="museum-primary-action primary"
+                disabled
+                aria-disabled="true"
+              >
+                <span className="ticket-button__icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M4.5 7.75a1.75 1.75 0 0 1 1.75-1.75h4.5v2a1.75 1.75 0 1 0 0 3.5v2h-4.5A1.75 1.75 0 0 1 4.5 11.75v-4Z"
+                      fill="currentColor"
+                    />
+                    <path
+                      d="M13.25 16.25v-2a1.75 1.75 0 1 0 0-3.5v-2h4.5a1.75 1.75 0 0 1 1.75 1.75v4a1.75 1.75 0 0 1-1.75 1.75h-4.5Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
                 <span className="ticket-button__label-text">{t('buyTickets')}</span>
-              </span>
-            </button>
+              </button>
+            </div>
           )}
 
           {hasWebsite && (
@@ -1146,7 +1180,7 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
               href={resolvedMuseum.websiteUrl}
               target="_blank"
               rel="noreferrer"
-              className="museum-primary-action secondary inline-flex items-center justify-center rounded-full border border-slate-300 bg-transparent px-5 py-3 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 dark:border-slate-600 dark:text-slate-100 dark:hover:bg-slate-800/70 dark:focus-visible:ring-offset-slate-900"
+              className="museum-primary-action secondary"
               onClick={handleWebsiteLinkClick}
             >
               <span>{t('website')}</span>
@@ -1549,33 +1583,52 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
             <div className="museum-mobile-actions__body">
               <div className="museum-mobile-actions__actions">
                 {hasTicketLink ? (
-                  <button
-                    type="button"
-                    className="museum-primary-action primary museum-mobile-actions__action inline-flex items-center justify-center rounded-full border border-transparent bg-sky-600 px-5 py-3 text-sm font-semibold text-white shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:bg-sky-500 dark:text-slate-900 dark:focus-visible:ring-offset-slate-900"
-                    onClick={handleMobileTicketAction}
-                    aria-describedby={ticketContext ? mobileTicketNoteId : undefined}
-                    title={ticketHoverMessage}
-                  >
-                    <span className="ticket-button__label">
-                      {showAffiliateNote ? (
-                        <TicketButtonAffiliateInfo infoMessage={ticketHoverMessage} />
-                      ) : null}
+                  <div className="museum-primary-action-stack">
+                    <button
+                      type="button"
+                      className="museum-primary-action primary museum-mobile-actions__action"
+                      onClick={handleMobileTicketAction}
+                      aria-describedby={ticketContext ? mobileTicketNoteId : undefined}
+                      title={ticketHoverMessage}
+                      aria-label={ticketAriaLabel}
+                      data-affiliate={showAffiliateNote ? 'true' : undefined}
+                    >
+                      <span className="ticket-button__icon" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                          <path
+                            d="M4.5 7.75a1.75 1.75 0 0 1 1.75-1.75h4.5v2a1.75 1.75 0 1 0 0 3.5v2h-4.5A1.75 1.75 0 0 1 4.5 11.75v-4Z"
+                            fill="currentColor"
+                          />
+                          <path
+                            d="M13.25 16.25v-2a1.75 1.75 0 1 0 0-3.5v-2h4.5a1.75 1.75 0 0 1 1.75 1.75v4a1.75 1.75 0 0 1-1.75 1.75h-4.5Z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </span>
                       <span className="ticket-button__label-text">{t('buyTickets')}</span>
-                    </span>
+                      {showAffiliateNote ? (
+                        <span className="ticket-button__badge">
+                          {t('ticketsPartnerBadge')}
+                          <span className="sr-only"> — {t('ticketsViaPartner')}</span>
+                        </span>
+                      ) : null}
+                    </button>
                     {ticketContext ? (
                       <TicketButtonNote
                         affiliate={showAffiliateNote}
+                        showIcon={false}
                         id={mobileTicketNoteId}
+                        className="museum-primary-action__note"
                       >
                         {createTicketNote('mobile-ticket-note')}
                       </TicketButtonNote>
                     ) : null}
-                  </button>
+                  </div>
                 ) : null}
                 {hasWebsite ? (
                   <button
                     type="button"
-                    className="museum-primary-action secondary museum-mobile-actions__action inline-flex items-center justify-center rounded-full border border-slate-300 bg-transparent px-5 py-3 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 dark:border-slate-600 dark:text-slate-100 dark:hover:bg-slate-800/70 dark:focus-visible:ring-offset-slate-900"
+                    className="museum-primary-action secondary museum-mobile-actions__action"
                     onClick={handleMobileWebsiteAction}
                   >
                     <span>{t('website')}</span>

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -367,8 +367,30 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
   const directTicketUrl = resolvedMuseum.ticketUrl || resolvedMuseum.websiteUrl || null;
   const ticketUrl = affiliateTicketUrl || directTicketUrl;
   const showAffiliateNote = Boolean(affiliateTicketUrl) && shouldShowAffiliateNote(slug);
-  const ticketContext = t(showAffiliateNote ? 'ticketsViaPartner' : 'ticketsViaOfficialSite');
-  const ticketHoverMessage = showAffiliateNote ? t('ticketsAffiliateHover') : undefined;
+  const ticketHoverMessage = showAffiliateNote ? t('ticketsAffiliateDisclosure') : undefined;
+  const ticketNoteDefinitions = showAffiliateNote
+    ? [
+        { key: 'partner', message: t('ticketsViaPartner'), disclosure: false },
+        { key: 'disclosure', message: t('ticketsAffiliateDisclosure'), disclosure: true },
+      ]
+    : [{ key: 'official', message: t('ticketsViaOfficialSite'), disclosure: false }];
+
+  const createTicketNote = (prefix) => {
+    if (!ticketNoteDefinitions.length) {
+      return null;
+    }
+
+    return ticketNoteDefinitions.map((definition, index) => (
+      <span
+        key={`${prefix}-${definition.key ?? index}`}
+        className={`ticket-button__note-line${definition.disclosure ? ' ticket-button__note-disclosure' : ''}`}
+      >
+        {definition.message}
+      </span>
+    ));
+  };
+
+  const ticketContext = createTicketNote('ticket-context');
   const primaryTicketNoteId = useId();
   const overviewTicketNoteId = useId();
   const mobileTicketNoteId = useId();
@@ -1102,7 +1124,7 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
                   affiliate={showAffiliateNote}
                   id={primaryTicketNoteId}
                 >
-                  {ticketContext}
+                  {createTicketNote('primary-ticket-note')}
                 </TicketButtonNote>
               ) : null}
             </a>
@@ -1545,7 +1567,7 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
                         affiliate={showAffiliateNote}
                         id={mobileTicketNoteId}
                       >
-                        {ticketContext}
+                        {createTicketNote('mobile-ticket-note')}
                       </TicketButtonNote>
                     ) : null}
                   </button>

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -369,8 +369,9 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
   const ticketHoverMessage = showAffiliateNote ? t('ticketsAffiliateDisclosure') : undefined;
   const ticketNoteDefinitions = showAffiliateNote
     ? [
-        { key: 'partner', message: t('ticketsViaPartner'), disclosure: false },
+        { key: 'intro', message: t('ticketsAffiliateIntro'), disclosure: false },
         { key: 'disclosure', message: t('ticketsAffiliateDisclosure'), disclosure: true },
+        { key: 'prices', message: t('ticketsAffiliatePricesMayVary'), disclosure: true },
       ]
     : [];
 
@@ -1131,13 +1132,21 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
                     />
                   </svg>
                 </span>
-                <span className="ticket-button__label-text">{t('buyTickets')}</span>
-                {showAffiliateNote ? (
-                  <span className="ticket-button__badge">
-                    {t('ticketsPartnerBadge')}
-                    <span className="sr-only"> — {t('ticketsViaPartner')}</span>
-                  </span>
-                ) : null}
+                <span
+                  className={
+                    showAffiliateNote
+                      ? 'ticket-button__label ticket-button__label--stacked'
+                      : 'ticket-button__label'
+                  }
+                >
+                  <span className="ticket-button__label-text">{t('buyTickets')}</span>
+                  {showAffiliateNote ? (
+                    <span className="ticket-button__badge">
+                      {t('ticketsPartnerBadge')}
+                      <span className="sr-only"> — {t('ticketsAffiliateIntro')}</span>
+                    </span>
+                  ) : null}
+                </span>
               </a>
               {ticketContext ? (
                 <TicketButtonNote
@@ -1170,7 +1179,9 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
                     />
                   </svg>
                 </span>
-                <span className="ticket-button__label-text">{t('buyTickets')}</span>
+                <span className="ticket-button__label">
+                  <span className="ticket-button__label-text">{t('buyTickets')}</span>
+                </span>
               </button>
             </div>
           )}
@@ -1605,13 +1616,21 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
                           />
                         </svg>
                       </span>
-                      <span className="ticket-button__label-text">{t('buyTickets')}</span>
-                      {showAffiliateNote ? (
-                        <span className="ticket-button__badge">
-                          {t('ticketsPartnerBadge')}
-                          <span className="sr-only"> — {t('ticketsViaPartner')}</span>
-                        </span>
-                      ) : null}
+                      <span
+                        className={
+                          showAffiliateNote
+                            ? 'ticket-button__label ticket-button__label--stacked'
+                            : 'ticket-button__label'
+                        }
+                      >
+                        <span className="ticket-button__label-text">{t('buyTickets')}</span>
+                        {showAffiliateNote ? (
+                          <span className="ticket-button__badge">
+                            {t('ticketsPartnerBadge')}
+                            <span className="sr-only"> — {t('ticketsAffiliateIntro')}</span>
+                          </span>
+                        ) : null}
+                      </span>
                     </button>
                     {ticketContext ? (
                       <TicketButtonNote

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2364,7 +2364,7 @@ button.hero-quick-link {
   font-size: 0.75rem;
   font-weight: 500;
   line-height: 1.3;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--accent-ink);
   opacity: 1;
   text-align: center;
   max-width: 100%;
@@ -2379,6 +2379,37 @@ button.hero-quick-link {
 .ticket-button__note-text {
   display: inline;
   white-space: normal;
+}
+
+.ticket-button__note-line {
+  display: block;
+  width: 100%;
+  color: inherit;
+}
+
+.ticket-button__note-disclosure {
+  display: block;
+  width: 100%;
+  color: inherit;
+  opacity: 0.9;
+}
+
+@media (prefers-color-scheme: dark) {
+  .ticket-button__note {
+    color: var(--accent-ink);
+  }
+
+  .ticket-button__note-disclosure {
+    opacity: 0.92;
+  }
+}
+
+[data-theme='dark'] .ticket-button__note {
+  color: var(--accent-ink);
+}
+
+[data-theme='dark'] .ticket-button__note-disclosure {
+  opacity: 0.92;
 }
 
 .ticket-button__note-icon {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1358,6 +1358,16 @@ button.hero-quick-link {
   align-items: center;
   gap: var(--space-16);
 }
+.museum-primary-action-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+}
+.museum-primary-action-stack .museum-primary-action {
+  width: fit-content;
+}
 .museum-primary-action-group:empty {
   display: none;
 }
@@ -1443,6 +1453,22 @@ button.hero-quick-link {
 }
 [data-theme='dark'] .museum-primary-action.secondary:hover {
   background: rgba(100, 116, 139, 0.24);
+}
+.museum-primary-action__note {
+  width: auto;
+  padding: 0;
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+  align-items: flex-start;
+  gap: 4px;
+  color: var(--muted);
+}
+.museum-primary-action__note .ticket-button__note-text {
+  gap: 2px;
+}
+[data-theme='dark'] .museum-primary-action__note {
+  color: var(--muted);
 }
 .museum-primary-action-utility .icon-button {
   width: 42px;
@@ -2248,48 +2274,43 @@ button.hero-quick-link {
   top: 16px;
   left: 16px;
   z-index: 1;
-  display: inline-flex;
-  align-items: stretch;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  max-width: calc(100% - 32px);
 }
 
 .ticket-button--card {
   display: inline-flex;
-  flex-direction: column;
-  align-items: flex-start;
-  width: clamp(92px, 28vw, 112px);
-  min-height: 0;
-  padding: 6px 10px;
-  border-radius: 0.7rem;
-  gap: 4px;
-  text-align: left;
-  line-height: 1.1;
-  box-shadow: 0 12px 26px rgba(37, 99, 235, 0.24);
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  border-radius: 0.875rem;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.95), rgba(37, 99, 235, 0.82));
+  color: var(--accent-ink);
+  border: 1px solid rgba(255, 255, 255, 0.32);
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.26);
+  backdrop-filter: blur(10px);
+  min-width: 0;
+}
+
+.ticket-button--card:hover {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.98), rgba(14, 165, 233, 0.92));
+  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.32);
+}
+
+.ticket-button--card:focus-visible {
+  border-color: rgba(255, 255, 255, 0.7);
 }
 
 .ticket-button--card .ticket-button__label {
-  width: 100%;
-  font-size: 0.8125rem;
+  width: auto;
+  font-size: 0.9375rem;
   font-weight: 600;
-  letter-spacing: 0.01em;
+  letter-spacing: -0.01em;
   justify-content: flex-start;
-}
-
-.ticket-button--card .ticket-button__note {
-  width: 100%;
-  justify-content: flex-start;
-  font-size: 0.65rem;
-  line-height: 1.2;
-  gap: 4px;
-  text-align: left;
-}
-
-.ticket-button--card .ticket-button__note-icon {
-  width: 10px;
-  height: 10px;
-}
-
-.ticket-button--card .ticket-button__note-text {
-  flex: 1;
+  gap: 10px;
 }
 .ticket-button {
   padding: 8px 16px;
@@ -2354,68 +2375,110 @@ button.hero-quick-link {
 .ticket-button__label-text {
   display: inline;
 }
-.ticket-button__note {
+
+.ticket-button__icon {
+  width: 20px;
+  height: 20px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  flex-wrap: wrap;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.18);
+  color: inherit;
+  flex-shrink: 0;
+}
+
+.ticket-button__icon svg {
+  width: 14px;
+  height: 14px;
+}
+
+.ticket-button__badge {
+  display: inline-flex;
+  align-items: center;
   gap: 4px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.96);
+  color: #1f2937;
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  line-height: 1;
+}
+
+[data-theme='dark'] .ticket-button__badge {
+  background: rgba(15, 23, 42, 0.9);
+  border-color: rgba(148, 163, 184, 0.5);
+  color: rgba(226, 232, 240, 0.92);
+}
+.ticket-button__note {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 6px;
   width: 100%;
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
   font-weight: 500;
-  line-height: 1.3;
-  color: var(--accent-ink);
-  opacity: 1;
-  text-align: center;
+  line-height: 1.35;
+  color: var(--muted);
+  text-align: left;
   max-width: 100%;
-  position: relative;
 }
 
 .ticket-button__note--partner {
-  font-weight: 500;
-  font-size: 0.7rem;
+  color: var(--muted);
 }
 
 .ticket-button__note-text {
-  display: inline;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
   white-space: normal;
 }
 
 .ticket-button__note-line {
-  display: block;
-  width: 100%;
+  display: inline;
   color: inherit;
 }
 
 .ticket-button__note-disclosure {
-  display: block;
-  width: 100%;
-  color: inherit;
-  opacity: 0.9;
-}
-
-@media (prefers-color-scheme: dark) {
-  .ticket-button__note {
-    color: var(--accent-ink);
-  }
-
-  .ticket-button__note-disclosure {
-    opacity: 0.92;
-  }
-}
-
-[data-theme='dark'] .ticket-button__note {
-  color: var(--accent-ink);
-}
-
-[data-theme='dark'] .ticket-button__note-disclosure {
-  opacity: 0.92;
+  opacity: 0.85;
 }
 
 .ticket-button__note-icon {
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
   flex-shrink: 0;
+  color: inherit;
+  margin-top: 1px;
+}
+
+.ticket-button__overlay-note {
+  padding: 6px 10px;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.18);
+  backdrop-filter: blur(8px);
+}
+
+.ticket-button__overlay-note .ticket-button__note-text {
+  gap: 3px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .ticket-button__overlay-note {
+    background: rgba(15, 23, 42, 0.92);
+    color: rgba(226, 232, 240, 0.92);
+    box-shadow: 0 14px 30px rgba(2, 6, 23, 0.55);
+  }
+}
+
+[data-theme='dark'] .ticket-button__overlay-note {
+  background: rgba(15, 23, 42, 0.92);
+  color: rgba(226, 232, 240, 0.92);
+  box-shadow: 0 14px 30px rgba(2, 6, 23, 0.55);
 }
 
 .ticket-button__affiliate-info-group {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2370,6 +2370,20 @@ button.hero-quick-link {
   justify-content: center;
   gap: 6px;
   line-height: 1.1;
+  text-align: center;
+}
+
+.ticket-button__label--stacked {
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ticket-button__label--stacked .ticket-button__label-text {
+  display: block;
+}
+
+.ticket-button__label--stacked .ticket-button__badge {
+  margin-top: 2px;
 }
 
 .ticket-button__label-text {
@@ -2396,22 +2410,31 @@ button.hero-quick-link {
 .ticket-button__badge {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 4px;
-  padding: 4px 8px;
+  padding: 2px 8px;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.8);
-  background: rgba(255, 255, 255, 0.96);
-  color: #1f2937;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  background: rgba(255, 255, 255, 0.18);
+  color: var(--accent-ink);
   font-size: 0.625rem;
-  font-weight: 700;
+  font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  line-height: 1;
+  line-height: 1.1;
+}
+
+@media (prefers-color-scheme: dark) {
+  .ticket-button__badge {
+    border-color: rgba(148, 163, 184, 0.45);
+    background: rgba(148, 163, 184, 0.22);
+    color: rgba(226, 232, 240, 0.92);
+  }
 }
 
 [data-theme='dark'] .ticket-button__badge {
-  background: rgba(15, 23, 42, 0.9);
-  border-color: rgba(148, 163, 184, 0.5);
+  border-color: rgba(148, 163, 184, 0.45);
+  background: rgba(148, 163, 184, 0.22);
   color: rgba(226, 232, 240, 0.92);
 }
 .ticket-button__note {
@@ -2421,10 +2444,20 @@ button.hero-quick-link {
   width: 100%;
   font-size: 0.6875rem;
   font-weight: 500;
-  line-height: 1.35;
-  color: var(--muted);
+  line-height: 1.45;
+  color: rgba(71, 85, 105, 0.95);
   text-align: left;
   max-width: 100%;
+}
+
+@media (prefers-color-scheme: dark) {
+  .ticket-button__note {
+    color: rgba(226, 232, 240, 0.88);
+  }
+}
+
+[data-theme='dark'] .ticket-button__note {
+  color: rgba(226, 232, 240, 0.88);
 }
 
 .ticket-button__note--partner {
@@ -2439,12 +2472,12 @@ button.hero-quick-link {
 }
 
 .ticket-button__note-line {
-  display: inline;
+  display: block;
   color: inherit;
 }
 
 .ticket-button__note-disclosure {
-  opacity: 0.85;
+  opacity: 0.88;
 }
 
 .ticket-button__note-icon {
@@ -2455,30 +2488,12 @@ button.hero-quick-link {
   margin-top: 1px;
 }
 
-.ticket-button__overlay-note {
-  padding: 6px 10px;
-  border-radius: 0.75rem;
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.18);
-  backdrop-filter: blur(8px);
+.museum-card__affiliate-note {
+  margin-top: 12px;
 }
 
-.ticket-button__overlay-note .ticket-button__note-text {
-  gap: 3px;
-}
-
-@media (prefers-color-scheme: dark) {
-  .ticket-button__overlay-note {
-    background: rgba(15, 23, 42, 0.92);
-    color: rgba(226, 232, 240, 0.92);
-    box-shadow: 0 14px 30px rgba(2, 6, 23, 0.55);
-  }
-}
-
-[data-theme='dark'] .ticket-button__overlay-note {
-  background: rgba(15, 23, 42, 0.92);
-  color: rgba(226, 232, 240, 0.92);
-  box-shadow: 0 14px 30px rgba(2, 6, 23, 0.55);
+.exposition-card__affiliate-note {
+  margin-top: 12px;
 }
 
 .ticket-button__affiliate-info-group {

--- a/tests/ticketCta.test.cjs
+++ b/tests/ticketCta.test.cjs
@@ -19,16 +19,32 @@ assert(
   'Dutch affiliate hover copy missing'
 );
 assert(
-  /ticketsAffiliateDisclosure:\s*'Partner link — MuseumBuddy may receive a commission when you buy via this link.'/.test(
+  /ticketsAffiliateIntro:\s*'You buy tickets via an affiliate partner.'/.test(translationsContent),
+  'English affiliate intro copy missing'
+);
+assert(
+  /ticketsAffiliateIntro:\s*'Je koopt tickets via een affiliate partner.'/.test(translationsContent),
+  'Dutch affiliate intro copy missing'
+);
+assert(
+  /ticketsAffiliateDisclosure:\s*'MuseumBuddy may receive a commission when you buy via this link.'/.test(
     translationsContent
   ),
   'English affiliate disclosure copy missing'
 );
 assert(
-  /ticketsAffiliateDisclosure:\s*'Partnerlink — MuseumBuddy ontvangt mogelijk commissie bij aankoop via deze link.'/.test(
+  /ticketsAffiliateDisclosure:\s*'MuseumBuddy ontvangt mogelijk commissie bij aankoop via deze link.'/.test(
     translationsContent
   ),
   'Dutch affiliate disclosure copy missing'
+);
+assert(
+  /ticketsAffiliatePricesMayVary:\s*'Prices may vary.'/.test(translationsContent),
+  'English affiliate price disclaimer missing'
+);
+assert(
+  /ticketsAffiliatePricesMayVary:\s*'Prijzen kunnen afwijken.'/.test(translationsContent),
+  'Dutch affiliate price disclaimer missing'
 );
 assert(/ticketsPartnerBadge:\s*'Partner'/.test(translationsContent), 'English partner badge copy missing');
 assert(/ticketsPartnerBadge:\s*'Partner'/.test(translationsContent), 'Dutch partner badge copy missing');

--- a/tests/ticketCta.test.cjs
+++ b/tests/ticketCta.test.cjs
@@ -30,6 +30,8 @@ assert(
   ),
   'Dutch affiliate disclosure copy missing'
 );
+assert(/ticketsPartnerBadge:\s*'Partner'/.test(translationsContent), 'English partner badge copy missing');
+assert(/ticketsPartnerBadge:\s*'Partner'/.test(translationsContent), 'Dutch partner badge copy missing');
 
 const files = [
   'components/MuseumCard.js',
@@ -40,7 +42,8 @@ const legacyTooltipPattern = /title={t\('affiliateLink'\)}/;
 const legacyNotePattern = /className="affiliate-note"/;
 const newNotePattern = /TicketButtonNote/;
 const hoverTitlePattern = /title={ticketHoverMessage}/;
-const affiliateInfoPattern = /TicketButtonAffiliateInfo infoMessage={ticketHoverMessage}/;
+const partnerBadgePattern = /ticketsPartnerBadge/;
+const affiliateInfoPattern = /TicketButtonAffiliateInfo/;
 
 for (const file of files) {
   const content = fs.readFileSync(file, 'utf8');
@@ -48,7 +51,8 @@ for (const file of files) {
   assert(!legacyNotePattern.test(content), `Legacy affiliate note class found in ${file}`);
   assert(newNotePattern.test(content), `Ticket note missing in ${file}`);
   assert(hoverTitlePattern.test(content), `Affiliate hover title missing in ${file}`);
-  assert(affiliateInfoPattern.test(content), `Affiliate info tooltip missing in ${file}`);
+  assert(partnerBadgePattern.test(content), `Partner badge translation missing in ${file}`);
+  assert(!affiliateInfoPattern.test(content), `Legacy affiliate info component found in ${file}`);
 }
 
 console.log('Ticket CTA copy tests passed.');

--- a/tests/ticketCta.test.cjs
+++ b/tests/ticketCta.test.cjs
@@ -18,6 +18,18 @@ assert(
   ),
   'Dutch affiliate hover copy missing'
 );
+assert(
+  /ticketsAffiliateDisclosure:\s*'Partner link — MuseumBuddy may receive a commission when you buy via this link.'/.test(
+    translationsContent
+  ),
+  'English affiliate disclosure copy missing'
+);
+assert(
+  /ticketsAffiliateDisclosure:\s*'Partnerlink — MuseumBuddy ontvangt mogelijk commissie bij aankoop via deze link.'/.test(
+    translationsContent
+  ),
+  'Dutch affiliate disclosure copy missing'
+);
 
 const files = [
   'components/MuseumCard.js',


### PR DESCRIPTION
## Summary
- add a dedicated affiliate disclosure translation and enforce it in the ticket CTA regression test
- render multi-line partner notes in museum and exposition ticket buttons, reusing the new disclosure copy in tooltips
- update TicketButtonNote and global styles to support multiple note lines with accessible contrast in both themes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d654921d3c8326b7b2c4cc2002ccc6