### PR TITLE
Hide nearby filter option

### DIFF
--- a/components/FiltersSheet.js
+++ b/components/FiltersSheet.js
@@ -20,7 +20,7 @@ function resolveSections(sections, labels) {
         { name: 'free', label: labels?.free },
         { name: 'exhibitions', label: labels?.exhibitions },
         { name: 'kidFriendly', label: labels?.kidFriendly },
-        { name: 'nearby', label: labels?.distance },
+        { name: 'nearby', label: labels?.distance, hidden: true },
       ],
     },
   ];
@@ -53,7 +53,7 @@ export function FiltersForm({
                 </h3>
               )}
               {options.map((option) => {
-                if (!option) return null;
+                if (!option || option.hidden) return null;
                 const optionId = `${sectionId}-${option.name}`;
                 const isDisabled = Boolean(option.disabled);
                 const className = [


### PR DESCRIPTION
## Summary
- hide the "nearby" filter option in the filter sheet by marking it hidden while keeping the underlying filter logic intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da5d19b2a88326849354e82d468b3a