### PR TITLE
Remove exposition image handling

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -1,11 +1,8 @@
-import Image from 'next/image';
 import { Fragment, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useLanguage } from './LanguageContext';
 import { useFavorites } from './FavoritesContext';
 import { shouldShowAffiliateNote } from '../lib/nonAffiliateMuseums';
 import TicketButtonNote from './TicketButtonNote';
-
-const FALLBACK_IMAGE = '/images/exposition-placeholder.svg';
 
 function formatRange(start, end, locale) {
   if (!start) return '';
@@ -22,96 +19,6 @@ function formatRange(start, end, locale) {
       .padStart(2, '0')} ${month}`;
   }
   return `${startFmt} - ${endFmt}`;
-}
-
-function resolveMediaUrl(exposition) {
-  if (!exposition || typeof exposition !== 'object') return null;
-  const primaryKeys = [
-    'image',
-    'image_url',
-    'imageUrl',
-    'afbeelding',
-    'afbeelding_url',
-    'afbeeldingUrl',
-    'mediaUrl',
-    'coverImage',
-    'cover_image',
-    'poster',
-    'posterUrl',
-    'hero_image',
-    'heroImage',
-  ];
-  for (const key of primaryKeys) {
-    const value = exposition[key];
-    if (typeof value === 'string' && value.trim()) {
-      return value.trim();
-    }
-  }
-  const collectionKeys = ['images', 'photos', 'media', 'gallery'];
-  for (const key of collectionKeys) {
-    const value = exposition[key];
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        if (typeof item === 'string' && item.trim()) {
-          return item.trim();
-        }
-        if (item && typeof item === 'object') {
-          if (typeof item.url === 'string' && item.url.trim()) {
-            return item.url.trim();
-          }
-          if (typeof item.src === 'string' && item.src.trim()) {
-            return item.src.trim();
-          }
-        }
-      }
-    } else if (value && typeof value === 'object') {
-      if (typeof value.url === 'string' && value.url.trim()) {
-        return value.url.trim();
-      }
-      if (typeof value.src === 'string' && value.src.trim()) {
-        return value.src.trim();
-      }
-    }
-  }
-  return null;
-}
-
-function resolveMediaAlt(exposition, translate) {
-  if (!exposition || typeof exposition !== 'object') {
-    return typeof translate === 'function' ? translate('exhibitionsTitle') : '';
-  }
-  const altKeys = [
-    'image_alt',
-    'imageAlt',
-    'image_alt_text',
-    'imageAltText',
-    'afbeelding_alt',
-    'afbeeldingAlt',
-    'afbeelding_omschrijving',
-    'afbeeldingOmschrijving',
-    'media_alt',
-    'mediaAlt',
-    'poster_alt',
-    'posterAlt',
-    'hero_image_alt',
-    'heroImageAlt',
-    'cover_image_alt',
-    'coverImageAlt',
-    'alt',
-  ];
-  for (const key of altKeys) {
-    const value = exposition[key];
-    if (typeof value === 'string') {
-      const trimmed = value.trim();
-      if (trimmed) {
-        return trimmed;
-      }
-    }
-  }
-  if (typeof exposition.titel === 'string' && exposition.titel.trim()) {
-    return exposition.titel.trim();
-  }
-  return typeof translate === 'function' ? translate('exhibitionsTitle') : '';
 }
 
 function pickBoolean(...values) {
@@ -160,8 +67,6 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
   const ctaDescribedBy = ticketContext ? ticketNoteId : undefined;
 
   const [isFavoriteBouncing, setIsFavoriteBouncing] = useState(false);
-  const [hasImageError, setHasImageError] = useState(false);
-  const [isImageLoaded, setIsImageLoaded] = useState(false);
   const bounceTimeoutRef = useRef(null);
 
   useEffect(() => {
@@ -183,17 +88,6 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
     }, 420);
   };
 
-  const mediaUrl = useMemo(() => resolveMediaUrl(exposition), [exposition]);
-  const hasMedia = Boolean(mediaUrl) && !hasImageError;
-  const resolvedImage = hasMedia ? mediaUrl : FALLBACK_IMAGE;
-  const favoriteImage = hasMedia ? mediaUrl : FALLBACK_IMAGE;
-  const resolvedAltText = useMemo(() => resolveMediaAlt(exposition, t), [exposition, t]);
-
-  useEffect(() => {
-    setHasImageError(false);
-    setIsImageLoaded(false);
-  }, [mediaUrl]);
-
   const handleFavorite = () => {
     toggleFavorite({
       id: exposition.id,
@@ -204,7 +98,7 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
       ticketAffiliateUrl: primaryAffiliateUrl,
       ticketUrl: buyUrl,
       museumSlug: slug,
-      image: favoriteImage,
+      image: null,
       type: 'exposition',
     });
     triggerFavoriteBounce();
@@ -229,39 +123,10 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
   ];
   const activeTags = tagDefinitions.filter((tag) => tag.active);
 
-  const mediaClassName = [
-    'exposition-card__media',
-    !isImageLoaded ? ' is-loading' : '',
-    hasMedia ? '' : ' is-placeholder',
-  ]
-    .filter(Boolean)
-    .join(' ');
-
   return (
     <article
       className={`exposition-card${isFavoriteBouncing ? ' is-bouncing' : ''}`}
     >
-      <div className={mediaClassName} aria-busy={!isImageLoaded}>
-        {!isImageLoaded && (
-          <div className="exposition-card__skeleton" aria-hidden="true">
-            <div className="exposition-card__skeleton-shimmer" />
-          </div>
-        )}
-        <Image
-          src={resolvedImage}
-          alt={resolvedAltText}
-          width={630}
-          height={300}
-          className="exposition-card__image"
-          loading="lazy"
-          sizes="(max-width: 600px) 100vw, (max-width: 1024px) 70vw, 300px"
-          onLoadingComplete={() => setIsImageLoaded(true)}
-          onError={() => {
-            setHasImageError(true);
-            setIsImageLoaded(true);
-          }}
-        />
-      </div>
       <div className="exposition-card__body">
         <div className="exposition-card__topline">
           {rangeLabel && (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3118,54 +3118,6 @@ button.hero-quick-link {
   box-shadow: 0 20px 50px rgba(2, 6, 23, 0.6);
 }
 
-.exposition-card__media {
-  position: relative;
-  overflow: hidden;
-  aspect-ratio: 21 / 10;
-  background: linear-gradient(135deg, rgba(255,90,60,0.14), rgba(14,116,144,0.14));
-}
-
-.exposition-card__media.is-placeholder {
-  background: linear-gradient(135deg, rgba(255,90,60,0.1), rgba(59,130,246,0.12));
-}
-
-.exposition-card__skeleton {
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: var(--skeleton-base);
-  overflow: hidden;
-  opacity: 0;
-  transition: opacity 0.25s ease;
-}
-
-.exposition-card__skeleton-shimmer {
-  position: absolute;
-  inset: 0;
-  transform: translateX(-100%);
-  background: linear-gradient(90deg, transparent 0%, var(--skeleton-highlight) 50%, transparent 100%);
-  animation: skeleton-shimmer 1.6s ease-in-out infinite;
-}
-
-.exposition-card__media.is-loading .exposition-card__skeleton {
-  opacity: 1;
-}
-
-.exposition-card__image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-  transition: transform 0.35s ease, opacity 0.25s ease;
-}
-
-.exposition-card__media.is-loading .exposition-card__image {
-  opacity: 0;
-}
-
-.exposition-card:hover .exposition-card__image {
-  transform: scale(1.02);
-}
 
 .exposition-card__body,
 .event-card__body {
@@ -3174,6 +3126,16 @@ button.hero-quick-link {
   gap: var(--space-16);
   padding: var(--space-24);
   min-height: 0;
+}
+
+.exposition-card__body {
+  background: linear-gradient(180deg, rgba(148,163,184,0.12) 0%, rgba(248,250,252,0) 78%);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+[data-theme='dark'] .exposition-card__body {
+  background: linear-gradient(180deg, rgba(148,163,184,0.16) 0%, rgba(2,6,23,0) 78%);
+  border-bottom-color: rgba(100, 116, 139, 0.32);
 }
 
 .exposition-card__topline {
@@ -3392,14 +3354,12 @@ button.hero-quick-link {
 @media (prefers-reduced-motion: reduce) {
   .exposition-carousel__arrow,
   .exposition-carousel__dot,
-  .exposition-card,
-  .exposition-card__image {
+  .exposition-card {
     transition: none;
   }
   .exposition-card.is-bouncing .icon-button.large {
     animation: none;
   }
-  .exposition-card__skeleton-shimmer,
   .exposition-card--loading .exposition-card__summary::after,
   .exposition-card--loading .exposition-card__title::after,
   .exposition-card--loading .exposition-card__tag::after,


### PR DESCRIPTION
## Summary
- remove exposition card image handling and related generated fallback logic
- simplify the card layout and styling for a text-only presentation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d78bf28fd88326a69ad848033271c7