### PR TITLE
Add media header glyph to exposition cards

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -33,23 +33,18 @@ function getMediaTheme(exposition, museumSlug) {
   const slugPart = museumSlug || exposition?.museumSlug || '';
   const titlePart = exposition?.titel || '';
   const seed = `${idPart}-${slugPart}-${titlePart}`;
-  if (!seed) {
-    return { className: 'exposition-card__media--tone-1', style: undefined };
-  }
-
   let hash = 0;
   for (let i = 0; i < seed.length; i += 1) {
     hash = (hash * 31 + seed.charCodeAt(i)) | 0;
   }
   const positiveHash = Math.abs(hash);
   const hue = positiveHash % 360;
-  const secondaryHue = (hue + 32) % 360;
-  const toneClass = `exposition-card__media--tone-${(positiveHash % 3) + 1}`;
+  const saturation = 55 + (positiveHash % 10);
+  const lightness = 82 + (positiveHash % 8);
 
   return {
-    className: toneClass,
     style: {
-      background: `linear-gradient(135deg, hsla(${hue}, 62%, 86%, 0.9), hsla(${secondaryHue}, 58%, 82%, 0.88))`,
+      backgroundColor: `hsl(${hue}, ${saturation}%, ${lightness}%)`,
     },
   };
 }
@@ -148,12 +143,7 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
   ];
   const activeTags = tagDefinitions.filter((tag) => tag.active);
   const mediaTheme = useMemo(() => getMediaTheme(exposition, slug), [exposition, slug]);
