### PR TITLE
Tighten mobile header layout on small screens

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -242,11 +242,14 @@ img { max-width: 100%; height: auto; display: block; }
   background: color-mix(in srgb, var(--bg) 86%, transparent);
   border-bottom-color: color-mix(in srgb, var(--border) 70%, transparent);
 }
+.header .navbar {
+  padding: clamp(12px, 3vw, 18px) clamp(20px, 6vw, 44px);
+}
 .navbar {
   display: flex;
   align-items: center;
   gap: clamp(16px, 4vw, 32px);
-  padding: clamp(14px, 2.5vw, 18px) clamp(22px, 6vw, 44px);
+  padding: 0;
   flex-wrap: wrap;
 }
 
@@ -624,9 +627,9 @@ button.header-link {
 }
 
 @media (max-width: 960px) {
-  .navbar {
+  .header .navbar {
+    padding: clamp(10px, 2.8vw, 16px) clamp(18px, 5vw, 32px);
     gap: 16px;
-    padding: clamp(12px, 3vw, 16px) clamp(18px, 5vw, 24px);
   }
 
   .header-links {
@@ -645,61 +648,120 @@ button.header-link {
 }
 
 @media (max-width: 680px) {
+  .header {
+    background: color-mix(in srgb, var(--bg) 88%, transparent);
+    border-bottom-color: color-mix(in srgb, var(--border) 58%, transparent);
+  }
+
+  [data-theme='dark'] .header {
+    background: color-mix(in srgb, var(--bg) 80%, transparent);
+    border-bottom-color: color-mix(in srgb, var(--border) 62%, transparent);
+  }
+
+  .header .navbar {
+    padding: 10px 16px;
+    gap: 14px;
+  }
+
   .header-brand {
-    width: 100%;
+    width: auto;
+    padding: 0;
+    gap: 10px;
+    background: none;
+    border: none;
+    box-shadow: none;
+  }
+
+  .brand-square {
+    width: 36px;
+    height: 36px;
+    border-radius: 12px;
+    font-size: 0.85rem;
   }
 
   .brand-title {
-    font-size: 1.05rem;
+    font-size: 1rem;
   }
 
-  .brand-tagline {
-    letter-spacing: 0.18em;
-  }
-
-  .header-links {
-    gap: 8px;
-  }
-
-  .header-link {
-    padding: 10px 12px;
-  }
-
-  .header-actions {
-    width: 100%;
-    justify-content: flex-start;
-    flex-wrap: wrap;
-    gap: 10px;
-  }
-
-  .lang-select,
-  .contrast-toggle {
-    flex: 1 1 140px;
-    justify-content: center;
-    min-height: 44px;
-  }
-}
-
-@media (max-width: 480px) {
   .brand-tagline {
     display: none;
   }
 
   .header-links {
-    gap: 10px;
+    order: 3;
+    flex: 1 1 100%;
+    width: 100%;
+    flex-wrap: nowrap;
+    gap: 12px;
+    overflow-x: auto;
+    padding-bottom: 2px;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .header-links::-webkit-scrollbar {
+    display: none;
   }
 
   .header-link {
-    flex: 1 1 calc(50% - 10px);
-    justify-content: center;
+    flex: 0 0 auto;
+    padding: 6px 0;
+    background: none;
+    border: none;
+    box-shadow: none;
+    color: color-mix(in srgb, var(--muted) 85%, var(--text) 15%);
+    font-size: 0.9rem;
+    font-weight: 600;
+  }
+
+  .header-link:hover,
+  .header-link:focus-visible {
+    color: var(--text);
+    text-decoration: underline;
+    background: none;
+  }
+
+  .header-link svg {
+    width: 16px;
+    height: 16px;
+  }
+
+  .header-link--favorites {
+    padding-inline: 0;
   }
 
   .header-link--filters {
-    flex-basis: 100%;
+    padding: 6px 14px;
   }
 
   .header-actions {
-    gap: 12px;
+    order: 2;
+    width: auto;
+    margin-left: auto;
+    flex-wrap: nowrap;
+    gap: 8px;
+  }
+
+  .lang-select,
+  .contrast-toggle {
+    flex: 0 0 40px;
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    justify-content: center;
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--surface) 80%, transparent);
+    border: 1px solid color-mix(in srgb, var(--panel-border) 75%, transparent);
+    box-shadow: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .header .navbar {
+    padding-inline: 16px;
+  }
+
+  .header-links {
+    gap: 10px;
   }
 }
 


### PR DESCRIPTION
## Summary
- reduce padding on the sticky header container and switch the brand treatment to a lighter style on phones
- streamline header action buttons and adjust the filters button so it stays compact while remaining prominent
- allow header navigation links to scroll horizontally on very small screens to avoid multi-row layouts

## Testing
- npm run dev *(fails: next not found because dependencies are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d66e1a0d648326844bb8f9926f6d27