### PR TITLE
Adjust museum detail hero text color in light theme

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1356,6 +1356,9 @@ button.hero-quick-link {
   background: linear-gradient(180deg, var(--info-card-bg) 0%, rgba(255, 255, 255, 0.95) 100%);
   box-shadow: var(--panel-shadow);
 }
+.museum-hero-text--standalone .museum-hero-title {
+  color: rgba(255, 255, 255, 0.95);
+}
 .museum-hero-text--standalone .museum-hero-location,
 .museum-hero-text--standalone .museum-hero-tagline {
   color: var(--muted);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1347,9 +1347,13 @@ button.hero-quick-link {
   background: linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.68) 68%, rgba(15, 23, 42, 0.9) 100%);
   color: rgba(248, 250, 252, 0.96);
 }
+.museum-hero-overlay .museum-hero-title {
+  color: rgba(255, 255, 255, 0.98);
+  text-shadow: 0 18px 36px rgba(15, 23, 42, 0.45);
+}
 .museum-hero-text { display: flex; flex-direction: column; gap: 6px; max-width: 720px; }
-.museum-hero-overlay .museum-hero-location { color: rgba(226, 232, 240, 0.78); }
-.museum-hero-overlay .museum-hero-tagline { color: rgba(226, 232, 240, 0.9); }
+.museum-hero-overlay .museum-hero-location { color: rgba(248, 250, 252, 0.82); }
+.museum-hero-overlay .museum-hero-tagline { color: rgba(241, 245, 249, 0.92); }
 .museum-hero-text--standalone {
   padding: clamp(var(--space-24), 5vw, var(--space-32));
   border-radius: var(--radius-md);


### PR DESCRIPTION
## Summary
- ensure the standalone hero text on museum detail pages renders the museum name in white for the light layout

## Testing
- not run (blocked by 403 downloading @capacitor/android during npm install)


------
https://chatgpt.com/codex/tasks/task_e_68da35a83e3883269bb56f002c886039