### PR TITLE
Remove ticket icon from buy ticket buttons

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -333,18 +333,6 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
               aria-label={ticketAriaLabel}
               data-affiliate={showAffiliateNote ? 'true' : undefined}
             >
-              <span className="ticket-button__icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M4.5 7.75a1.75 1.75 0 0 1 1.75-1.75h4.5v2a1.75 1.75 0 1 0 0 3.5v2h-4.5A1.75 1.75 0 0 1 4.5 11.75v-4Z"
-                    fill="currentColor"
-                  />
-                  <path
-                    d="M13.25 16.25v-2a1.75 1.75 0 1 0 0-3.5v-2h4.5a1.75 1.75 0 0 1 1.75 1.75v4a1.75 1.75 0 0 1-1.75 1.75h-4.5Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </span>
               <span
                 className={
                   showAffiliateNote
@@ -369,18 +357,6 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
             disabled
             aria-disabled="true"
           >
-            <span className="ticket-button__icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path
-                  d="M4.5 7.75a1.75 1.75 0 0 1 1.75-1.75h4.5v2a1.75 1.75 0 1 0 0 3.5v2h-4.5A1.75 1.75 0 0 1 4.5 11.75v-4Z"
-                  fill="currentColor"
-                />
-                <path
-                  d="M13.25 16.25v-2a1.75 1.75 0 1 0 0-3.5v-2h4.5a1.75 1.75 0 0 1 1.75 1.75v4a1.75 1.75 0 0 1-1.75 1.75h-4.5Z"
-                  fill="currentColor"
-                />
-              </svg>
-            </span>
             <span className="ticket-button__label">
               <span className="ticket-button__label-text">{t('buyTickets')}</span>
             </span>

--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -191,22 +191,6 @@ export default function MuseumCard({ museum, priority = false }) {
             aria-describedby={showAffiliateNote ? ticketNoteId : undefined}
             data-affiliate={showAffiliateNote ? 'true' : undefined}
           >
-            <span className="ticket-button__icon" aria-hidden="true">
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M4.5 7.75a1.75 1.75 0 0 1 1.75-1.75h4.5v2a1.75 1.75 0 1 0 0 3.5v2h-4.5A1.75 1.75 0 0 1 4.5 11.75v-4Z"
-                  fill="currentColor"
-                />
-                <path
-                  d="M13.25 16.25v-2a1.75 1.75 0 1 0 0-3.5v-2h4.5a1.75 1.75 0 0 1 1.75 1.75v4a1.75 1.75 0 0 1-1.75 1.75h-4.5Z"
-                  fill="currentColor"
-                />
-              </svg>
-            </span>
             <span className={labelClassName}>
               <span className="ticket-button__label-text">{t('buyTickets')}</span>
               {partnerBadge}
@@ -218,22 +202,6 @@ export default function MuseumCard({ museum, priority = false }) {
 
     return (
       <button type="button" className={classNames} disabled aria-disabled="true">
-        <span className="ticket-button__icon" aria-hidden="true">
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M4.5 7.75a1.75 1.75 0 0 1 1.75-1.75h4.5v2a1.75 1.75 0 1 0 0 3.5v2h-4.5A1.75 1.75 0 0 1 4.5 11.75v-4Z"
-              fill="currentColor"
-            />
-            <path
-              d="M13.25 16.25v-2a1.75 1.75 0 1 0 0-3.5v-2h4.5a1.75 1.75 0 0 1 1.75 1.75v4a1.75 1.75 0 0 1-1.75 1.75h-4.5Z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
         <span className="ticket-button__label">
           <span className="ticket-button__label-text">{t('buyTickets')}</span>
         </span>

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -1120,18 +1120,6 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
                 aria-label={ticketAriaLabel}
                 data-affiliate={showAffiliateNote ? 'true' : undefined}
               >
-                <span className="ticket-button__icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path
-                      d="M4.5 7.75a1.75 1.75 0 0 1 1.75-1.75h4.5v2a1.75 1.75 0 1 0 0 3.5v2h-4.5A1.75 1.75 0 0 1 4.5 11.75v-4Z"
-                      fill="currentColor"
-                    />
-                    <path
-                      d="M13.25 16.25v-2a1.75 1.75 0 1 0 0-3.5v-2h4.5a1.75 1.75 0 0 1 1.75 1.75v4a1.75 1.75 0 0 1-1.75 1.75h-4.5Z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </span>
                 <span
                   className={
                     showAffiliateNote
@@ -1167,18 +1155,6 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
                 disabled
                 aria-disabled="true"
               >
-                <span className="ticket-button__icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path
-                      d="M4.5 7.75a1.75 1.75 0 0 1 1.75-1.75h4.5v2a1.75 1.75 0 1 0 0 3.5v2h-4.5A1.75 1.75 0 0 1 4.5 11.75v-4Z"
-                      fill="currentColor"
-                    />
-                    <path
-                      d="M13.25 16.25v-2a1.75 1.75 0 1 0 0-3.5v-2h4.5a1.75 1.75 0 0 1 1.75 1.75v4a1.75 1.75 0 0 1-1.75 1.75h-4.5Z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </span>
                 <span className="ticket-button__label">
                   <span className="ticket-button__label-text">{t('buyTickets')}</span>
                 </span>
@@ -1604,18 +1580,6 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
                       aria-label={ticketAriaLabel}
                       data-affiliate={showAffiliateNote ? 'true' : undefined}
                     >
-                      <span className="ticket-button__icon" aria-hidden="true">
-                        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                          <path
-                            d="M4.5 7.75a1.75 1.75 0 0 1 1.75-1.75h4.5v2a1.75 1.75 0 1 0 0 3.5v2h-4.5A1.75 1.75 0 0 1 4.5 11.75v-4Z"
-                            fill="currentColor"
-                          />
-                          <path
-                            d="M13.25 16.25v-2a1.75 1.75 0 1 0 0-3.5v-2h4.5a1.75 1.75 0 0 1 1.75 1.75v4a1.75 1.75 0 0 1-1.75 1.75h-4.5Z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                      </span>
                       <span
                         className={
                           showAffiliateNote

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2375,15 +2375,18 @@ button.hero-quick-link {
 
 .ticket-button__label--stacked {
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
+  align-items: center;
 }
 
 .ticket-button__label--stacked .ticket-button__label-text {
   display: block;
+  transform: translateY(1px);
 }
 
 .ticket-button__label--stacked .ticket-button__badge {
-  margin-top: 2px;
+  margin-top: 0;
+  transform: translateY(-1px);
 }
 
 .ticket-button__label-text {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2390,23 +2390,6 @@ button.hero-quick-link {
   display: inline;
 }
 
-.ticket-button__icon {
-  width: 20px;
-  height: 20px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 0.75rem;
-  background: rgba(255, 255, 255, 0.18);
-  color: inherit;
-  flex-shrink: 0;
-}
-
-.ticket-button__icon svg {
-  width: 14px;
-  height: 14px;
-}
-
 .ticket-button__badge {
   display: inline-flex;
   align-items: center;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2284,9 +2284,9 @@ button.hero-quick-link {
 .ticket-button--card {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 16px;
-  border-radius: 0.875rem;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 0.8125rem;
   background: linear-gradient(135deg, rgba(37, 99, 235, 0.95), rgba(37, 99, 235, 0.82));
   color: var(--accent-ink);
   border: 1px solid rgba(255, 255, 255, 0.32);
@@ -2313,12 +2313,12 @@ button.hero-quick-link {
   gap: 10px;
 }
 .ticket-button {
-  padding: 8px 16px;
+  padding: 6px 14px;
   border: none;
-  border-radius: 0.625rem;
+  border-radius: 0.5625rem;
   background: var(--accent);
   color: var(--accent-ink);
-  font-size: 0.85rem;
+  font-size: 0.8125rem;
   font-weight: 600;
   letter-spacing: -0.01em;
   cursor: pointer;
@@ -2328,7 +2328,7 @@ button.hero-quick-link {
   justify-content: center;
   text-align: center;
   text-decoration: none;
-  gap: 6px;
+  gap: 5px;
   min-width: 0;
   width: fit-content;
   max-width: 100%;
@@ -2350,7 +2350,7 @@ button.hero-quick-link {
 }
 .museum-info-links .ticket-button {
   width: fit-content;
-  padding: 8px 16px;
+  padding: 6px 14px;
   box-shadow: 0 10px 22px rgba(37, 99, 235, 0.22);
 }
 @media (min-width: 601px) {


### PR DESCRIPTION
## Summary
- remove the decorative icon from the buy ticket buttons across exposition, museum card, and museum detail layouts
- clean up unused ticket button icon styles now that the glyph is gone

## Testing
- npm install *(fails: 403 Forbidden fetching @capacitor/app)*

------
https://chatgpt.com/codex/tasks/task_e_68d66646d9fc8326b41462b9e17e7726