### PR TITLE
Adjust affiliate note layout

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -139,16 +139,16 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
   const buyUrl = primaryAffiliateUrl || fallbackTicketUrl || sourceUrl;
   const showAffiliateNote = Boolean(primaryAffiliateUrl) && (!slug || shouldShowAffiliateNote(slug));
   const ticketHoverMessage = showAffiliateNote ? t('ticketsAffiliateDisclosure') : undefined;
+  const ticketDisclosureLine = [t('ticketsAffiliateDisclosure'), t('ticketsAffiliatePricesMayVary')]
+    .filter(Boolean)
+    .join(' ');
   const ticketContext = showAffiliateNote
     ? [
         <span key="intro" className="ticket-button__note-line">
           {t('ticketsAffiliateIntro')}
         </span>,
-        <span key="disclosure" className="ticket-button__note-line ticket-button__note-disclosure">
-          {t('ticketsAffiliateDisclosure')}
-        </span>,
-        <span key="prices" className="ticket-button__note-line ticket-button__note-disclosure">
-          {t('ticketsAffiliatePricesMayVary')}
+        <span key="details" className="ticket-button__note-line ticket-button__note-disclosure">
+          {ticketDisclosureLine}
         </span>,
       ]
     : null;

--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -62,16 +62,16 @@ export default function MuseumCard({ museum, priority = false }) {
   const showAffiliateNote = Boolean(museum.ticketUrl) && shouldShowAffiliateNote(museum.slug);
   const ticketNoteId = useId();
   const ticketHoverMessage = showAffiliateNote ? t('ticketsAffiliateDisclosure') : undefined;
+  const ticketDisclosureLine = [t('ticketsAffiliateDisclosure'), t('ticketsAffiliatePricesMayVary')]
+    .filter(Boolean)
+    .join(' ');
   const ticketContext = showAffiliateNote
     ? [
         <span key="intro" className="ticket-button__note-line">
           {t('ticketsAffiliateIntro')}
         </span>,
-        <span key="disclosure" className="ticket-button__note-line ticket-button__note-disclosure">
-          {t('ticketsAffiliateDisclosure')}
-        </span>,
-        <span key="prices" className="ticket-button__note-line ticket-button__note-disclosure">
-          {t('ticketsAffiliatePricesMayVary')}
+        <span key="details" className="ticket-button__note-line ticket-button__note-disclosure">
+          {ticketDisclosureLine}
         </span>,
       ]
     : null;

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -367,11 +367,13 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
   const ticketUrl = affiliateTicketUrl || directTicketUrl;
   const showAffiliateNote = Boolean(affiliateTicketUrl) && shouldShowAffiliateNote(slug);
   const ticketHoverMessage = showAffiliateNote ? t('ticketsAffiliateDisclosure') : undefined;
+  const ticketDetailsLine = [t('ticketsAffiliateDisclosure'), t('ticketsAffiliatePricesMayVary')]
+    .filter(Boolean)
+    .join(' ');
   const ticketNoteDefinitions = showAffiliateNote
     ? [
         { key: 'intro', message: t('ticketsAffiliateIntro'), disclosure: false },
-        { key: 'disclosure', message: t('ticketsAffiliateDisclosure'), disclosure: true },
-        { key: 'prices', message: t('ticketsAffiliatePricesMayVary'), disclosure: true },
+        { key: 'details', message: ticketDetailsLine, disclosure: true },
       ]
     : [];
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2428,7 +2428,7 @@ button.hero-quick-link {
   align-items: flex-start;
   gap: 6px;
   width: 100%;
-  font-size: 0.6875rem;
+  font-size: 0.625rem;
   font-weight: 500;
   line-height: 1.45;
   color: rgba(71, 85, 105, 0.95);


### PR DESCRIPTION
## Summary
- collapse the affiliate ticket note copy into two lines across museum and exhibition views
- reduce the ticket note font size for a subtler presentation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d669ee4344832695471d585f292f99