### PR TITLE
Hide Why MuseumBuddy section on mobile

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3421,6 +3421,12 @@ button.hero-quick-link {
   gap: clamp(20px, 3vw, 28px);
 }
 
+@media (max-width: 768px) {
+  .home-value-props {
+    display: none;
+  }
+}
+
 .home-value-props__intro {
   max-width: 640px;
 }


### PR DESCRIPTION
## Summary
- hide the home value proposition section on small screens so the "Why MuseumBuddy" content no longer appears on mobile

## Testing
- npm install *(fails: 403 Forbidden fetching @capacitor/app from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d6984651a48326aef734ea2c9cfd13