### PR TITLE
Refactor museum detail hero layout

### DIFF
--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -941,97 +941,29 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
 
       <header className={`museum-detail-hero-section${heroImage ? ' has-hero-image' : ''}`}>
         <div className="museum-detail-container">
-          <div className="museum-hero-heading-container">
-          <div className="museum-hero-heading">
-            <nav className="museum-breadcrumbs" aria-label={t('breadcrumbsLabel')}>
-              <Link href="/" className="museum-backlink">
-                <svg
-                  viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden="true"
-                    width="20"
-                    height="20"
-                  >
-                    <path d="M15 18l-6-6 6-6" />
-                  </svg>
-                  <span>{t('breadcrumbMuseums')}</span>
-                </Link>
-              </nav>
+          <nav className="museum-breadcrumbs" aria-label={t('breadcrumbsLabel')}>
+            <Link href="/" className="museum-backlink">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+                width="20"
+                height="20"
+              >
+                <path d="M15 18l-6-6 6-6" />
+              </svg>
+              <span>{t('breadcrumbMuseums')}</span>
+            </Link>
+          </nav>
+        </div>
 
-              <div className="museum-hero-text">
-                {locationLabel && <p className="detail-sub museum-hero-location">{locationLabel}</p>}
-                <h1 className="detail-title museum-hero-title">{displayName}</h1>
-                {summary && <p className="detail-sub museum-hero-tagline">{summary}</p>}
-              </div>
-
-              <div className="museum-hero-actions">
-                {hasTicketLink ? (
-                  <div className="museum-hero-primary">
-                    <a
-                      href={ticketUrl}
-                      target="_blank"
-                      rel={ticketRel}
-                      className="museum-primary-action primary"
-                      aria-describedby={ticketContext ? primaryTicketNoteId : undefined}
-                      onClick={handleTicketLinkClick}
-                      title={ticketHoverMessage}
-                      aria-label={ticketAriaLabel}
-                      data-affiliate={showAffiliateNote ? 'true' : undefined}
-                    >
-                      <span
-                        className={
-                          showAffiliateNote
-                            ? 'ticket-button__label ticket-button__label--stacked'
-                            : 'ticket-button__label'
-                        }
-                      >
-                        <span className="ticket-button__label-text">{t('buyTickets')}</span>
-                        {showAffiliateNote ? (
-                          <span className="ticket-button__badge">
-                            {t('ticketsPartnerBadge')}
-                            <span className="sr-only"> — {t('ticketsAffiliateIntro')}</span>
-                          </span>
-                        ) : null}
-                      </span>
-                    </a>
-                    {ticketContext ? (
-                      <TicketButtonNote
-                        affiliate={showAffiliateNote}
-                        showIcon={false}
-                        id={primaryTicketNoteId}
-                        className="museum-primary-action__note museum-hero-ticket-note"
-                      >
-                        {ticketContext}
-                      </TicketButtonNote>
-                    ) : null}
-                  </div>
-                ) : null}
-
-                <div className="museum-hero-utilities">
-                  {hasWebsite ? (
-                    <a
-                      href={resolvedMuseum.websiteUrl}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="museum-primary-action secondary museum-hero-secondary-action"
-                      onClick={handleWebsiteLinkClick}
-                    >
-                      <span>{t('website')}</span>
-                    </a>
-                  ) : null}
-                  <ShareButton onShare={handleShare} label={t('share')} />
-                  <FavoriteButton active={isFavorite} onToggle={handleFavorite} label={t('save')} />
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {heroImage && (
-            <div className="museum-detail-hero">
+        <div className="museum-detail-hero">
+          {heroImage ? (
+            <>
               <Image
                 src={heroImage}
                 alt={displayName}
@@ -1041,6 +973,80 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
                 priority={isLandingMuseum}
                 loading={isLandingMuseum ? 'eager' : 'lazy'}
               />
+              <div className="museum-hero-overlay">
+                <div className="museum-detail-container">
+                  <div className="museum-hero-overlay-card">
+                    <div className="museum-hero-heading">
+                      <div className="museum-hero-text">
+                        {locationLabel && <p className="detail-sub museum-hero-location">{locationLabel}</p>}
+                        <h1 className="detail-title museum-hero-title">{displayName}</h1>
+                        {summary && <p className="detail-sub museum-hero-tagline">{summary}</p>}
+                      </div>
+
+                      <div className="museum-hero-actions">
+                        {hasTicketLink ? (
+                          <div className="museum-hero-primary">
+                            <a
+                              href={ticketUrl}
+                              target="_blank"
+                              rel={ticketRel}
+                              className="museum-primary-action primary"
+                              aria-describedby={ticketContext ? primaryTicketNoteId : undefined}
+                              onClick={handleTicketLinkClick}
+                              title={ticketHoverMessage}
+                              aria-label={ticketAriaLabel}
+                              data-affiliate={showAffiliateNote ? 'true' : undefined}
+                            >
+                              <span
+                                className={
+                                  showAffiliateNote
+                                    ? 'ticket-button__label ticket-button__label--stacked'
+                                    : 'ticket-button__label'
+                                }
+                              >
+                                <span className="ticket-button__label-text">{t('buyTickets')}</span>
+                                {showAffiliateNote ? (
+                                  <span className="ticket-button__badge">
+                                    {t('ticketsPartnerBadge')}
+                                    <span className="sr-only"> — {t('ticketsAffiliateIntro')}</span>
+                                  </span>
+                                ) : null}
+                              </span>
+                            </a>
+                            {ticketContext ? (
+                              <TicketButtonNote
+                                affiliate={showAffiliateNote}
+                                showIcon={false}
+                                id={primaryTicketNoteId}
+                                className="museum-primary-action__note museum-hero-ticket-note"
+                              >
+                                {ticketContext}
+                              </TicketButtonNote>
+                            ) : null}
+                          </div>
+                        ) : null}
+
+                        <div className="museum-hero-utilities">
+                          {hasWebsite ? (
+                            <a
+                              href={resolvedMuseum.websiteUrl}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="museum-primary-action secondary museum-hero-secondary-action"
+                              onClick={handleWebsiteLinkClick}
+                            >
+                              <span>{t('website')}</span>
+                            </a>
+                          ) : null}
+                          <ShareButton onShare={handleShare} label={t('share')} />
+                          <FavoriteButton active={isFavorite} onToggle={handleFavorite} label={t('save')} />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
               {!isPublicDomainImage && hasCreditSegments && (
                 <p className="museum-hero-credit" title={creditFullText || undefined}>
                   {creditSegments.map((segment, index) => (
@@ -1066,6 +1072,76 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
                   ))}
                 </p>
               )}
+            </>
+          ) : (
+            <div className="museum-detail-container">
+              <div className="museum-hero-heading museum-hero-heading--no-image">
+                <div className="museum-hero-text">
+                  {locationLabel && <p className="detail-sub museum-hero-location">{locationLabel}</p>}
+                  <h1 className="detail-title museum-hero-title">{displayName}</h1>
+                  {summary && <p className="detail-sub museum-hero-tagline">{summary}</p>}
+                </div>
+
+                <div className="museum-hero-actions">
+                  {hasTicketLink ? (
+                    <div className="museum-hero-primary">
+                      <a
+                        href={ticketUrl}
+                        target="_blank"
+                        rel={ticketRel}
+                        className="museum-primary-action primary"
+                        aria-describedby={ticketContext ? primaryTicketNoteId : undefined}
+                        onClick={handleTicketLinkClick}
+                        title={ticketHoverMessage}
+                        aria-label={ticketAriaLabel}
+                        data-affiliate={showAffiliateNote ? 'true' : undefined}
+                      >
+                        <span
+                          className={
+                            showAffiliateNote
+                              ? 'ticket-button__label ticket-button__label--stacked'
+                              : 'ticket-button__label'
+                          }
+                        >
+                          <span className="ticket-button__label-text">{t('buyTickets')}</span>
+                          {showAffiliateNote ? (
+                            <span className="ticket-button__badge">
+                              {t('ticketsPartnerBadge')}
+                              <span className="sr-only"> — {t('ticketsAffiliateIntro')}</span>
+                            </span>
+                          ) : null}
+                        </span>
+                      </a>
+                      {ticketContext ? (
+                        <TicketButtonNote
+                          affiliate={showAffiliateNote}
+                          showIcon={false}
+                          id={primaryTicketNoteId}
+                          className="museum-primary-action__note museum-hero-ticket-note"
+                        >
+                          {ticketContext}
+                        </TicketButtonNote>
+                      ) : null}
+                    </div>
+                  ) : null}
+
+                  <div className="museum-hero-utilities">
+                    {hasWebsite ? (
+                      <a
+                        href={resolvedMuseum.websiteUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="museum-primary-action secondary museum-hero-secondary-action"
+                        onClick={handleWebsiteLinkClick}
+                      >
+                        <span>{t('website')}</span>
+                      </a>
+                    ) : null}
+                    <ShareButton onShare={handleShare} label={t('share')} />
+                    <FavoriteButton active={isFavorite} onToggle={handleFavorite} label={t('save')} />
+                  </div>
+                </div>
+              </div>
             </div>
           )}
         </div>

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -975,7 +975,7 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
               />
               <div className="museum-hero-overlay">
                 <div className="museum-detail-container">
-                  <div className="museum-hero-overlay-card">
+                  <div className="museum-hero-content">
                     <div className="museum-hero-heading">
                       <div className="museum-hero-text">
                         {locationLabel && <p className="detail-sub museum-hero-location">{locationLabel}</p>}

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -1189,31 +1189,31 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
             </div>
 
             <div className="museum-detail-grid">
-          <div className="museum-detail-main">
-            <div className="museum-tablist" role="tablist" aria-label={t('museumTabsLabel')}>
-              {tabDefinitions.map((tab, index) => {
-                const isActive = activeTab === tab.id;
-                return (
-                  <button
-                    key={tab.id}
-                    type="button"
-                    role="tab"
-                    id={`museum-tab-${tab.id}`}
-                    aria-controls={tab.hash}
-                    aria-selected={isActive}
-                    aria-label={tab.title}
-                    tabIndex={isActive ? 0 : -1}
-                    className={`museum-tab${isActive ? ' is-active' : ''}`}
-                    onClick={() => handleTabSelect(tab.id)}
-                    onKeyDown={(event) => handleTabKeyDown(event, index)}
-                  >
-                    <span>{tab.label}</span>
-                  </button>
-                );
-              })}
-            </div>
+              <div className="museum-detail-main">
+                <div className="museum-tablist" role="tablist" aria-label={t('museumTabsLabel')}>
+                  {tabDefinitions.map((tab, index) => {
+                    const isActive = activeTab === tab.id;
+                    return (
+                      <button
+                        key={tab.id}
+                        type="button"
+                        role="tab"
+                        id={`museum-tab-${tab.id}`}
+                        aria-controls={tab.hash}
+                        aria-selected={isActive}
+                        aria-label={tab.title}
+                        tabIndex={isActive ? 0 : -1}
+                        className={`museum-tab${isActive ? ' is-active' : ''}`}
+                        onClick={() => handleTabSelect(tab.id)}
+                        onKeyDown={(event) => handleTabKeyDown(event, index)}
+                      >
+                        <span>{tab.label}</span>
+                      </button>
+                    );
+                  })}
+                </div>
 
-            <section
+                <section
               id={TAB_HASHES.overview}
               role="tabpanel"
               aria-labelledby="museum-tab-overview"
@@ -1273,9 +1273,9 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
                   </ul>
                 )}
               </div>
-            </section>
+                </section>
 
-            <section
+                <section
               id={TAB_HASHES.exhibitions}
               role="tabpanel"
               aria-labelledby="museum-tab-exhibitions"
@@ -1388,9 +1388,9 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
                   )}
                 </div>
               </div>
