### PR TITLE
Fix modern art tag parsing

### DIFF
--- a/lib/museumSearch.js
+++ b/lib/museumSearch.js
@@ -54,6 +54,20 @@ const CATEGORY_SYNONYMS = {
   film: ['film', 'films', 'cinema', 'movie', 'movies', 'bioscoop'],
 };
 
+const SORTED_CATEGORY_SYNONYMS = Object.entries(CATEGORY_SYNONYMS)
+  .flatMap(([category, synonyms]) =>
+    synonyms
+      .map((synonym) => (typeof synonym === 'string' ? synonym.trim() : ''))
+      .filter(Boolean)
+      .map((synonym) => ({ category, synonym }))
+  )
+  .sort((a, b) => {
+    if (b.synonym.length === a.synonym.length) {
+      return a.synonym.localeCompare(b.synonym);
+    }
+    return b.synonym.length - a.synonym.length;
+  });
+
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -67,16 +81,15 @@ export function parseMuseumSearchQuery(rawQuery) {
   let workingLower = rawQuery.toLowerCase();
   const matchedCategories = new Set();
 
-  Object.entries(CATEGORY_SYNONYMS).forEach(([category, synonyms]) => {
-    synonyms.forEach((synonym) => {
-      const term = synonym.toLowerCase();
-      const pattern = new RegExp(`\\b${escapeRegExp(term)}\\b`, 'gi');
-      if (pattern.test(workingLower)) {
-        matchedCategories.add(category);
-        working = working.replace(pattern, ' ');
-        workingLower = workingLower.replace(pattern, ' ');
-      }
-    });
+  SORTED_CATEGORY_SYNONYMS.forEach(({ category, synonym }) => {
+    const term = synonym.toLowerCase();
+    const pattern = new RegExp(`\\b${escapeRegExp(term)}\\b`, 'gi');
+    if (pattern.test(workingLower)) {
+      matchedCategories.add(category);
+      const replacePattern = new RegExp(`\\b${escapeRegExp(term)}\\b`, 'gi');
+      working = working.replace(replacePattern, ' ');
+      workingLower = workingLower.replace(replacePattern, ' ');
+    }
   });
 
   const textQuery = working.replace(/\s+/g, ' ').trim();

--- a/tests/museumSearch.test.cjs
+++ b/tests/museumSearch.test.cjs
@@ -63,6 +63,20 @@ async function run() {
     'Non-science museums should be filtered out when filtering by science'
   );
 
+  const modernArtQuery = parseMuseumSearchQuery('Moderne kunst');
+
+  assert.strictEqual(
+    modernArtQuery.textQuery,
+    '',
+    'Moderne kunst should not leave behind partial free text search terms'
+  );
+
+  assert.deepStrictEqual(
+    modernArtQuery.categoryFilters,
+    ['modern-art'],
+    'Moderne kunst should map to the modern art category filter'
+  );
+
   console.log('Museum search parsing tests passed.');
 }
 


### PR DESCRIPTION
## Summary
- prioritize longer category synonyms when parsing search queries to avoid partial matches leaving stray text
- add a regression test to ensure "Moderne kunst" maps to the modern art category without leftover query terms

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da59d03ad88326b76ca5c146aa32d1