### PR TITLE
Adjust mobile language toggle alignment

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -753,6 +753,16 @@ button.header-link {
     border: 1px solid color-mix(in srgb, var(--panel-border) 75%, transparent);
     box-shadow: none;
   }
+
+  .lang-select {
+    gap: 0;
+    font-size: 0.8rem;
+    font-weight: 700;
+  }
+
+  .lang-select svg {
+    display: none;
+  }
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- tighten the mobile language switch styling so the button contents are centered and balanced

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6706071a48326a768fe7ba173df71