### PR TITLE
Refine MuseumCard accent styling

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -9,29 +9,10 @@ import { shouldShowAffiliateNote } from '../lib/nonAffiliateMuseums';
 import formatImageCredit from '../lib/formatImageCredit';
 import TicketButtonNote from './TicketButtonNote';
 
-const HOVER_COLORS = ['#A7D8F0', '#77DDDD', '#F7C59F', '#D8BFD8', '#EAE0C8'];
+// Keep in sync with --card-accent-soft-solid in styles/globals.css
+const CARD_ACCENT_SOFT_HEX = '#dbeafe';
 
-function hashKey(value) {
-  if (!value) return 0;
-  const str = String(value);
-  let hash = 0;
-  for (let i = 0; i < str.length; i += 1) {
-    hash = (hash << 5) - hash + str.charCodeAt(i);
-    hash |= 0;
-  }
-  return Math.abs(hash);
-}
-
-function getHoverColor(slug, id) {
-  const key = slug || (typeof id !== 'undefined' ? String(id) : '');
-  if (!key) {
-    return HOVER_COLORS[0];
-  }
-  const index = hashKey(key) % HOVER_COLORS.length;
-  return HOVER_COLORS[index];
-}
-
-function createBlurDataUrl(color) {
+function createBlurDataUrl(color = CARD_ACCENT_SOFT_HEX) {
   if (typeof color !== 'string' || !color) {
     return 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 20"%3E%3Crect width="32" height="20" fill="%23e2e8f0" /%3E%3C/svg%3E';
   }
@@ -39,10 +20,12 @@ function createBlurDataUrl(color) {
   const normalized = color.startsWith('#') ? color : `#${color}`;
   const sanitized = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(normalized)
     ? normalized
-    : '#e2e8f0';
+    : CARD_ACCENT_SOFT_HEX;
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 20"><rect width="32" height="20" fill="${sanitized}" /></svg>`;
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 }
+
+const DEFAULT_BLUR_DATA_URL = createBlurDataUrl();
 
 export default function MuseumCard({ museum, priority = false }) {
   if (!museum) return null;
@@ -50,11 +33,7 @@ export default function MuseumCard({ museum, priority = false }) {
   const { favorites, toggleFavorite } = useFavorites();
   const { t, lang } = useLanguage();
   const isFavorite = favorites.some((f) => f.id === museum.id && f.type === 'museum');
-  const hoverColor = useMemo(
-    () => getHoverColor(museum.slug, museum.id),
-    [museum.slug, museum.id]
-  );
-  const blurDataUrl = useMemo(() => createBlurDataUrl(hoverColor), [hoverColor]);
+  const blurDataUrl = DEFAULT_BLUR_DATA_URL;
 
   const summary = museumSummaries[museum.slug]?.[lang] || museum.summary;
   const hours = museumOpeningHours[museum.slug]?.[lang];
@@ -246,7 +225,7 @@ export default function MuseumCard({ museum, priority = false }) {
   };
 
   return (
-    <article className="museum-card" style={{ '--hover-bg': hoverColor }}>
+    <article className="museum-card">
       <div className="museum-card-image">
         <Link
           href={{ pathname: '/museum/[slug]', query: { slug: museum.slug } }}
@@ -313,7 +292,7 @@ export default function MuseumCard({ museum, priority = false }) {
         <h3 className="museum-card-title">
           <Link
             href={{ pathname: '/museum/[slug]', query: { slug: museum.slug } }}
-            style={{ color: 'inherit', textDecoration: 'none' }}
+            className="museum-card-title-link"
           >
             {museum.title}
           </Link>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -8,6 +8,10 @@
   --border: rgba(148, 163, 184, 0.45);
   --accent: #2563eb;
   --accent-ink: #ffffff;
+  --card-accent: #2563eb;
+  --card-accent-rgb: 37, 99, 235;
+  --card-accent-soft: rgba(var(--card-accent-rgb), 0.16);
+  --card-accent-soft-solid: #dbeafe;
   --surface: #ffffff;
   --panel-bg: rgba(255, 255, 255, 0.92);
   --panel-border: rgba(148, 163, 184, 0.32);
@@ -47,6 +51,10 @@
   --border: rgba(71, 85, 105, 0.55);
   --accent: #38bdf8;
   --accent-ink: #0f172a;
+  --card-accent: #38bdf8;
+  --card-accent-rgb: 56, 189, 248;
+  --card-accent-soft: rgba(var(--card-accent-rgb), 0.2);
+  --card-accent-soft-solid: #0f2942;
   --surface: #111827;
   --panel-bg: rgba(15, 23, 42, 0.86);
   --panel-border: rgba(100, 116, 139, 0.45);
@@ -2198,7 +2206,14 @@ button.hero-quick-link {
   align-items: flex-end;
   justify-content: space-between;
   gap: 12px;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.35) 45%, rgba(15, 23, 42, 0.68) 100%);
+  background:
+    linear-gradient(
+      180deg,
+      rgba(15, 23, 42, 0) 0%,
+      rgba(15, 23, 42, 0.35) 45%,
+      rgba(15, 23, 42, 0.68) 100%
+    ),
+    linear-gradient(180deg, rgba(var(--card-accent-rgb), 0) 0%, rgba(var(--card-accent-rgb), 0.35) 100%);
   opacity: 0;
   transform: translateY(12px);
   transition: opacity 0.35s ease, transform 0.35s ease;
@@ -2227,9 +2242,10 @@ button.hero-quick-link {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: var(--hover-bg, rgba(255, 255, 255, 0.85));
-  color: rgba(15, 23, 42, 0.9);
-  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.35);
+  background: var(--card-accent-soft);
+  color: var(--card-accent);
+  border: 1px solid rgba(var(--card-accent-rgb), 0.25);
+  box-shadow: 0 16px 32px rgba(var(--card-accent-rgb), 0.24);
 }
 
 .museum-card-overlay-icon svg {
@@ -2256,17 +2272,18 @@ button.hero-quick-link {
   gap: 6px;
   padding: 6px;
   border-radius: 16px;
-  background: var(--chip-bg);
-  border: 1px solid var(--chip-border);
-  box-shadow: 0 12px 24px rgba(15,23,42,0.14);
+  background: var(--card-accent-soft);
+  border: 1px solid rgba(var(--card-accent-rgb), 0.18);
+  box-shadow: 0 12px 24px rgba(var(--card-accent-rgb), 0.18);
   backdrop-filter: blur(10px);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
   z-index: 1;
+  color: var(--card-accent);
 }
 
 .museum-card:hover .museum-card-actions {
   transform: translateY(-2px);
-  box-shadow: 0 16px 32px rgba(15,23,42,0.18);
+  box-shadow: 0 16px 32px rgba(var(--card-accent-rgb), 0.24);
 }
 
 .museum-card-ticket {
@@ -2287,7 +2304,11 @@ button.hero-quick-link {
   gap: 8px;
   padding: 8px 14px;
   border-radius: 0.8125rem;
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.95), rgba(37, 99, 235, 0.82));
+  background: linear-gradient(
+    135deg,
+    rgba(var(--card-accent-rgb), 0.95),
+    rgba(var(--card-accent-rgb), 0.82)
+  );
   color: var(--accent-ink);
   border: 1px solid rgba(255, 255, 255, 0.32);
   box-shadow: 0 14px 32px rgba(15, 23, 42, 0.26);
@@ -2296,7 +2317,11 @@ button.hero-quick-link {
 }
 
 .ticket-button--card:hover {
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.98), rgba(14, 165, 233, 0.92));
+  background: linear-gradient(
+    135deg,
+    rgba(var(--card-accent-rgb), 0.98),
+    rgba(var(--card-accent-rgb), 0.88)
+  );
   box-shadow: 0 18px 42px rgba(15, 23, 42, 0.32);
 }
 
@@ -2702,30 +2727,21 @@ button.hero-quick-link {
   border-radius: 12px;
   gap: 0;
   box-shadow: none;
+  transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
 }
 
 .museum-card-actions .icon-button:not(.favorited) {
-  background: transparent;
-  border: 1px solid var(--panel-border);
-  color: var(--muted);
+  background: rgba(var(--card-accent-rgb), 0.08);
+  border: 1px solid rgba(var(--card-accent-rgb), 0.22);
+  color: var(--card-accent);
 }
 
-.museum-card-actions .icon-button:not(.favorited):hover {
-  background: rgba(255,255,255,0.85);
-  border-color: rgba(15,23,42,0.12);
-  color: var(--text);
-}
-
-[data-theme='dark'] .museum-card-actions .icon-button:not(.favorited) {
-  background: rgba(15,23,42,0.35);
-  border-color: rgba(148,163,184,0.28);
-  color: var(--muted);
-}
-
-[data-theme='dark'] .museum-card-actions .icon-button:not(.favorited):hover {
-  background: rgba(15,23,42,0.55);
-  border-color: rgba(148,163,184,0.32);
-  color: var(--text);
+.museum-card-actions .icon-button:not(.favorited):hover,
+.museum-card-actions .icon-button:not(.favorited):focus-visible {
+  background: rgba(var(--card-accent-rgb), 0.16);
+  border-color: rgba(var(--card-accent-rgb), 0.3);
+  color: var(--card-accent);
+  box-shadow: 0 8px 18px rgba(var(--card-accent-rgb), 0.2);
 }
 
 .museum-card-info {
@@ -2742,6 +2758,17 @@ button.hero-quick-link {
   font-weight: 600;
   letter-spacing: -0.015em;
   line-height: 1.25;
+}
+
+.museum-card-title-link {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.museum-card-title-link:hover,
+.museum-card-title-link:focus-visible {
+  color: var(--card-accent);
 }
 
 .museum-card-meta {
@@ -2768,7 +2795,7 @@ button.hero-quick-link {
   align-items: center;
   justify-content: center;
   margin-top: 2px;
-  color: var(--accent);
+  color: var(--card-accent);
 }
 
 .museum-card-meta-icon svg {


### PR DESCRIPTION
## Summary
- align the MuseumCard blur placeholder and title link with the new card accent design tokens
- introduce global card accent variables and apply them to the card overlay, actions, and ticket CTA styles
- update non-favorited action buttons to use the accent tokens for hover and focus states

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d66b272df48326a00f0eb86e07e6e1