### PR TITLE
Enable nearby filter with Supabase RPC

### DIFF
--- a/components/FiltersSheet.js
+++ b/components/FiltersSheet.js
@@ -20,15 +20,8 @@ function resolveSections(sections, labels) {
         { name: 'free', label: labels?.free },
         { name: 'exhibitions', label: labels?.exhibitions },
         { name: 'kidFriendly', label: labels?.kidFriendly },
+        { name: 'nearby', label: labels?.distance },
       ],
-    },
-    {
-      id: 'comingsoon',
-      title: labels?.future,
-      options: [
-        { name: 'nearby', label: labels?.distance, disabled: true, badge: labels?.comingSoon },
-      ],
-      note: labels?.todo,
     },
   ];
 }

--- a/lib/museumFilters.js
+++ b/lib/museumFilters.js
@@ -1,0 +1,32 @@
+export function filterMuseumsForDisplay(
+  museums,
+  { excludeSlugs = [], onlyKidFriendly = false, isKidFriendlyCheck, isNearbyActive = false } = {}
+) {
+  const list = Array.isArray(museums) ? museums.filter(Boolean) : [];
+  const exclusions = Array.isArray(excludeSlugs)
+    ? excludeSlugs.filter(Boolean)
+    : excludeSlugs
+    ? [excludeSlugs]
+    : [];
+  const exclusionSet = new Set(exclusions);
+
+  let filtered = list;
+
+  if (exclusionSet.size > 0) {
+    filtered = filtered.filter((museum) => !exclusionSet.has(museum?.slug));
+  }
+
+  if (onlyKidFriendly && typeof isKidFriendlyCheck === 'function') {
+    filtered = filtered.filter((museum) => isKidFriendlyCheck(museum));
+  }
+
+  // When the nearby filter is active we intentionally keep all results, even when
+  // `afstand_meter` is null, because the RPC already limits the rows to the
+  // requested radius. This also ensures we show the calculated distances that
+  // come back from the server.
+  if (isNearbyActive) {
+    return filtered;
+  }
+
+  return filtered;
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "start": "next start",
     "crawl": "node scripts/crawl.mjs",
-    "test": "node tests/ticketCta.test.cjs && node tests/kidFriendlyFilter.test.cjs",
+    "test": "node tests/ticketCta.test.cjs && node tests/kidFriendlyFilter.test.cjs && node tests/nearbyFilter.test.cjs",
     "build:web": "next build",
     "cap:copy": "npx cap copy",
     "cap:sync": "npx cap sync"

--- a/scripts/musea_within_radius.sql
+++ b/scripts/musea_within_radius.sql
@@ -1,0 +1,49 @@
+-- Create or replace the RPC that returns museums within a given radius and the calculated distance.
+-- Adjust the latitude/longitude column names if your schema differs.
+create or replace function public.musea_within_radius(
+  lat double precision,
+  lng double precision,
+  radius_meters double precision
+)
+returns table (
+  id uuid,
+  naam text,
+  stad text,
+  provincie text,
+  slug text,
+  gratis_toegankelijk boolean,
+  ticket_affiliate_url text,
+  website_url text,
+  kindvriendelijk boolean,
+  afstand_meter double precision
+)
+as
+$$
+  with origin as (
+    select ST_SetSRID(ST_MakePoint(lng, lat), 4326)::geography as geom
+  )
+  select
+    m.id,
+    m.naam,
+    m.stad,
+    m.provincie,
+    m.slug,
+    m.gratis_toegankelijk,
+    m.ticket_affiliate_url,
+    m.website_url,
+    m.kindvriendelijk,
+    ST_Distance(
+      origin.geom,
+      ST_SetSRID(ST_MakePoint(m.longitude, m.latitude), 4326)::geography
+    ) as afstand_meter
+  from musea m
+  cross join origin
+  where ST_DWithin(
+    origin.geom,
+    ST_SetSRID(ST_MakePoint(m.longitude, m.latitude), 4326)::geography,
+    radius_meters
+  )
+  order by afstand_meter asc, lower(m.naam);
+$$
+language sql
+stable;

--- a/tests/nearbyFilter.test.cjs
+++ b/tests/nearbyFilter.test.cjs
@@ -1,0 +1,41 @@
+const assert = require('assert');
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+async function loadModule() {
+  const moduleUrl = pathToFileURL(path.resolve(__dirname, '../lib/museumFilters.js'));
+  return import(moduleUrl.href);
+}
+
+async function run() {
+  const { filterMuseumsForDisplay } = await loadModule();
+
+  const museums = [
+    { id: 1, slug: 'museum-a', naam: 'Museum A', afstand_meter: 120 },
+    { id: 2, slug: 'museum-b', naam: 'Museum B', afstand_meter: null },
+  ];
+
+  const filtered = filterMuseumsForDisplay(museums, {
+    excludeSlugs: [],
+    onlyKidFriendly: false,
+    isNearbyActive: true,
+    isKidFriendlyCheck: () => true,
+  });
+
+  assert.strictEqual(filtered.length, museums.length, 'Nearby results should remain visible');
+  assert(
+    filtered.some((museum) => museum.afstand_meter === 120),
+    'Museums with calculated distance should be present'
+  );
+  assert(
+    filtered.some((museum) => museum.afstand_meter === null),
+    'Museums without a distance fallback should not be filtered out on the client'
+  );
+
+  console.log('Nearby filter results remain visible.');
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- prompt for geolocation when enabling the nearby filter and store the user coordinates
- switch the museum query to call the new `musea_within_radius` RPC and use distance-aware sorting
- add a reusable museum filter helper, Supabase SQL for the RPC, and a test covering nearby results

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da473bdc208326ab61782ce2d6f011