### PR TITLE
Fix horizontal scrolling on exposition carousel

### DIFF
--- a/components/ExpositionCarousel.js
+++ b/components/ExpositionCarousel.js
@@ -95,6 +95,32 @@ export default function ExpositionCarousel({
   useEffect(() => {
     const viewport = viewportRef.current;
     if (!viewport || totalSlides <= 1) return undefined;
+
+    const handleWheel = (event) => {
+      if (!viewport) return;
+      if (event.ctrlKey) return;
+      const isScrollable = viewport.scrollWidth - viewport.clientWidth > 1;
+      if (!isScrollable) return;
+
+      const { deltaX = 0, deltaY = 0 } = event;
+      if (Math.abs(deltaY) <= Math.abs(deltaX)) return;
+
+      event.preventDefault();
+      viewport.scrollBy({
+        left: deltaY,
+        behavior: 'smooth',
+      });
+    };
+
+    viewport.addEventListener('wheel', handleWheel, { passive: false });
+    return () => {
+      viewport.removeEventListener('wheel', handleWheel);
+    };
+  }, [totalSlides]);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport || totalSlides <= 1) return undefined;
     let frame = null;
 
     const handleScroll = () => {


### PR DESCRIPTION
## Summary
- translate vertical mouse-wheel gestures into horizontal movement for the exposition carousel
- guard against unnecessary interception when horizontal scrolling is unavailable or gestures are already horizontal

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da5e1d39b48326aed24842dc0fbb88