### PR TITLE
Use brand logo asset in header

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import Head from 'next/head';
+import Image from 'next/image';
 import { useFavorites } from './FavoritesContext';
 import { useLanguage } from './LanguageContext';
 import Footer from './Footer';
@@ -26,13 +27,20 @@ export default function Layout({ children }) {
       <header className="header">
         <nav className="navbar container" aria-label={navLabel}>
           <Link href="/" className="header-brand" aria-label={t('homeLabel')}>
-            <span className="brand-square">
-              <span className="brand-letter">MB</span>
-            </span>
-            <span className="brand-lockup">
-              <span className="brand-title">MuseumBuddy</span>
-              <span className="brand-tagline">{t('heroTagline')}</span>
-            </span>
+            <div className="brand-identity">
+              <Image
+                className="brand-logo"
+                src="/brand/MuseumBuddy Logo Design 2.png"
+                alt="MuseumBuddy logo with stylized columns"
+                priority
+                width={132}
+                height={44}
+              />
+              <div className="brand-lockup">
+                <span className="brand-title">MuseumBuddy</span>
+                <span className="brand-tagline">{t('heroTagline')}</span>
+              </div>
+            </div>
           </Link>
           <div className="header-links">
             <Link href="/about" className="header-link">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -396,25 +396,23 @@ img { max-width: 100%; height: auto; display: block; }
 .header-brand {
   display: inline-flex;
   align-items: center;
-  gap: 14px;
-  padding: 10px 14px;
+  gap: 16px;
+  padding: 8px 18px;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--surface) 92%, transparent);
-  border: 1px solid color-mix(in srgb, var(--panel-border) 85%, transparent);
+  background: color-mix(in srgb, var(--surface) 96%, transparent);
+  border: 1px solid color-mix(in srgb, var(--panel-border) 80%, transparent);
   box-shadow: var(--panel-shadow);
   color: var(--text);
   text-decoration: none;
-  transition: background-color 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease,
-    transform 0.25s ease;
+  transition: background-color 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
 }
 
 .header-brand:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.12);
+  box-shadow: var(--panel-shadow);
 }
 
 [data-theme='dark'] .header-brand:hover {
-  box-shadow: 0 16px 28px rgba(2, 6, 23, 0.52);
+  box-shadow: var(--panel-shadow);
 }
 
 .header-brand:focus-visible {
@@ -422,28 +420,21 @@ img { max-width: 100%; height: auto; display: block; }
   outline-offset: 4px;
 }
 
-.brand-square {
+.brand-identity {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 44px;
+  gap: 14px;
+}
+
+.brand-logo {
+  display: block;
   height: 44px;
-  border-radius: 16px;
-  background: var(--text);
-  color: var(--bg);
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-size: 0.95rem;
+  width: auto;
+  object-fit: contain;
 }
 
-[data-theme='dark'] .brand-square {
-  background: rgba(226, 232, 240, 0.14);
-  color: var(--text);
-}
-
-.brand-letter {
-  line-height: 1;
+[data-theme='dark'] .brand-logo {
+  filter: brightness(1.08) contrast(1.05);
 }
 
 .brand-lockup {


### PR DESCRIPTION
## Summary
- replace the header brand monogram with the branded image asset via the Next.js Image component
- reorganize the brand lockup markup and refresh the styling to accommodate the logo and subtler hover states

## Testing
- not run (npm install failed with 403 fetching @capacitor/app)


------
https://chatgpt.com/codex/tasks/task_e_68da949585948326803854bda39a01a1