### PR TITLE
Revamp exposition fallback styling

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3125,8 +3125,89 @@ button.hero-quick-link {
   background: linear-gradient(135deg, rgba(255,90,60,0.14), rgba(14,116,144,0.14));
 }
 
-.exposition-card__media.is-placeholder {
-  background: linear-gradient(135deg, rgba(255,90,60,0.1), rgba(59,130,246,0.12));
+.exposition-card__media.is-fallback {
+  --fallback-start: rgba(79, 70, 229, 0.92);
+  --fallback-end: rgba(14, 165, 233, 0.88);
+  --fallback-glow: rgba(56, 189, 248, 0.52);
+  background: linear-gradient(135deg, var(--fallback-start), var(--fallback-end));
+  color: rgba(248, 250, 252, 0.96);
+}
+
+.exposition-card__fallback {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-12);
+  padding: var(--space-24);
+  text-align: center;
+  color: inherit;
+  isolation: isolate;
+}
+
+.exposition-card__fallback::before {
+  content: '';
+  position: absolute;
+  inset: -18%;
+  background:
+    radial-gradient(circle at 24% 26%, rgba(255, 255, 255, 0.44), transparent 58%),
+    radial-gradient(circle at 76% 22%, rgba(255, 255, 255, 0.32), transparent 55%),
+    radial-gradient(circle at 50% 82%, var(--fallback-glow), transparent 62%);
+  opacity: 0.85;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.exposition-card__fallback::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.18) 0%, transparent 42%);
+  mix-blend-mode: screen;
+  opacity: 0.75;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.exposition-card__fallback-letter {
+  position: relative;
+  font-size: clamp(2.6rem, 7vw, 4.1rem);
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+.exposition-card__fallback-pill {
+  position: relative;
+  padding: 0.35em 1.6em;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.32);
+  border: 1px solid rgba(15, 23, 42, 0.26);
+  color: rgba(248, 250, 252, 0.94);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  box-shadow: 0 12px 34px rgba(15, 23, 42, 0.34);
+  backdrop-filter: blur(18px);
+}
+
+@supports not ((-webkit-backdrop-filter: blur(18px)) or (backdrop-filter: blur(18px))) {
+  .exposition-card__fallback-pill {
+    background: rgba(15, 23, 42, 0.46);
+  }
+}
+
+[data-theme='dark'] .exposition-card__media.is-fallback {
+  color: rgba(248, 250, 252, 0.95);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+[data-theme='dark'] .exposition-card__fallback-pill {
+  background: rgba(15, 23, 42, 0.56);
+  border-color: rgba(15, 23, 42, 0.38);
 }
 
 .exposition-card__skeleton {


### PR DESCRIPTION
## Summary
- replace the exposition placeholder image with a generative fallback banner that shows the exhibition initial and a gradient tied to each expo
- update the card logic to avoid loading missing images and to keep favorite entries from storing placeholder URLs
- add the supporting styles, including dark-theme tweaks and blur fallbacks, for the new fallback artwork treatment

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d78bf28fd88326a69ad848033271c7