### PR TITLE
Improve image loading performance

### DIFF
--- a/lib/museumImages.js
+++ b/lib/museumImages.js
@@ -1,32 +1,59 @@
+import allardPiersonAmsterdam from "../public/images/Eric de Redelijkheid Allard Pierson Museum.jpg";
+import amsterdamMuseumAmsterdam from "../public/images/Amsterdam Museum Rachel Ecclestone_CC_BY_SA 4_0_via Hart Amsterdam.jpg";
+import anneFrankAmsterdam from "../public/images/Anne Frank.jpg";
+import bodyWorldsAmsterdam from "../public/images/Body Worlds Franz Kohler.jpg";
+import eyeFilmmuseumAmsterdam from "../public/images/Eye Sam Amil.jpg";
+import foamFotografiemuseumAmsterdam from "../public/images/FOAM Jan-WIllem Doornenbal.jpg";
+import hartMuseumAmsterdam from "../public/images/H'art_Monique Vermeulen.jpg";
+import hetGrachtenmuseumAmsterdam from "../public/images/Het grachtenmuseum Thomas Quine.jpg";
+import hetSchipAmsterdam from "../public/images/Het Schip_Marcel Westhoff_MWFF4975 1.jpg";
+import hetScheepvaartmuseumAmsterdam from "../public/images/Het scheepsvaartmudeum_Rob Oo.jpg";
+import huisMarseilleAmsterdam from "../public/images/Huis Marseille_Hans Luthart.jpg";
+import joodsMuseumAmsterdam from "../public/images/Joods Historisch Museum_Michele Ahin.jpg";
+import kattenkabinetAmsterdam from "../public/images/KattenKabinet_Taylor Dahlin.jpg";
+import micropiaMuseumAmsterdam from "../public/images/micropia-museum-amsterdam.jpg";
+import mocoMuseumAmsterdam from "../public/images/moco-museum-amsterdam.jpg";
+import museumVanLoonAmsterdam from "../public/images/Van Loon_ Willem van Valkenburg.jpg";
+import nemoScienceMuseumAmsterdam from "../public/images/NEMO_Randy Connolly.jpg";
+import nxtMuseumAmsterdam from "../public/images/Nxt Museum_Rob Oo.jpg";
+import onsLieveHeerOpSolderAmsterdam from "../public/images/Ons Lieve heer op Solder_Gary Campell Hall.jpg";
+import rembrandthuisAmsterdam from "../public/images/Rembrandt Huis_Thomas Quine.jpg";
+import rijksmuseumAmsterdam from "../public/images/Nachtwacht via Rijksmuseum.jpg";
+import stedelijkMuseumAmsterdam from "../public/images/liam-mcgarry-stedelijk.jpg";
+import straatMuseumAmsterdam from "../public/images/STRAAT_Frank Kovalchek.jpg";
+import tropenmuseumAmsterdam from "../public/images/Wereldmuseum_Alexander Svensson.jpg";
+import vanGoghMuseumAmsterdam from "../public/images/Van Gogh via Rijksmuseum.jpg";
+import wereldmuseumAmsterdam from "../public/images/Wereldmuseum_Alexander Svensson.jpg";
+import woonbootmuseumAmsterdam from "../public/images/Woonbootmuseum_Stefan.jpg";
+
 const museumImages = {
-  'allard-pierson-amsterdam': '/images/Eric de Redelijkheid Allard Pierson Museum.jpg',
-  'amsterdam-museum-amsterdam':
-    '/images/Amsterdam Museum Rachel Ecclestone_CC_BY_SA 4_0_via Hart Amsterdam.jpg',
-  'anne-frank-huis-amsterdam': '/images/Anne Frank.jpg',
-  'body-worlds-amsterdam': '/images/Body Worlds Franz Kohler.jpg',
-  'eye-filmmuseum-amsterdam': '/images/Eye Sam Amil.jpg',
-  'foam-fotografiemuseum-amsterdam': '/images/FOAM Jan-WIllem Doornenbal.jpg',
-  'hart-museum-amsterdam': "/images/H'art_Monique Vermeulen.jpg",
-  'het-grachtenmuseum-amsterdam': '/images/Het grachtenmuseum Thomas Quine.jpg',
-  'het-schip-amsterdam': '/images/Het Schip_Marcel Westhoff_MWFF4975 1.jpg',
-  'huis-marseille-amsterdam': '/images/Huis Marseille_Hans Luthart.jpg',
-  'joods-museum-amsterdam': '/images/Joods Historisch Museum_Michele Ahin.jpg',
-  'kattenkabinet-amsterdam': '/images/KattenKabinet_Taylor Dahlin.jpg',
-  'micropia-museum-amsterdam': '/images/micropia-museum-amsterdam.jpg',
-  'moco-museum-amsterdam': '/images/moco-museum-amsterdam.jpg',
-  'museum-van-loon-amsterdam': '/images/Van Loon_ Willem van Valkenburg.jpg',
-  'nemo-science-museum-amsterdam': '/images/NEMO_Randy Connolly.jpg',
-  'nxt-museum-amsterdam': '/images/Nxt Museum_Rob Oo.jpg',
-  'ons-lieve-heer-op-solder-amsterdam': '/images/Ons Lieve heer op Solder_Gary Campell Hall.jpg',
-  'rembrandthuis-amsterdam': '/images/Rembrandt Huis_Thomas Quine.jpg',
-  'rijksmuseum-amsterdam': '/images/Nachtwacht via Rijksmuseum.jpg',
-  'scheepvaartmuseum-amsterdam': '/images/Het scheepsvaartmudeum_Rob Oo.jpg',
-  'stedelijk-museum-amsterdam': '/images/liam-mcgarry-stedelijk.jpg',
-  'straat-museum-amsterdam': '/images/STRAAT_Frank Kovalchek.jpg',
-  'tropenmuseum-amsterdam': '/images/Wereldmuseum_Alexander Svensson.jpg',
-  'van-gogh-museum-amsterdam': '/images/Van Gogh via Rijksmuseum.jpg',
-  'wereldmuseum-amsterdam': '/images/Wereldmuseum_Alexander Svensson.jpg',
-  'woonbootmuseum-amsterdam': '/images/Woonbootmuseum_Stefan.jpg',
+  "allard-pierson-amsterdam": allardPiersonAmsterdam,
+  "amsterdam-museum-amsterdam": amsterdamMuseumAmsterdam,
+  "anne-frank-huis-amsterdam": anneFrankAmsterdam,
+  "body-worlds-amsterdam": bodyWorldsAmsterdam,
+  "eye-filmmuseum-amsterdam": eyeFilmmuseumAmsterdam,
+  "foam-fotografiemuseum-amsterdam": foamFotografiemuseumAmsterdam,
+  "hart-museum-amsterdam": hartMuseumAmsterdam,
+  "het-grachtenmuseum-amsterdam": hetGrachtenmuseumAmsterdam,
+  "het-schip-amsterdam": hetSchipAmsterdam,
+  "huis-marseille-amsterdam": huisMarseilleAmsterdam,
+  "joods-museum-amsterdam": joodsMuseumAmsterdam,
+  "kattenkabinet-amsterdam": kattenkabinetAmsterdam,
+  "micropia-museum-amsterdam": micropiaMuseumAmsterdam,
+  "moco-museum-amsterdam": mocoMuseumAmsterdam,
+  "museum-van-loon-amsterdam": museumVanLoonAmsterdam,
+  "nemo-science-museum-amsterdam": nemoScienceMuseumAmsterdam,
+  "nxt-museum-amsterdam": nxtMuseumAmsterdam,
+  "ons-lieve-heer-op-solder-amsterdam": onsLieveHeerOpSolderAmsterdam,
+  "rembrandthuis-amsterdam": rembrandthuisAmsterdam,
+  "rijksmuseum-amsterdam": rijksmuseumAmsterdam,
+  "scheepvaartmuseum-amsterdam": hetScheepvaartmuseumAmsterdam,
+  "stedelijk-museum-amsterdam": stedelijkMuseumAmsterdam,
+  "straat-museum-amsterdam": straatMuseumAmsterdam,
+  "tropenmuseum-amsterdam": tropenmuseumAmsterdam,
+  "van-gogh-museum-amsterdam": vanGoghMuseumAmsterdam,
+  "wereldmuseum-amsterdam": wereldmuseumAmsterdam,
+  "woonbootmuseum-amsterdam": woonbootmuseumAmsterdam,
 };
 
 export default museumImages;

