### PR TITLE
Adjust hero exhibitions button color

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -917,10 +917,10 @@ button.hero-quick-link {
 }
 .hero-quick-link:hover { transform: translateY(-1px); box-shadow: 0 12px 28px rgba(15, 23, 42, 0.18); }
 .hero-quick-link--primary {
-  background: linear-gradient(135deg, #2563eb 0%, #7c3aed 100%);
+  background: linear-gradient(135deg, #f97316 0%, #ea580c 100%);
   color: #fff;
   border-color: transparent;
-  box-shadow: 0 12px 30px rgba(59, 130, 246, 0.32);
+  box-shadow: 0 12px 30px rgba(234, 88, 12, 0.32);
 }
 .hero-quick-link--ghost {
   background: transparent;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -918,7 +918,7 @@ button.hero-quick-link {
 .hero-quick-link:hover { transform: translateY(-1px); box-shadow: 0 12px 28px rgba(15, 23, 42, 0.18); }
 .hero-quick-link--primary {
   background: linear-gradient(135deg, #f97316 0%, #ea580c 100%);
-  color: #fff;
+  color: #000;
   border-color: transparent;
   box-shadow: 0 12px 30px rgba(234, 88, 12, 0.32);
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -917,10 +917,10 @@ button.hero-quick-link {
 }
 .hero-quick-link:hover { transform: translateY(-1px); box-shadow: 0 12px 28px rgba(15, 23, 42, 0.18); }
 .hero-quick-link--primary {
-  background: linear-gradient(135deg, #ff7a45 0%, #ff4f64 100%);
+  background: linear-gradient(135deg, #2563eb 0%, #7c3aed 100%);
   color: #fff;
   border-color: transparent;
-  box-shadow: 0 12px 30px rgba(255, 79, 100, 0.28);
+  box-shadow: 0 12px 30px rgba(59, 130, 246, 0.32);
 }
 .hero-quick-link--ghost {
   background: transparent;


### PR DESCRIPTION
## Summary
- update the hero exhibitions quick link with a higher-contrast gradient and shadow

## Testing
- npm install *(fails: 403 Forbidden fetching @capacitor/app)*

------
https://chatgpt.com/codex/tasks/task_e_68d69a244e2c8326969109956511d846