-  const mediaClassName = useMemo(() => {
-    if (!mediaTheme?.className) {
-      return 'exposition-card__media';
-    }
-    return `exposition-card__media ${mediaTheme.className}`;
-  }, [mediaTheme]);
+  const mediaClassName = 'exposition-card__media';
 
   return (
     <article

--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -28,63 +28,6 @@ function pickBoolean(...values) {
   return undefined;
 }
 
-function getExpositionGlyph(exposition, tags = {}) {
-  if (!exposition) {
-    return '🏛️';
-  }
-
-  const isChildFriendly =
-    pickBoolean(
-      tags.childFriendly,
-      exposition?.kindvriendelijk,
-      exposition?.childFriendly,
-      exposition?.familievriendelijk,
-      exposition?.familyFriendly
-    ) === true;
-
-  if (isChildFriendly) {
-    return '🧒';
-  }
-
-  const isFree =
-    pickBoolean(tags.free, exposition?.gratis, exposition?.free, exposition?.kosteloos, exposition?.freeEntry) === true;
-  if (isFree) {
-    return '🎟️';
-  }
-
-  const isTemporary =
-    pickBoolean(
-      tags.temporary,
-      exposition?.tijdelijk,
-      exposition?.temporary,
-      exposition?.tijdelijkeTentoonstelling
-    ) === true;
-  if (isTemporary) {
-    return '⏳';
-  }
-
-  if (Array.isArray(exposition?.tags) && exposition.tags.length > 0) {
-    const themedTag = exposition.tags.find((tag) => typeof tag === 'string');
-    if (themedTag) {
-      const normalized = themedTag.trim().toLowerCase();
-      if (normalized.includes('modern') || normalized.includes('design')) return '🎨';
-      if (normalized.includes('history')) return '📜';
-      if (normalized.includes('science')) return '🔬';
-      if (normalized.includes('nature')) return '🌿';
-    }
-  }
-
-  const title = typeof exposition.titel === 'string' ? exposition.titel.trim() : '';
-  if (title) {
-    const firstChar = title.charAt(0).toUpperCase();
-    if (firstChar) {
-      return firstChar;
-    }
-  }
-
-  return '🏛️';
-}
-
 function getMediaTheme(exposition, museumSlug) {
   const idPart = exposition?.id != null ? String(exposition.id) : '';
   const slugPart = museumSlug || exposition?.museumSlug || '';
@@ -106,7 +49,7 @@ function getMediaTheme(exposition, museumSlug) {
   return {
     className: toneClass,
     style: {
-      background: `linear-gradient(135deg, hsla(${hue}, 82%, 64%, 0.38), hsla(${secondaryHue}, 78%, 58%, 0.32))`,
+      background: `linear-gradient(135deg, hsla(${hue}, 62%, 86%, 0.9), hsla(${secondaryHue}, 58%, 82%, 0.88))`,
     },
   };
 }
@@ -204,18 +147,7 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
     { key: 'temporary', label: t('tagTemporary'), active: temporaryTag === true },
   ];
   const activeTags = tagDefinitions.filter((tag) => tag.active);
-  const mediaGlyph = useMemo(() => getExpositionGlyph(exposition, tags), [exposition, tags]);
   const mediaTheme = useMemo(() => getMediaTheme(exposition, slug), [exposition, slug]);
-  const mediaGlyphLabel = useMemo(() => {
-    if (!mediaGlyph) return undefined;
-    if (mediaGlyph === '🧒') return t('tagChildFriendly') || undefined;
-    if (mediaGlyph === '🎟️') return t('tagFree') || undefined;
-    if (mediaGlyph === '⏳') return t('tagTemporary') || undefined;
-    if (typeof mediaGlyph === 'string' && mediaGlyph.length === 1 && exposition?.titel) {
-      return exposition.titel;
-    }
-    return undefined;
-  }, [exposition?.titel, mediaGlyph, t]);
   const mediaClassName = useMemo(() => {
     if (!mediaTheme?.className) {
       return 'exposition-card__media';
@@ -227,11 +159,7 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
     <article
       className={`exposition-card${isFavoriteBouncing ? ' is-bouncing' : ''}`}
     >
-      <div className={mediaClassName} style={mediaTheme?.style}>
-        <div className="exposition-card__media-content" role="img" aria-label={mediaGlyphLabel}>
-          {mediaGlyph}
-        </div>
-      </div>
+      <div className={mediaClassName} style={mediaTheme?.style} aria-hidden="true" />
       <div className="exposition-card__body">
         <div className="exposition-card__topline">
           {rangeLabel && (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3145,15 +3145,110 @@ button.hero-quick-link {
   box-shadow: 0 20px 50px rgba(2, 6, 23, 0.6);
 }
 
+
 .exposition-card__media {
   position: relative;
   overflow: hidden;
   aspect-ratio: 21 / 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(16px, 4vw, 28px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.22);
   background: linear-gradient(135deg, rgba(255,90,60,0.14), rgba(14,116,144,0.14));
+  transition: background 0.35s ease, border-color 0.35s ease;
+}
+
+.exposition-card__media::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 24% 18%, rgba(255,255,255,0.35) 0%, transparent 55%);
+  opacity: 0.6;
+  mix-blend-mode: screen;
 }
 
 .exposition-card__media.is-placeholder {
   background: linear-gradient(135deg, rgba(255,90,60,0.1), rgba(59,130,246,0.12));
+}
+
+.exposition-card__media-content {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border-radius: calc(var(--radius-md) - 10px);
+  padding: clamp(12px, 3vw, 24px);
+  background: rgba(255, 255, 255, 0.18);
+  color: rgba(15, 23, 42, 0.85);
+  font-size: clamp(2.5rem, 8vw, 3.75rem);
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  text-transform: uppercase;
+  backdrop-filter: blur(2px) saturate(120%);
+  transition: transform 0.35s ease, background 0.35s ease;
+}
+
+.exposition-card:hover .exposition-card__media-content {
+  transform: scale(1.025);
+  background: rgba(255, 255, 255, 0.24);
+}
+
+[data-theme='dark'] .exposition-card__media {
+  border-color: rgba(71, 85, 105, 0.42);
+}
+
+[data-theme='dark'] .exposition-card__media::before {
+  opacity: 0.4;
+}
+
+[data-theme='dark'] .exposition-card__media-content {
+  background: rgba(15, 23, 42, 0.55);
+  color: rgba(226, 232, 240, 0.92);
+}
+
+[data-theme='dark'] .exposition-card:hover .exposition-card__media-content {
+  background: rgba(15, 23, 42, 0.66);
+}
+
+.exposition-card__media--tone-1 {
+  background: linear-gradient(135deg, rgba(244,114,182,0.28), rgba(129,140,248,0.32));
+}
+
+.exposition-card__media--tone-2 {
+  background: linear-gradient(135deg, rgba(56,189,248,0.26), rgba(99,102,241,0.28));
+}
+
+.exposition-card__media--tone-3 {
+  background: linear-gradient(135deg, rgba(251,191,36,0.28), rgba(248,113,113,0.28));
+}
+
+.exposition-card__media--tone-1::before,
+.exposition-card__media--tone-2::before,
+.exposition-card__media--tone-3::before {
+  opacity: 0.55;
+}
+
+.exposition-card__media-content img,
+.exposition-card__media-content svg {
+  max-width: 100%;
+  max-height: 100%;
+}
+
+@media (max-width: 640px) {
+  .exposition-card__media {
+    aspect-ratio: 16 / 9;
+    padding: clamp(12px, 8vw, 20px);
+  }
+
+  .exposition-card__media-content {
+    border-radius: calc(var(--radius-md) - 12px);
+    font-size: clamp(2rem, 12vw, 3.25rem);
+  }
 }
 
 .exposition-card__skeleton {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3153,71 +3153,26 @@ button.hero-quick-link {
   aspect-ratio: 21 / 10;
   border-bottom: 1px solid rgba(148, 163, 184, 0.22);
   border-radius: var(--radius-md) var(--radius-md) 0 0;
-  background: linear-gradient(135deg, rgba(236, 72, 153, 0.18), rgba(59, 130, 246, 0.18));
-  transition: transform 0.35s ease, background 0.35s ease, border-color 0.35s ease;
+  background-color: rgba(241, 245, 249, 0.85);
+  transition: transform 0.35s ease, background-color 0.35s ease, border-color 0.35s ease;
 }
 
-.exposition-card__media::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: radial-gradient(circle at 24% 18%, rgba(255, 255, 255, 0.5) 0%, transparent 58%);
-  opacity: 0.55;
-  mix-blend-mode: screen;
-}
-
+.exposition-card__media::before,
 .exposition-card__media::after {
-  content: '';
-  position: absolute;
-  inset: clamp(14px, 4vw, 24px);
-  border-radius: calc(var(--radius-md) - 12px);
-  background: rgba(255, 255, 255, 0.24);
-  transition: transform 0.35s ease, background 0.35s ease;
-  transform: scale(0.985);
-}
-
-.exposition-card:hover .exposition-card__media::after {
-  transform: scale(1);
-  background: rgba(255, 255, 255, 0.32);
+  content: none;
 }
 
 .exposition-card__media.is-placeholder {
-  background: linear-gradient(135deg, rgba(244, 114, 182, 0.16), rgba(14, 165, 233, 0.18));
+  background-color: rgba(241, 245, 249, 0.85);
 }
 
 [data-theme='dark'] .exposition-card__media {
   border-color: rgba(71, 85, 105, 0.42);
 }
 
-[data-theme='dark'] .exposition-card__media::after {
-  background: rgba(15, 23, 42, 0.38);
-}
-
-[data-theme='dark'] .exposition-card:hover .exposition-card__media::after {
-  background: rgba(15, 23, 42, 0.46);
-}
-
-.exposition-card__media--tone-1 {
-  background: linear-gradient(135deg, rgba(240, 171, 252, 0.42), rgba(129, 140, 248, 0.36));
-}
-
-.exposition-card__media--tone-2 {
-  background: linear-gradient(135deg, rgba(134, 239, 172, 0.45), rgba(56, 189, 248, 0.38));
-}
-
-.exposition-card__media--tone-3 {
-  background: linear-gradient(135deg, rgba(253, 230, 138, 0.45), rgba(248, 196, 113, 0.4));
-}
-
 @media (max-width: 640px) {
   .exposition-card__media {
     aspect-ratio: 16 / 9;
-  }
-
-  .exposition-card__media::after {
-    inset: clamp(12px, 8vw, 20px);
-    border-radius: calc(var(--radius-md) - 16px);
   }
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3146,17 +3146,15 @@ button.hero-quick-link {
 }
 
 
+
 .exposition-card__media {
   position: relative;
   overflow: hidden;
   aspect-ratio: 21 / 10;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: clamp(16px, 4vw, 28px);
   border-bottom: 1px solid rgba(148, 163, 184, 0.22);
-  background: linear-gradient(135deg, rgba(255,90,60,0.14), rgba(14,116,144,0.14));
-  transition: background 0.35s ease, border-color 0.35s ease;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  background: linear-gradient(135deg, rgba(236, 72, 153, 0.18), rgba(59, 130, 246, 0.18));
+  transition: transform 0.35s ease, background 0.35s ease, border-color 0.35s ease;
 }
 
 .exposition-card__media::before {
@@ -3164,90 +3162,62 @@ button.hero-quick-link {
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: radial-gradient(circle at 24% 18%, rgba(255,255,255,0.35) 0%, transparent 55%);
-  opacity: 0.6;
+  background: radial-gradient(circle at 24% 18%, rgba(255, 255, 255, 0.5) 0%, transparent 58%);
+  opacity: 0.55;
   mix-blend-mode: screen;
 }
 
-.exposition-card__media.is-placeholder {
-  background: linear-gradient(135deg, rgba(255,90,60,0.1), rgba(59,130,246,0.12));
-}
-
-.exposition-card__media-content {
-  position: relative;
-  z-index: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  border-radius: calc(var(--radius-md) - 10px);
-  padding: clamp(12px, 3vw, 24px);
-  background: rgba(255, 255, 255, 0.18);
-  color: rgba(15, 23, 42, 0.85);
-  font-size: clamp(2.5rem, 8vw, 3.75rem);
-  font-weight: 700;
-  letter-spacing: -0.015em;
-  text-transform: uppercase;
-  backdrop-filter: blur(2px) saturate(120%);
-  transition: transform 0.35s ease, background 0.35s ease;
-}
-
-.exposition-card:hover .exposition-card__media-content {
-  transform: scale(1.025);
+.exposition-card__media::after {
+  content: '';
+  position: absolute;
+  inset: clamp(14px, 4vw, 24px);
+  border-radius: calc(var(--radius-md) - 12px);
   background: rgba(255, 255, 255, 0.24);
+  transition: transform 0.35s ease, background 0.35s ease;
+  transform: scale(0.985);
+}
+
+.exposition-card:hover .exposition-card__media::after {
+  transform: scale(1);
+  background: rgba(255, 255, 255, 0.32);
+}
+
+.exposition-card__media.is-placeholder {
+  background: linear-gradient(135deg, rgba(244, 114, 182, 0.16), rgba(14, 165, 233, 0.18));
 }
 
 [data-theme='dark'] .exposition-card__media {
   border-color: rgba(71, 85, 105, 0.42);
 }
 
-[data-theme='dark'] .exposition-card__media::before {
-  opacity: 0.4;
+[data-theme='dark'] .exposition-card__media::after {
+  background: rgba(15, 23, 42, 0.38);
 }
 
-[data-theme='dark'] .exposition-card__media-content {
-  background: rgba(15, 23, 42, 0.55);
-  color: rgba(226, 232, 240, 0.92);
-}
-
-[data-theme='dark'] .exposition-card:hover .exposition-card__media-content {
-  background: rgba(15, 23, 42, 0.66);
+[data-theme='dark'] .exposition-card:hover .exposition-card__media::after {
+  background: rgba(15, 23, 42, 0.46);
 }
 
 .exposition-card__media--tone-1 {
-  background: linear-gradient(135deg, rgba(244,114,182,0.28), rgba(129,140,248,0.32));
+  background: linear-gradient(135deg, rgba(240, 171, 252, 0.42), rgba(129, 140, 248, 0.36));
 }
 
 .exposition-card__media--tone-2 {
-  background: linear-gradient(135deg, rgba(56,189,248,0.26), rgba(99,102,241,0.28));
+  background: linear-gradient(135deg, rgba(134, 239, 172, 0.45), rgba(56, 189, 248, 0.38));
 }
 
 .exposition-card__media--tone-3 {
-  background: linear-gradient(135deg, rgba(251,191,36,0.28), rgba(248,113,113,0.28));
-}
-
-.exposition-card__media--tone-1::before,
-.exposition-card__media--tone-2::before,
-.exposition-card__media--tone-3::before {
-  opacity: 0.55;
-}
-
-.exposition-card__media-content img,
-.exposition-card__media-content svg {
-  max-width: 100%;
-  max-height: 100%;
+  background: linear-gradient(135deg, rgba(253, 230, 138, 0.45), rgba(248, 196, 113, 0.4));
 }
 
 @media (max-width: 640px) {
   .exposition-card__media {
     aspect-ratio: 16 / 9;
-    padding: clamp(12px, 8vw, 20px);
   }
 
-  .exposition-card__media-content {
-    border-radius: calc(var(--radius-md) - 12px);
-    font-size: clamp(2rem, 12vw, 3.25rem);
+  .exposition-card__media::after {
+    inset: clamp(12px, 8vw, 20px);
+    border-radius: calc(var(--radius-md) - 16px);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a media header section to exposition cards with dynamic gradients and glyphs
- derive glyphs from exposition metadata and provide accessible labelling
- extend global styles for the new media slot with responsive layout and tone modifiers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da784b83f883268eaa0cc49152a4e4