--- a/lib/resolveImageSource.js
+++ b/lib/resolveImageSource.js
@@ -1,0 +1,53 @@
+function isStaticImport(image) {
+  return Boolean(image && typeof image === 'object' && 'src' in image);
+}
+
+function normalizePath(path) {
+  if (typeof path !== 'string') return null;
+  const trimmed = path.trim();
+  if (!trimmed) return null;
+  const withoutLeadingSlashes = trimmed.replace(/^\/+/, '');
+  return `/${withoutLeadingSlashes}`;
+}
+
+export function normalizeImageSource(image) {
+  if (!image) return null;
+  if (isStaticImport(image)) {
+    return image;
+  }
+  if (typeof image !== 'string') {
+    return null;
+  }
+  const trimmed = image.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (/^(https?:|data:|blob:)/i.test(trimmed)) {
+    return trimmed;
+  }
+  if (trimmed.startsWith('/')) {
+    return trimmed;
+  }
+  return normalizePath(trimmed);
+}
+
+export function resolveImageUrl(image) {
+  if (!image) return null;
+  if (isStaticImport(image)) {
+    return image.src || null;
+  }
+  if (typeof image !== 'string') {
+    return null;
+  }
+  const trimmed = image.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (/^(https?:|data:|blob:)/i.test(trimmed)) {
+    return trimmed;
+  }
+  if (trimmed.startsWith('/')) {
+    return trimmed;
+  }
+  return normalizePath(trimmed);
+}


### PR DESCRIPTION
## Summary
- import the museum hero assets as static resources so Next.js can reuse metadata and placeholders
- add shared helpers to normalize image sources and supply safe URLs for SEO and favorites
- update museum cards and detail hero images to reuse the normalized sources, blur placeholders, and fetch priorities for faster loading

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da7a703a4483268beade56ff36e73d