### PR TITLE
Enhance exposition card tag visuals

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -4,6 +4,24 @@ import { useFavorites } from './FavoritesContext';
 import { shouldShowAffiliateNote } from '../lib/nonAffiliateMuseums';
 import TicketButtonNote from './TicketButtonNote';
 
+const TAG_CONFIG = {
+  childFriendly: {
+    labelKey: 'tagChildFriendly',
+    icon: '🧒',
+    modifier: 'child-friendly',
+  },
+  free: {
+    labelKey: 'tagFree',
+    icon: '🆓',
+    modifier: 'free',
+  },
+  temporary: {
+    labelKey: 'tagTemporary',
+    icon: '⏳',
+    modifier: 'temporary',
+  },
+};
+
 function formatRange(start, end, locale) {
   if (!start) return '';
   const opts = { day: '2-digit', month: 'short' };
@@ -137,11 +155,41 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
     temporaryTag = true;
   }
   const tagDefinitions = [
-    { key: 'childFriendly', label: t('tagChildFriendly'), active: pickBoolean(tags.childFriendly, exposition?.kindvriendelijk, exposition?.childFriendly, exposition?.familievriendelijk, exposition?.familyFriendly) === true },
-    { key: 'free', label: t('tagFree'), active: pickBoolean(tags.free, exposition?.gratis, exposition?.free, exposition?.kosteloos, exposition?.freeEntry) === true },
-    { key: 'temporary', label: t('tagTemporary'), active: temporaryTag === true },
+    {
+      key: 'childFriendly',
+      active:
+        pickBoolean(
+          tags.childFriendly,
+          exposition?.kindvriendelijk,
+          exposition?.childFriendly,
+          exposition?.familievriendelijk,
+          exposition?.familyFriendly,
+        ) === true,
+    },
+    {
+      key: 'free',
+      active:
+        pickBoolean(
+          tags.free,
+          exposition?.gratis,
+          exposition?.free,
+          exposition?.kosteloos,
+          exposition?.freeEntry,
+        ) === true,
+    },
+    { key: 'temporary', active: temporaryTag === true },
   ];
-  const activeTags = tagDefinitions.filter((tag) => tag.active);
+  const activeTags = tagDefinitions
+    .filter((tag) => tag.active && TAG_CONFIG[tag.key])
+    .map((tag) => {
+      const config = TAG_CONFIG[tag.key];
+      return {
+        key: tag.key,
+        label: t(config.labelKey),
+        icon: config.icon,
+        modifier: config.modifier,
+      };
+    });
   const mediaTheme = useMemo(() => getMediaTheme(exposition, slug), [exposition, slug]);
   const mediaClassName = 'exposition-card__media';
 
@@ -192,7 +240,12 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
           <ul className="exposition-card__tags">
             {activeTags.map((tag) => (
               <li key={tag.key}>
-                <span className="exposition-card__tag">{tag.label}</span>
+                <span className={`exposition-card__tag exposition-card__tag--${tag.modifier}`}>
+                  <span className="exposition-card__tag-icon" aria-hidden="true">
+                    {tag.icon}
+                  </span>
+                  <span>{tag.label}</span>
+                </span>
               </li>
             ))}
           </ul>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3288,7 +3288,7 @@ button.hero-quick-link {
 .exposition-card__tag {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 5px;
   padding: 3px 10px;
   border-radius: 999px;
   font-size: 11px;
@@ -3304,6 +3304,11 @@ button.hero-quick-link {
   border-color: rgba(148,163,184,0.28);
 }
 
+.exposition-card__tag-icon {
+  font-size: 0.95em;
+  line-height: 1;
+}
+
 .exposition-card__tag::before {
   content: '';
   width: 6px;
@@ -3311,6 +3316,42 @@ button.hero-quick-link {
   border-radius: 50%;
   background: currentColor;
   opacity: 0.4;
+}
+
+.exposition-card__tag--child-friendly {
+  background: #ecfdf5;
+  border-color: rgba(45, 212, 191, 0.5);
+  color: #0f766e;
+}
+
+[data-theme='dark'] .exposition-card__tag--child-friendly {
+  background: rgba(16, 185, 129, 0.22);
+  border-color: rgba(45, 212, 191, 0.5);
+  color: #5eead4;
+}
+
+.exposition-card__tag--free {
+  background: #eff6ff;
+  border-color: rgba(96, 165, 250, 0.55);
+  color: #1d4ed8;
+}
+
+[data-theme='dark'] .exposition-card__tag--free {
+  background: rgba(59, 130, 246, 0.24);
+  border-color: rgba(96, 165, 250, 0.55);
+  color: #bfdbfe;
+}
+
+.exposition-card__tag--temporary {
+  background: #fef3c7;
+  border-color: rgba(251, 191, 36, 0.55);
+  color: #b45309;
+}
+
+[data-theme='dark'] .exposition-card__tag--temporary {
+  background: rgba(251, 191, 36, 0.25);
+  border-color: rgba(251, 191, 36, 0.55);
+  color: #facc15;
 }
 
 


### PR DESCRIPTION
## Summary
- introduce a centralized tag configuration for exposition cards with modifier classes and icons
- render translated tag labels with dedicated modifier classnames and inline icons
- style the new tag modifiers for light and dark themes, tuning chip spacing for iconography

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da7d16536c8326aa325542aefd9c9e