-            </section>
+                </section>
 
-            <section
+                <section
               id={TAB_HASHES.map}
               role="tabpanel"
               aria-labelledby="museum-tab-map"
@@ -1427,8 +1427,8 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
                   <p className="museum-map-empty">{t('mapUnavailable')}</p>
                 )}
               </div>
-            </section>
-          </div>
+                </section>
+              </div>
 
           <aside
             className={`museum-sidebar museum-tabpanel${activeTab === 'info' ? ' is-active' : ''}`}
@@ -1507,10 +1507,9 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
 
             </div>
           </aside>
+            </div>
+          </div>
         </div>
-      </div>
-    </div>
-  </div>
       </section>
 
       {hasMobilePrimaryActions ? (

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -1037,153 +1037,158 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
         idPrefix="exposition-filters-sheet"
       />
 
-      <div className="museum-detail-container museum-hero-heading-container">
-        <div className="museum-hero-heading">
-          <nav className="museum-breadcrumbs" aria-label={t('breadcrumbsLabel')}>
-            <Link href="/" className="museum-backlink">
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
-                width="20"
-                height="20"
-              >
-                <path d="M15 18l-6-6 6-6" />
-              </svg>
-              <span>{t('breadcrumbMuseums')}</span>
-            </Link>
-          </nav>
+      <header className={`museum-detail-hero-section${heroImage ? ' has-hero-image' : ''}`}>
+        <div className="museum-detail-container">
+          <div className="museum-hero-heading-container">
+            <div className="museum-hero-heading">
+              <nav className="museum-breadcrumbs" aria-label={t('breadcrumbsLabel')}>
+                <Link href="/" className="museum-backlink">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                    width="20"
+                    height="20"
+                  >
+                    <path d="M15 18l-6-6 6-6" />
+                  </svg>
+                  <span>{t('breadcrumbMuseums')}</span>
+                </Link>
+              </nav>
 
-          <div className="museum-hero-text">
-            {locationLabel && <p className="detail-sub museum-hero-location">{locationLabel}</p>}
-            <h1 className="detail-title museum-hero-title">{displayName}</h1>
-            {summary && <p className="detail-sub museum-hero-tagline">{summary}</p>}
+              <div className="museum-hero-text">
+                {locationLabel && <p className="detail-sub museum-hero-location">{locationLabel}</p>}
+                <h1 className="detail-title museum-hero-title">{displayName}</h1>
+                {summary && <p className="detail-sub museum-hero-tagline">{summary}</p>}
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
 
-      {heroImage && (
-        <div className="museum-detail-hero">
-          <Image
-            src={heroImage}
-            alt={displayName}
-            fill
-            className="museum-hero-image"
-            sizes="(max-width: 640px) 100vw, (max-width: 1200px) 90vw, 1200px"
-            priority={isLandingMuseum}
-            loading={isLandingMuseum ? 'eager' : 'lazy'}
-          />
-          {!isPublicDomainImage && hasCreditSegments && (
-            <p className="museum-hero-credit" title={creditFullText || undefined}>
-              {creditSegments.map((segment, index) => (
-                <Fragment key={`hero-credit-${segment.key}-${index}`}>
-                  {index > 0 && (
-                    <span aria-hidden="true" className="image-credit-divider">
-                      •
-                    </span>
-                  )}
-                  {segment.url ? (
+          {heroImage && (
+            <div className="museum-detail-hero">
+              <Image
+                src={heroImage}
+                alt={displayName}
+                fill
+                className="museum-hero-image"
+                sizes="(max-width: 640px) 100vw, (max-width: 1200px) 90vw, 1200px"
+                priority={isLandingMuseum}
+                loading={isLandingMuseum ? 'eager' : 'lazy'}
+              />
+              {!isPublicDomainImage && hasCreditSegments && (
+                <p className="museum-hero-credit" title={creditFullText || undefined}>
+                  {creditSegments.map((segment, index) => (
+                    <Fragment key={`hero-credit-${segment.key}-${index}`}>
+                      {index > 0 && (
+                        <span aria-hidden="true" className="image-credit-divider">
+                          •
+                        </span>
+                      )}
+                      {segment.url ? (
+                        <a
+                          className="image-credit-link"
+                          href={segment.url}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          {segment.label}
+                        </a>
+                      ) : (
+                        <span className="image-credit-part">{segment.label}</span>
+                      )}
+                    </Fragment>
+                  ))}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      </header>
+
+      <section className="museum-detail-body">
+        <div className="museum-detail-container">
+          <div className="museum-detail-body-content">
+            <div className="museum-primary-action-bar">
+              <div className="museum-primary-action-group">
+                {hasTicketLink ? (
+                  <div className="museum-primary-action-stack">
                     <a
-                      className="image-credit-link"
-                      href={segment.url}
+                      href={ticketUrl}
                       target="_blank"
-                      rel="noreferrer"
+                      rel={ticketRel}
+                      className="museum-primary-action primary"
+                      aria-describedby={ticketContext ? primaryTicketNoteId : undefined}
+                      onClick={handleTicketLinkClick}
+                      title={ticketHoverMessage}
+                      aria-label={ticketAriaLabel}
+                      data-affiliate={showAffiliateNote ? 'true' : undefined}
                     >
-                      {segment.label}
+                      <span
+                        className={
+                          showAffiliateNote
+                            ? 'ticket-button__label ticket-button__label--stacked'
+                            : 'ticket-button__label'
+                        }
+                      >
+                        <span className="ticket-button__label-text">{t('buyTickets')}</span>
+                        {showAffiliateNote ? (
+                          <span className="ticket-button__badge">
+                            {t('ticketsPartnerBadge')}
+                            <span className="sr-only"> — {t('ticketsAffiliateIntro')}</span>
+                          </span>
+                        ) : null}
+                      </span>
                     </a>
-                  ) : (
-                    <span className="image-credit-part">{segment.label}</span>
-                  )}
-                </Fragment>
-              ))}
-            </p>
-          )}
-        </div>
-      )}
+                    {ticketContext ? (
+                      <TicketButtonNote
+                        affiliate={showAffiliateNote}
+                        showIcon={false}
+                        id={primaryTicketNoteId}
+                        className="museum-primary-action__note"
+                      >
+                        {createTicketNote('primary-ticket-note')}
+                      </TicketButtonNote>
+                    ) : null}
+                  </div>
+                ) : (
+                  <div className="museum-primary-action-stack">
+                    <button
+                      type="button"
+                      className="museum-primary-action primary"
+                      disabled
+                      aria-disabled="true"
+                    >
+                      <span className="ticket-button__label">
+                        <span className="ticket-button__label-text">{t('buyTickets')}</span>
+                      </span>
+                    </button>
+                  </div>
+                )}
 
-      <div className="museum-detail-container">
+                {hasWebsite && (
+                  <a
+                    href={resolvedMuseum.websiteUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="museum-primary-action secondary"
+                    onClick={handleWebsiteLinkClick}
+                  >
+                    <span>{t('website')}</span>
+                  </a>
+                )}
+              </div>
 
-        <div className="museum-primary-action-bar">
-        <div className="museum-primary-action-group">
-          {hasTicketLink ? (
-            <div className="museum-primary-action-stack">
-              <a
-                href={ticketUrl}
-                target="_blank"
-                rel={ticketRel}
-                className="museum-primary-action primary"
-                aria-describedby={ticketContext ? primaryTicketNoteId : undefined}
-                onClick={handleTicketLinkClick}
-                title={ticketHoverMessage}
-                aria-label={ticketAriaLabel}
-                data-affiliate={showAffiliateNote ? 'true' : undefined}
-              >
-                <span
-                  className={
-                    showAffiliateNote
-                      ? 'ticket-button__label ticket-button__label--stacked'
-                      : 'ticket-button__label'
-                  }
-                >
-                  <span className="ticket-button__label-text">{t('buyTickets')}</span>
-                  {showAffiliateNote ? (
-                    <span className="ticket-button__badge">
-                      {t('ticketsPartnerBadge')}
-                      <span className="sr-only"> — {t('ticketsAffiliateIntro')}</span>
-                    </span>
-                  ) : null}
-                </span>
-              </a>
-              {ticketContext ? (
-                <TicketButtonNote
-                  affiliate={showAffiliateNote}
-                  showIcon={false}
-                  id={primaryTicketNoteId}
-                  className="museum-primary-action__note"
-                >
-                  {createTicketNote('primary-ticket-note')}
-                </TicketButtonNote>
-              ) : null}
+              <div className="museum-primary-action-utility">
+                <ShareButton onShare={handleShare} label={t('share')} />
+                <FavoriteButton active={isFavorite} onToggle={handleFavorite} label={t('save')} />
+              </div>
             </div>
-          ) : (
-            <div className="museum-primary-action-stack">
-              <button
-                type="button"
-                className="museum-primary-action primary"
-                disabled
-                aria-disabled="true"
-              >
-                <span className="ticket-button__label">
-                  <span className="ticket-button__label-text">{t('buyTickets')}</span>
-                </span>
-              </button>
-            </div>
-          )}
 
-          {hasWebsite && (
-            <a
-              href={resolvedMuseum.websiteUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="museum-primary-action secondary"
-              onClick={handleWebsiteLinkClick}
-            >
-              <span>{t('website')}</span>
-            </a>
-          )}
-        </div>
-
-          <div className="museum-primary-action-utility">
-            <ShareButton onShare={handleShare} label={t('share')} />
-            <FavoriteButton active={isFavorite} onToggle={handleFavorite} label={t('save')} />
-          </div>
-        </div>
-
-        <div className="museum-detail-grid">
+            <div className="museum-detail-grid">
           <div className="museum-detail-main">
             <div className="museum-tablist" role="tablist" aria-label={t('museumTabsLabel')}>
               {tabDefinitions.map((tab, index) => {
@@ -1504,6 +1509,9 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
           </aside>
         </div>
       </div>
+    </div>
+  </div>
+      </section>
 
       {hasMobilePrimaryActions ? (
         <div className={`museum-mobile-actions${mobileActionsOpen ? ' is-open' : ''}`}>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1325,8 +1325,8 @@ button.hero-quick-link {
 .museum-detail {
   position: relative;
   background: var(--body-bg);
-  padding-bottom: clamp(96px, 10vw, 140px);
-  --museum-hero-lift: clamp(72px, 10vw, 128px);
+  padding-bottom: clamp(84px, 9vw, 132px);
+  --museum-hero-lift: clamp(48px, 8vw, 96px);
 }
 .museum-detail:not(.has-hero) {
   --museum-hero-lift: 0px;
@@ -1334,9 +1334,9 @@ button.hero-quick-link {
 .museum-detail-container { position: relative; z-index: 2; }
 .museum-detail-hero-section {
   position: relative;
-  padding: clamp(16px, 4vw, 40px) clamp(16px, 4vw, 48px)
-    calc(var(--museum-hero-lift) + clamp(32px, 6vw, 72px));
-  background: linear-gradient(180deg, rgba(241, 245, 249, 0.92) 0%, rgba(248, 250, 252, 0.72) 35%, var(--body-bg) 100%);
+  padding: clamp(16px, 4vw, 36px) clamp(16px, 4vw, 44px)
+    calc(var(--museum-hero-lift) + clamp(24px, 5vw, 56px));
+  background: linear-gradient(180deg, rgba(241, 245, 249, 0.92) 0%, rgba(248, 250, 252, 0.78) 38%, var(--body-bg) 100%);
 }
 [data-theme='dark'] .museum-detail-hero-section {
   background: linear-gradient(180deg, rgba(2, 6, 23, 0.95) 0%, rgba(2, 6, 23, 0.88) 40%, var(--body-bg) 100%);
@@ -1349,7 +1349,7 @@ button.hero-quick-link {
 .museum-detail-hero {
   position: relative;
   width: 100%;
-  height: clamp(220px, 42vw, 340px);
+  height: clamp(220px, 40vw, 332px);
   overflow: hidden;
   border-radius: var(--radius-lg);
   box-shadow: 0 18px 30px rgba(15, 23, 42, 0.12);
@@ -1369,16 +1369,16 @@ button.hero-quick-link {
 }
 .museum-detail-body {
   position: relative;
-  padding: calc(var(--museum-hero-lift) + clamp(24px, 5vw, 48px)) clamp(16px, 4vw, 48px)
-    clamp(96px, 10vw, 128px);
+  padding: calc(var(--museum-hero-lift) + clamp(18px, 4vw, 40px)) clamp(16px, 4vw, 44px)
+    clamp(72px, 9vw, 112px);
   background: var(--body-bg);
 }
 .museum-detail-body-content {
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: clamp(28px, 5vw, 48px);
-  transform: translateY(calc(-1 * var(--museum-hero-lift)));
+  gap: clamp(24px, 4vw, 40px);
+  transform: translateY(calc(-0.7 * var(--museum-hero-lift)));
 }
 .museum-detail:not(.has-hero) .museum-detail-body-content {
   transform: none;
@@ -1416,21 +1416,23 @@ button.hero-quick-link {
   inset: 0;
   display: flex;
   align-items: flex-end;
-  padding: clamp(16px, 4vw, 36px);
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.08) 0%, rgba(15, 23, 42, 0.45) 65%, rgba(15, 23, 42, 0.78) 100%);
+  padding: clamp(18px, 4vw, 42px) clamp(18px, 4vw, 44px);
+  background:
+    radial-gradient(120% 120% at 12% 88%, rgba(15, 23, 42, 0.78) 0%, rgba(15, 23, 42, 0.42) 55%, rgba(15, 23, 42, 0) 100%),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.08) 0%, rgba(15, 23, 42, 0.6) 68%, rgba(15, 23, 42, 0.78) 100%);
   pointer-events: none;
 }
 
-.museum-hero-overlay-card {
+.museum-hero-content {
   pointer-events: auto;
+  position: relative;
   width: 100%;
   max-width: min(880px, 100%);
-  padding: clamp(18px, 3vw, 30px);
-  border-radius: var(--radius-lg);
-  background: rgba(15, 23, 42, 0.68);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 3vw, 28px);
+  padding: clamp(12px, 3vw, 20px) clamp(14px, 4vw, 26px);
   color: rgba(248, 250, 252, 0.96);
-  backdrop-filter: blur(18px);
-  box-shadow: 0 22px 46px rgba(15, 23, 42, 0.35);
 }
 
 .museum-hero-heading {
@@ -1451,6 +1453,10 @@ button.hero-quick-link {
   flex-direction: column;
   gap: 6px;
   max-width: 720px;
+}
+
+.museum-hero-content .museum-hero-text > * {
+  text-shadow: 0 14px 32px rgba(15, 23, 42, 0.6);
 }
 
 .museum-hero-location {
@@ -1635,46 +1641,46 @@ button.hero-quick-link {
   color: var(--muted);
 }
 
-.museum-hero-overlay-card .museum-hero-location,
-.museum-hero-overlay-card .museum-hero-tagline,
-.museum-hero-overlay-card .museum-primary-action__note {
+.museum-hero-content .museum-hero-location,
+.museum-hero-content .museum-hero-tagline,
+.museum-hero-content .museum-primary-action__note {
   color: rgba(248, 250, 252, 0.82);
 }
 
-.museum-hero-overlay-card .museum-primary-action.primary {
+.museum-hero-content .museum-primary-action.primary {
   background: rgba(248, 250, 252, 0.92);
   color: #0f172a;
   box-shadow: 0 16px 32px rgba(15, 23, 42, 0.32);
 }
 
-.museum-hero-overlay-card .museum-primary-action.primary:hover {
+.museum-hero-content .museum-primary-action.primary:hover {
   background: #fff;
 }
 
-.museum-hero-overlay-card .museum-primary-action.secondary {
+.museum-hero-content .museum-primary-action.secondary {
   background: rgba(15, 23, 42, 0.24);
   border-color: rgba(248, 250, 252, 0.35);
   color: rgba(248, 250, 252, 0.92);
 }
 
-.museum-hero-overlay-card .museum-primary-action.secondary:hover {
+.museum-hero-content .museum-primary-action.secondary:hover {
   background: rgba(248, 250, 252, 0.12);
 }
 
-.museum-hero-overlay-card .museum-hero-utilities .icon-button {
+.museum-hero-content .museum-hero-utilities .icon-button {
   background: rgba(15, 23, 42, 0.4);
   border-color: rgba(248, 250, 252, 0.35);
   color: rgba(248, 250, 252, 0.95);
   box-shadow: 0 14px 28px rgba(15, 23, 42, 0.3);
 }
 
-.museum-hero-overlay-card .museum-hero-utilities .icon-button:hover,
-.museum-hero-overlay-card .museum-hero-utilities .icon-button:focus-visible {
+.museum-hero-content .museum-hero-utilities .icon-button:hover,
+.museum-hero-content .museum-hero-utilities .icon-button:focus-visible {
   background: rgba(248, 250, 252, 0.18);
   color: #fff;
 }
 
-.museum-hero-overlay-card .museum-hero-utilities .icon-button.favorited {
+.museum-hero-content .museum-hero-utilities .icon-button.favorited {
   color: #fb7185;
   background: rgba(248, 250, 252, 0.2);
   box-shadow: 0 18px 32px rgba(251, 113, 133, 0.32);
@@ -1727,7 +1733,7 @@ button.hero-quick-link {
 
 .museum-detail-grid {
   display: grid;
-  gap: clamp(32px, 6vw, 48px);
+  gap: clamp(28px, 5vw, 44px);
   grid-template-columns: minmax(0, 1fr) minmax(0, 360px);
   align-items: start;
   margin: 0;
@@ -1998,7 +2004,7 @@ button.hero-quick-link {
 }
 
 @media (max-width: 1200px) {
-  .museum-detail { --museum-hero-lift: clamp(64px, 14vw, 120px); }
+  .museum-detail { --museum-hero-lift: clamp(44px, 12vw, 88px); }
   .museum-detail-grid { grid-template-columns: minmax(0, 1fr); }
   .museum-sidebar {
     position: static;
@@ -2008,24 +2014,24 @@ button.hero-quick-link {
 }
 
 @media (max-width: 900px) {
-  .museum-detail { --museum-hero-lift: clamp(56px, 22vw, 108px); }
+  .museum-detail { --museum-hero-lift: clamp(40px, 20vw, 80px); }
 }
 
 @media (max-width: 768px) {
   .museum-detail {
     padding-bottom: calc(148px + env(safe-area-inset-bottom, 0px));
-    --museum-hero-lift: clamp(52px, 28vw, 96px);
+    --museum-hero-lift: clamp(36px, 24vw, 76px);
   }
   .museum-detail-hero-section {
-    padding: clamp(18px, 7vw, 40px) clamp(16px, 6vw, 32px)
-      calc(var(--museum-hero-lift) + clamp(28px, 9vw, 52px));
+    padding: clamp(18px, 7vw, 36px) clamp(16px, 6vw, 30px)
+      calc(var(--museum-hero-lift) + clamp(22px, 8vw, 44px));
   }
   .museum-detail-body {
-    padding: calc(var(--museum-hero-lift) + clamp(20px, 6vw, 44px)) clamp(16px, 6vw, 32px)
-      clamp(96px, 20vw, 160px);
+    padding: calc(var(--museum-hero-lift) + clamp(16px, 6vw, 36px)) clamp(16px, 6vw, 30px)
+      clamp(88px, 20vw, 150px);
   }
   .museum-detail-body-content {
-    gap: clamp(28px, 8vw, 48px);
+    gap: clamp(24px, 8vw, 44px);
   }
   .museum-hero-heading { gap: 12px; }
   .museum-hero-tagline { font-size: 15px; }
@@ -2049,18 +2055,18 @@ button.hero-quick-link {
 @media (max-width: 600px) {
   .museum-detail {
     padding-bottom: calc(176px + env(safe-area-inset-bottom, 0px));
-    --museum-hero-lift: clamp(44px, 34vw, 84px);
+    --museum-hero-lift: clamp(32px, 28vw, 68px);
   }
   .museum-detail-hero-section {
-    padding: clamp(16px, 8vw, 36px) clamp(16px, 7vw, 28px)
-      calc(var(--museum-hero-lift) + clamp(24px, 9vw, 44px));
+    padding: clamp(16px, 8vw, 32px) clamp(16px, 7vw, 26px)
+      calc(var(--museum-hero-lift) + clamp(18px, 8vw, 40px));
   }
   .museum-detail-body {
-    padding: calc(var(--museum-hero-lift) + clamp(18px, 8vw, 40px)) clamp(16px, 7vw, 28px)
-      clamp(120px, 24vw, 200px);
+    padding: calc(var(--museum-hero-lift) + clamp(14px, 8vw, 32px)) clamp(16px, 7vw, 26px)
+      clamp(112px, 24vw, 192px);
   }
   .museum-detail-body-content {
-    gap: clamp(24px, 10vw, 40px);
+    gap: clamp(22px, 9vw, 38px);
   }
   .museum-detail-grid { gap: 24px; }
   .museum-expositions-card,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1322,10 +1322,31 @@ button.hero-quick-link {
 .detail-title { margin:8px 0 0; font-size:30px; font-weight:800; }
 .detail-sub { margin:6px 0 0; color:var(--muted); }
 
-.museum-detail { position: relative; background: var(--body-bg); padding-bottom: 64px; }
+.museum-detail {
+  position: relative;
+  background: var(--body-bg);
+  padding-bottom: clamp(120px, 12vw, 160px);
+  --museum-hero-lift: clamp(140px, 18vw, 220px);
+}
+.museum-detail:not(.has-hero) {
+  --museum-hero-lift: 0px;
+}
 .museum-detail-container { position: relative; z-index: 2; }
-.museum-detail.has-hero .museum-detail-container:not(.museum-hero-heading-container) { margin-top: -140px; }
-.museum-detail-hero { position: relative; height: clamp(220px, 48vh, 360px); overflow: hidden; border-radius: var(--radius-md); box-shadow: 0 10px 26px rgba(15, 23, 42, 0.18); }
+.museum-detail-hero-section {
+  position: relative;
+  padding: clamp(32px, 6vw, 72px) clamp(16px, 4vw, 48px)
+    calc(var(--museum-hero-lift) + clamp(48px, 8vw, 96px));
+  background: linear-gradient(180deg, rgba(226, 232, 240, 0.72) 0%, rgba(241, 245, 249, 0.82) 45%, var(--body-bg) 100%);
+}
+[data-theme='dark'] .museum-detail-hero-section {
+  background: linear-gradient(180deg, rgba(2, 6, 23, 0.92) 0%, rgba(2, 6, 23, 0.86) 45%, var(--body-bg) 100%);
+}
+.museum-detail-hero-section .museum-detail-container {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 5vw, 48px);
+}
+.museum-detail-hero { position: relative; width: 100%; height: clamp(220px, 48vh, 360px); overflow: hidden; border-radius: var(--radius-md); box-shadow: 0 10px 26px rgba(15, 23, 42, 0.18); }
 .museum-detail-hero::after {
   content: "";
   position: absolute;
@@ -1338,6 +1359,22 @@ button.hero-quick-link {
   pointer-events: none;
   z-index: 1;
   border-radius: inherit;
+}
+.museum-detail-body {
+  position: relative;
+  padding: calc(var(--museum-hero-lift) + clamp(24px, 5vw, 56px)) clamp(16px, 4vw, 48px)
+    clamp(120px, 12vw, 160px);
+  background: var(--body-bg);
+}
+.museum-detail-body-content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(32px, 6vw, 56px);
+  transform: translateY(calc(-1 * var(--museum-hero-lift)));
+}
+.museum-detail:not(.has-hero) .museum-detail-body-content {
+  transform: none;
 }
 .museum-hero-image { object-fit: cover; object-position: center; filter: saturate(1.08); }
 .museum-hero-credit {
@@ -1367,7 +1404,7 @@ button.hero-quick-link {
 .museum-hero-credit .image-credit-link {
   color: inherit;
 }
-.museum-hero-heading-container { position: relative; z-index: 5; margin-bottom: clamp(12px, 2vw, 20px); }
+.museum-hero-heading-container { position: relative; z-index: 5; margin: 0; }
 .museum-hero-heading { display: flex; flex-direction: column; align-items: flex-start; gap: 14px; }
 .museum-hero-text { display: flex; flex-direction: column; gap: 6px; max-width: 720px; }
 .museum-hero-location { margin: 0; font-size: 12px; letter-spacing: 0.16em; text-transform: uppercase; font-weight: 600; color: var(--muted); }
@@ -1414,7 +1451,7 @@ button.hero-quick-link {
   align-items: center;
   gap: var(--space-16);
   padding: var(--space-16) var(--space-24);
-  margin: clamp(20px, 3vw, 32px) 0 clamp(40px, 5vw, 56px);
+  margin: 0;
   border-radius: var(--radius-md);
   background: var(--action-bar-bg);
   border: 1px solid var(--action-bar-border);
@@ -1565,9 +1602,12 @@ button.hero-quick-link {
 }
 .museum-detail-grid {
   display: grid;
-  gap: 32px;
+  gap: clamp(32px, 6vw, 48px);
   grid-template-columns: minmax(0, 1fr) minmax(0, 360px);
   align-items: start;
+  margin: 0;
+  position: relative;
+  z-index: 1;
 }
 .museum-detail-main {
   display: flex;
@@ -1628,7 +1668,12 @@ button.hero-quick-link {
 }
 .museum-tabpanel {
   display: block;
-  scroll-margin-top: calc(160px + env(safe-area-inset-top, 0px));
+  scroll-margin-top: calc(120px + var(--museum-hero-lift) + env(safe-area-inset-top, 0px));
+}
+.museum-tabpanel:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 6px;
+  border-radius: var(--radius-md);
 }
 .museum-tabpanel[hidden] {
   display: none;
@@ -1819,7 +1864,7 @@ button.hero-quick-link {
 .museum-info-value { margin: 0; color: inherit; font-size: 15px; line-height: 1.5; }
 
 @media (max-width: 1200px) {
-  .museum-detail.has-hero .museum-detail-container:not(.museum-hero-heading-container) { margin-top: -120px; }
+  .museum-detail { --museum-hero-lift: clamp(110px, 20vw, 180px); }
   .museum-detail-grid { grid-template-columns: minmax(0, 1fr); }
   .museum-sidebar {
     position: static;
@@ -1829,7 +1874,7 @@ button.hero-quick-link {
 }
 
 @media (max-width: 900px) {
-  .museum-detail.has-hero .museum-detail-container:not(.museum-hero-heading-container) { margin-top: -90px; }
+  .museum-detail { --museum-hero-lift: clamp(90px, 26vw, 150px); }
   .museum-primary-action-bar {
     grid-template-columns: 1fr;
     top: calc(88px + env(safe-area-inset-top, 0px));
@@ -1841,9 +1886,22 @@ button.hero-quick-link {
 }
 
 @media (max-width: 768px) {
-  .museum-detail { padding-bottom: calc(168px + env(safe-area-inset-bottom, 0px)); }
+  .museum-detail {
+    padding-bottom: calc(168px + env(safe-area-inset-bottom, 0px));
+    --museum-hero-lift: clamp(64px, 30vw, 120px);
+  }
   .museum-primary-action-bar { display: none; }
-  .museum-detail.has-hero .museum-detail-container:not(.museum-hero-heading-container) { margin-top: -70px; }
+  .museum-detail-hero-section {
+    padding: clamp(24px, 8vw, 52px) clamp(16px, 6vw, 32px)
+      calc(var(--museum-hero-lift) + clamp(32px, 10vw, 60px));
+  }
+  .museum-detail-body {
+    padding: calc(var(--museum-hero-lift) + clamp(24px, 6vw, 48px)) clamp(16px, 6vw, 32px)
+      clamp(120px, 20vw, 190px);
+  }
+  .museum-detail-body-content {
+    gap: clamp(28px, 8vw, 48px);
+  }
   .museum-hero-heading { gap: 12px; }
   .museum-hero-tagline { font-size: 15px; }
   .museum-expositions-card,
@@ -2037,8 +2095,21 @@ button.hero-quick-link {
 }
 
 @media (max-width: 600px) {
-  .museum-detail { padding-bottom: calc(196px + env(safe-area-inset-bottom, 0px)); }
-  .museum-detail.has-hero .museum-detail-container:not(.museum-hero-heading-container) { margin-top: -48px; }
+  .museum-detail {
+    padding-bottom: calc(196px + env(safe-area-inset-bottom, 0px));
+    --museum-hero-lift: clamp(48px, 34vw, 96px);
+  }
+  .museum-detail-hero-section {
+    padding: clamp(20px, 8vw, 44px) clamp(16px, 7vw, 28px)
+      calc(var(--museum-hero-lift) + clamp(28px, 10vw, 48px));
+  }
+  .museum-detail-body {
+    padding: calc(var(--museum-hero-lift) + clamp(20px, 8vw, 44px)) clamp(16px, 7vw, 28px)
+      clamp(140px, 24vw, 220px);
+  }
+  .museum-detail-body-content {
+    gap: clamp(24px, 10vw, 40px);
+  }
   .museum-detail-grid { gap: 24px; }
   .museum-expositions-card,
   .museum-overview-card,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1325,8 +1325,8 @@ button.hero-quick-link {
 .museum-detail {
   position: relative;
   background: var(--body-bg);
-  padding-bottom: clamp(120px, 12vw, 160px);
-  --museum-hero-lift: clamp(140px, 18vw, 220px);
+  padding-bottom: clamp(96px, 10vw, 140px);
+  --museum-hero-lift: clamp(72px, 10vw, 128px);
 }
 .museum-detail:not(.has-hero) {
   --museum-hero-lift: 0px;
@@ -1334,19 +1334,26 @@ button.hero-quick-link {
 .museum-detail-container { position: relative; z-index: 2; }
 .museum-detail-hero-section {
   position: relative;
-  padding: clamp(32px, 6vw, 72px) clamp(16px, 4vw, 48px)
-    calc(var(--museum-hero-lift) + clamp(48px, 8vw, 96px));
-  background: linear-gradient(180deg, rgba(226, 232, 240, 0.72) 0%, rgba(241, 245, 249, 0.82) 45%, var(--body-bg) 100%);
+  padding: clamp(16px, 4vw, 40px) clamp(16px, 4vw, 48px)
+    calc(var(--museum-hero-lift) + clamp(32px, 6vw, 72px));
+  background: linear-gradient(180deg, rgba(241, 245, 249, 0.92) 0%, rgba(248, 250, 252, 0.72) 35%, var(--body-bg) 100%);
 }
 [data-theme='dark'] .museum-detail-hero-section {
-  background: linear-gradient(180deg, rgba(2, 6, 23, 0.92) 0%, rgba(2, 6, 23, 0.86) 45%, var(--body-bg) 100%);
+  background: linear-gradient(180deg, rgba(2, 6, 23, 0.95) 0%, rgba(2, 6, 23, 0.88) 40%, var(--body-bg) 100%);
 }
 .museum-detail-hero-section .museum-detail-container {
   display: flex;
   flex-direction: column;
-  gap: clamp(24px, 5vw, 48px);
+  gap: clamp(16px, 4vw, 32px);
 }
-.museum-detail-hero { position: relative; width: 100%; height: clamp(220px, 48vh, 360px); overflow: hidden; border-radius: var(--radius-md); box-shadow: 0 10px 26px rgba(15, 23, 42, 0.18); }
+.museum-detail-hero {
+  position: relative;
+  width: 100%;
+  height: clamp(220px, 42vw, 340px);
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.12);
+}
 .museum-detail-hero::after {
   content: "";
   position: absolute;
@@ -1362,15 +1369,15 @@ button.hero-quick-link {
 }
 .museum-detail-body {
   position: relative;
-  padding: calc(var(--museum-hero-lift) + clamp(24px, 5vw, 56px)) clamp(16px, 4vw, 48px)
-    clamp(120px, 12vw, 160px);
+  padding: calc(var(--museum-hero-lift) + clamp(24px, 5vw, 48px)) clamp(16px, 4vw, 48px)
+    clamp(96px, 10vw, 128px);
   background: var(--body-bg);
 }
 .museum-detail-body-content {
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: clamp(32px, 6vw, 56px);
+  gap: clamp(28px, 5vw, 48px);
   transform: translateY(calc(-1 * var(--museum-hero-lift)));
 }
 .museum-detail:not(.has-hero) .museum-detail-body-content {
@@ -1404,26 +1411,87 @@ button.hero-quick-link {
 .museum-hero-credit .image-credit-link {
   color: inherit;
 }
-.museum-hero-heading-container { position: relative; z-index: 5; margin: 0; }
-.museum-hero-heading { display: flex; flex-direction: column; align-items: flex-start; gap: 14px; }
-.museum-hero-text { display: flex; flex-direction: column; gap: 6px; max-width: 720px; }
-.museum-hero-location { margin: 0; font-size: 12px; letter-spacing: 0.16em; text-transform: uppercase; font-weight: 600; color: var(--muted); }
-.museum-hero-title { margin: 0; font-size: clamp(34px, 4.5vw, 48px); font-weight: 800; letter-spacing: -0.02em; line-height: 1.05; }
-.museum-hero-tagline { margin: 0; color: var(--muted); font-size: 16px; line-height: 1.5; }
+.museum-hero-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  padding: clamp(16px, 4vw, 36px);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.08) 0%, rgba(15, 23, 42, 0.45) 65%, rgba(15, 23, 42, 0.78) 100%);
+  pointer-events: none;
+}
+
+.museum-hero-overlay-card {
+  pointer-events: auto;
+  width: 100%;
+  max-width: min(880px, 100%);
+  padding: clamp(18px, 3vw, 30px);
+  border-radius: var(--radius-lg);
+  background: rgba(15, 23, 42, 0.68);
+  color: rgba(248, 250, 252, 0.96);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 22px 46px rgba(15, 23, 42, 0.35);
+}
+
+.museum-hero-heading {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 3vw, 24px);
+}
+
+.museum-hero-heading--no-image {
+  padding: clamp(20px, 4vw, 32px);
+  border-radius: var(--radius-lg);
+  background: var(--panel-bg);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+}
+
+.museum-hero-text {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-width: 720px;
+}
+
+.museum-hero-location {
+  margin: 0;
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: inherit;
+  opacity: 0.85;
+}
+
+.museum-hero-title {
+  margin: 0;
+  font-size: clamp(30px, 4vw, 44px);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.08;
+}
+
+.museum-hero-tagline {
+  margin: 0;
+  color: inherit;
+  opacity: 0.88;
+  font-size: 16px;
+  line-height: 1.5;
+}
 .museum-backlink {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 8px 14px;
-  border-radius: 16px;
+  padding: 6px 12px;
+  border-radius: 14px;
   font-size: 13px;
   font-weight: 600;
   margin: 0;
   color: var(--text);
-  background: rgba(255, 255, 255, 0.92);
-  border: 1px solid var(--panel-border);
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.3);
   text-decoration: none;
-  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.14);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.14);
   backdrop-filter: blur(6px);
   transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
 }
@@ -1439,7 +1507,7 @@ button.hero-quick-link {
 }
 .museum-backlink:hover {
   transform: translateY(-1px);
-  box-shadow: 0 14px 26px rgba(15, 23, 42, 0.18);
+  box-shadow: 0 12px 22px rgba(15, 23, 42, 0.2);
 }
 .museum-backlink:focus-visible {
   outline: 2px solid var(--accent);
@@ -1449,8 +1517,7 @@ button.hero-quick-link {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: clamp(16px, 3vw, 24px);
-  margin-top: clamp(8px, 2vw, 16px);
+  gap: clamp(12px, 2.5vw, 20px);
 }
 
 .museum-hero-primary {
@@ -1566,6 +1633,78 @@ button.hero-quick-link {
 }
 [data-theme='dark'] .museum-primary-action__note {
   color: var(--muted);
+}
+
+.museum-hero-overlay-card .museum-hero-location,
+.museum-hero-overlay-card .museum-hero-tagline,
+.museum-hero-overlay-card .museum-primary-action__note {
+  color: rgba(248, 250, 252, 0.82);
+}
+
+.museum-hero-overlay-card .museum-primary-action.primary {
+  background: rgba(248, 250, 252, 0.92);
+  color: #0f172a;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.32);
+}
+
+.museum-hero-overlay-card .museum-primary-action.primary:hover {
+  background: #fff;
+}
+
+.museum-hero-overlay-card .museum-primary-action.secondary {
+  background: rgba(15, 23, 42, 0.24);
+  border-color: rgba(248, 250, 252, 0.35);
+  color: rgba(248, 250, 252, 0.92);
+}
+
+.museum-hero-overlay-card .museum-primary-action.secondary:hover {
+  background: rgba(248, 250, 252, 0.12);
+}
+
+.museum-hero-overlay-card .museum-hero-utilities .icon-button {
+  background: rgba(15, 23, 42, 0.4);
+  border-color: rgba(248, 250, 252, 0.35);
+  color: rgba(248, 250, 252, 0.95);
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.3);
+}
+
+.museum-hero-overlay-card .museum-hero-utilities .icon-button:hover,
+.museum-hero-overlay-card .museum-hero-utilities .icon-button:focus-visible {
+  background: rgba(248, 250, 252, 0.18);
+  color: #fff;
+}
+
+.museum-hero-overlay-card .museum-hero-utilities .icon-button.favorited {
+  color: #fb7185;
+  background: rgba(248, 250, 252, 0.2);
+  box-shadow: 0 18px 32px rgba(251, 113, 133, 0.32);
+}
+
+.museum-hero-heading--no-image .museum-hero-location,
+.museum-hero-heading--no-image .museum-hero-tagline,
+.museum-hero-heading--no-image .museum-primary-action__note {
+  color: var(--muted);
+}
+
+@media (min-width: 900px) {
+  .museum-hero-heading {
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: clamp(24px, 4vw, 40px);
+  }
+
+  .museum-hero-heading .museum-hero-text {
+    max-width: min(540px, 60%);
+  }
+
+  .museum-hero-heading .museum-hero-actions {
+    align-items: flex-end;
+  }
+
+  .museum-hero-heading .museum-hero-utilities {
+    justify-content: flex-end;
+  }
 }
 
 .museum-hero-utilities .icon-button {
@@ -1859,7 +1998,7 @@ button.hero-quick-link {
 }
 
 @media (max-width: 1200px) {
-  .museum-detail { --museum-hero-lift: clamp(110px, 20vw, 180px); }
+  .museum-detail { --museum-hero-lift: clamp(64px, 14vw, 120px); }
   .museum-detail-grid { grid-template-columns: minmax(0, 1fr); }
   .museum-sidebar {
     position: static;
@@ -1869,21 +2008,21 @@ button.hero-quick-link {
 }
 
 @media (max-width: 900px) {
-  .museum-detail { --museum-hero-lift: clamp(90px, 26vw, 150px); }
+  .museum-detail { --museum-hero-lift: clamp(56px, 22vw, 108px); }
 }
 
 @media (max-width: 768px) {
   .museum-detail {
-    padding-bottom: calc(168px + env(safe-area-inset-bottom, 0px));
-    --museum-hero-lift: clamp(64px, 30vw, 120px);
+    padding-bottom: calc(148px + env(safe-area-inset-bottom, 0px));
+    --museum-hero-lift: clamp(52px, 28vw, 96px);
   }
   .museum-detail-hero-section {
-    padding: clamp(24px, 8vw, 52px) clamp(16px, 6vw, 32px)
-      calc(var(--museum-hero-lift) + clamp(32px, 10vw, 60px));
+    padding: clamp(18px, 7vw, 40px) clamp(16px, 6vw, 32px)
+      calc(var(--museum-hero-lift) + clamp(28px, 9vw, 52px));
   }
   .museum-detail-body {
-    padding: calc(var(--museum-hero-lift) + clamp(24px, 6vw, 48px)) clamp(16px, 6vw, 32px)
-      clamp(120px, 20vw, 190px);
+    padding: calc(var(--museum-hero-lift) + clamp(20px, 6vw, 44px)) clamp(16px, 6vw, 32px)
+      clamp(96px, 20vw, 160px);
   }
   .museum-detail-body-content {
     gap: clamp(28px, 8vw, 48px);
@@ -1909,16 +2048,16 @@ button.hero-quick-link {
 
 @media (max-width: 600px) {
   .museum-detail {
-    padding-bottom: calc(196px + env(safe-area-inset-bottom, 0px));
-    --museum-hero-lift: clamp(48px, 34vw, 96px);
+    padding-bottom: calc(176px + env(safe-area-inset-bottom, 0px));
+    --museum-hero-lift: clamp(44px, 34vw, 84px);
   }
   .museum-detail-hero-section {
-    padding: clamp(20px, 8vw, 44px) clamp(16px, 7vw, 28px)
-      calc(var(--museum-hero-lift) + clamp(28px, 10vw, 48px));
+    padding: clamp(16px, 8vw, 36px) clamp(16px, 7vw, 28px)
+      calc(var(--museum-hero-lift) + clamp(24px, 9vw, 44px));
   }
   .museum-detail-body {
-    padding: calc(var(--museum-hero-lift) + clamp(20px, 8vw, 44px)) clamp(16px, 7vw, 28px)
-      clamp(140px, 24vw, 220px);
+    padding: calc(var(--museum-hero-lift) + clamp(18px, 8vw, 40px)) clamp(16px, 7vw, 28px)
+      clamp(120px, 24vw, 200px);
   }
   .museum-detail-body-content {
     gap: clamp(24px, 10vw, 40px);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1445,46 +1445,34 @@ button.hero-quick-link {
   outline: 2px solid var(--accent);
   outline-offset: 3px;
 }
-.museum-primary-action-bar {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: var(--space-16);
-  padding: var(--space-16) var(--space-24);
-  margin: 0;
-  border-radius: var(--radius-md);
-  background: var(--action-bar-bg);
-  border: 1px solid var(--action-bar-border);
-  box-shadow: var(--action-bar-shadow);
-  backdrop-filter: blur(18px);
-  position: sticky;
-  top: calc(96px + env(safe-area-inset-top, 0px));
-  z-index: 30;
-}
-.museum-primary-action-group {
-  display: inline-flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--space-16);
-}
-.museum-primary-action-stack {
+.museum-hero-actions {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  gap: clamp(16px, 3vw, 24px);
+  margin-top: clamp(8px, 2vw, 16px);
+}
+
+.museum-hero-primary {
+  display: flex;
+  flex-direction: column;
   gap: 8px;
-  min-width: 0;
+  max-width: 100%;
 }
-.museum-primary-action-stack .museum-primary-action {
-  width: fit-content;
-}
-.museum-primary-action-group:empty {
-  display: none;
-}
-.museum-primary-action-utility {
+
+.museum-hero-utilities {
   display: inline-flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: var(--space-16);
-  justify-content: flex-end;
+  gap: 12px;
+}
+
+.museum-hero-secondary-action {
+  text-decoration: none;
+}
+
+.museum-hero-ticket-note {
+  color: var(--muted);
 }
 .museum-primary-action {
   display: inline-flex;
@@ -1579,27 +1567,25 @@ button.hero-quick-link {
 [data-theme='dark'] .museum-primary-action__note {
   color: var(--muted);
 }
-.museum-primary-action-utility .icon-button {
+
+.museum-hero-utilities .icon-button {
   width: 42px;
   height: 42px;
   border-radius: var(--radius-md);
-}
-.museum-primary-action-utility .icon-button:not(.favorited) {
-  background: rgba(255,255,255,0.94);
+  background: rgba(255, 255, 255, 0.94);
   border: 1px solid var(--panel-border);
-  box-shadow: 0 10px 22px rgba(15,23,42,0.16);
-}
-[data-theme='dark'] .museum-primary-action-utility .icon-button:not(.favorited) {
-  background: rgba(15,23,42,0.7);
-  border-color: rgba(148,163,184,0.28);
-}
-.museum-primary-action-utility .icon-button.favorited {
-  box-shadow: 0 12px 26px rgba(255,90,60,0.3);
+  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.16);
 }
 
-.museum-mobile-actions {
-  display: none;
+.museum-hero-utilities .icon-button.favorited {
+  box-shadow: 0 12px 26px rgba(255, 90, 60, 0.3);
 }
+
+[data-theme='dark'] .museum-hero-utilities .icon-button:not(.favorited) {
+  background: rgba(15, 23, 42, 0.7);
+  border-color: rgba(148, 163, 184, 0.28);
+}
+
 .museum-detail-grid {
   display: grid;
   gap: clamp(32px, 6vw, 48px);
@@ -1822,6 +1808,7 @@ button.hero-quick-link {
   align-self: start;
   max-width: 360px;
   width: 100%;
+  scroll-margin-top: calc(120px + var(--museum-hero-lift) + env(safe-area-inset-top, 0px));
 }
 .museum-sidebar-card {
   background: linear-gradient(180deg, var(--info-card-bg) 0%, rgba(255,255,255,0.95) 100%);
@@ -1862,6 +1849,14 @@ button.hero-quick-link {
 .museum-info-label { font-size: 12px; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; color: rgba(0,0,0,0.55); }
 [data-theme='dark'] .museum-info-label { color: rgba(226,232,240,0.7); }
 .museum-info-value { margin: 0; color: inherit; font-size: 15px; line-height: 1.5; }
+.museum-info-note {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  font-size: 13px;
+  color: var(--muted);
+}
 
 @media (max-width: 1200px) {
   .museum-detail { --museum-hero-lift: clamp(110px, 20vw, 180px); }
@@ -1875,14 +1870,6 @@ button.hero-quick-link {
 
 @media (max-width: 900px) {
   .museum-detail { --museum-hero-lift: clamp(90px, 26vw, 150px); }
-  .museum-primary-action-bar {
-    grid-template-columns: 1fr;
-    top: calc(88px + env(safe-area-inset-top, 0px));
-  }
-  .museum-primary-action-group,
-  .museum-primary-action-utility {
-    justify-content: center;
-  }
 }
 
 @media (max-width: 768px) {
@@ -1890,7 +1877,6 @@ button.hero-quick-link {
     padding-bottom: calc(168px + env(safe-area-inset-bottom, 0px));
     --museum-hero-lift: clamp(64px, 30vw, 120px);
   }
-  .museum-primary-action-bar { display: none; }
   .museum-detail-hero-section {
     padding: clamp(24px, 8vw, 52px) clamp(16px, 6vw, 32px)
       calc(var(--museum-hero-lift) + clamp(32px, 10vw, 60px));
@@ -1904,194 +1890,21 @@ button.hero-quick-link {
   }
   .museum-hero-heading { gap: 12px; }
   .museum-hero-tagline { font-size: 15px; }
+  .museum-hero-actions { align-items: stretch; }
+  .museum-hero-utilities {
+    width: 100%;
+    justify-content: flex-start;
+  }
+  .museum-hero-utilities .museum-primary-action {
+    flex: 1 1 auto;
+    justify-content: center;
+    width: 100%;
+  }
   .museum-expositions-card,
   .museum-overview-card,
   .museum-map-card,
   .museum-sidebar-card { border-radius: var(--radius-md); }
   .museum-info-links { gap: 10px; }
-
-  .museum-mobile-actions {
-    display: block;
-    position: fixed;
-    inset: 0;
-    z-index: 90;
-    pointer-events: none;
-  }
-
-  .museum-mobile-actions__fab {
-    position: absolute;
-    right: 20px;
-    bottom: calc(24px + env(safe-area-inset-bottom, 0px));
-    width: 60px;
-    height: 60px;
-    border-radius: 50%;
-    border: none;
-    background: var(--accent);
-    color: var(--accent-ink);
-    box-shadow: 0 20px 42px rgba(15,23,42,0.28);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    pointer-events: auto;
-    transition: transform 0.22s ease, box-shadow 0.22s ease;
-  }
-
-  .museum-mobile-actions__fab:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 24px 48px rgba(15,23,42,0.32);
-  }
-
-  .museum-mobile-actions__fab:active {
-    transform: translateY(0) scale(0.96);
-    box-shadow: 0 18px 32px rgba(15,23,42,0.26);
-  }
-
-  .museum-mobile-actions__fab:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 2px var(--focus-ring-outline), 0 0 0 6px var(--focus-ring-shadow),
-      0 24px 50px rgba(255,90,60,0.34);
-  }
-
-  .museum-mobile-actions__fab svg {
-    width: 26px;
-    height: 26px;
-  }
-
-  .museum-mobile-actions__backdrop {
-    position: absolute;
-    inset: 0;
-    background: rgba(15,23,42,0.38);
-    opacity: 0;
-    transition: opacity 0.28s ease;
-    pointer-events: none;
-  }
-
-  .museum-mobile-actions__sheet {
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    transform: translateY(100%);
-    transition: transform 0.32s ease;
-    background: var(--action-bar-bg);
-    border: 1px solid var(--action-bar-border);
-    border-radius: 28px 28px 0 0;
-    box-shadow: 0 -22px 46px rgba(15,23,42,0.28);
-    backdrop-filter: blur(18px);
-    padding: 20px 22px calc(24px + env(safe-area-inset-bottom, 0px));
-    pointer-events: none;
-  }
-
-  .museum-mobile-actions__handle {
-    width: 56px;
-    height: 5px;
-    border-radius: 999px;
-    background: rgba(148,163,184,0.5);
-    margin: 0 auto 18px;
-  }
-
-  .museum-mobile-actions__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    margin-bottom: 16px;
-  }
-
-  .museum-mobile-actions__title {
-    font-size: 17px;
-    font-weight: 600;
-    margin: 0;
-  }
-
-  .museum-mobile-actions__close {
-    width: 44px;
-    height: 44px;
-    border-radius: 16px;
-    border: 1px solid var(--panel-border);
-    background: rgba(255,255,255,0.92);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--text);
-    cursor: pointer;
-    transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
-  }
-
-  .museum-mobile-actions__close:hover {
-    transform: translateY(-1px);
-    background: rgba(255,255,255,1);
-    box-shadow: 0 12px 26px rgba(15,23,42,0.2);
-  }
-
-  .museum-mobile-actions__close:active {
-    transform: translateY(0) scale(0.94);
-  }
-
-  .museum-mobile-actions__close:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 2px var(--focus-ring-outline), 0 0 0 5px var(--focus-ring-shadow);
-  }
-
-  .museum-mobile-actions__body {
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
-  }
-
-  .museum-mobile-actions__actions {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-  }
-
-  .museum-mobile-actions__action {
-    width: 100%;
-  }
-
-  .museum-mobile-actions__utility {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 18px;
-  }
-
-  .museum-mobile-actions__utility .icon-button {
-    width: 52px;
-    height: 52px;
-    border-radius: var(--radius-md);
-  }
-
-  .museum-mobile-actions__utility .icon-button svg {
-    width: 22px;
-    height: 22px;
-  }
-
-  .museum-mobile-actions.is-open {
-    pointer-events: auto;
-  }
-
-  .museum-mobile-actions.is-open .museum-mobile-actions__backdrop {
-    opacity: 1;
-    pointer-events: auto;
-  }
-
-  .museum-mobile-actions.is-open .museum-mobile-actions__sheet {
-    transform: translateY(0);
-    pointer-events: auto;
-  }
-
-  [data-theme='dark'] .museum-mobile-actions__close {
-    background: rgba(15,23,42,0.72);
-    border-color: rgba(148,163,184,0.32);
-    color: var(--text);
-  }
-
-  [data-theme='dark'] .museum-mobile-actions__close:hover {
-    background: rgba(15,23,42,0.82);
-    box-shadow: 0 16px 32px rgba(0,0,0,0.45);
-  }
 }
 
 @media (max-width: 600px) {
@@ -2135,14 +1948,6 @@ button.hero-quick-link {
   .museum-hero-location { font-size: 11px; }
   .museum-hero-title { font-size: clamp(28px, 9vw, 36px); }
   .museum-hero-tagline { font-size: 14px; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .museum-mobile-actions__fab,
-  .museum-mobile-actions__sheet,
-  .museum-mobile-actions__backdrop {
-    transition: none !important;
-  }
 }
 
 /* Footer space */


### PR DESCRIPTION
## Summary
- replace the museum detail hero markup with a semantic header and wrap the remaining content in a dedicated body section
- refresh museum detail styling with a gradient hero background, responsive padding, and floating grid layout without negative offsets
- adjust tab panel accessibility and responsive variables for consistent spacing across breakpoints

## Testing
- npm run lint *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d674fb18888326bfda3be1827d5bc7