### PR TITLE
Replace header logo with new artwork

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -29,7 +29,7 @@ export default function Layout({ children }) {
           <Link href="/" className="header-brand" aria-label={t('homeLabel')}>
             <Image
               src="/images/museum-buddy-header.svg"
-              alt="Museum Buddy"
+              alt="Museum Buddy logo"
               width={320}
               height={120}
               priority

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Image from 'next/image';
 import Head from 'next/head';
 import { useFavorites } from './FavoritesContext';
 import { useLanguage } from './LanguageContext';
@@ -26,13 +27,15 @@ export default function Layout({ children }) {
       <header className="header">
         <nav className="navbar container" aria-label={navLabel}>
           <Link href="/" className="header-brand" aria-label={t('homeLabel')}>
-            <span className="brand-square">
-              <span className="brand-letter">MB</span>
-            </span>
-            <span className="brand-lockup">
-              <span className="brand-title">MuseumBuddy</span>
-              <span className="brand-tagline">{t('heroTagline')}</span>
-            </span>
+            <Image
+              src="/images/museum-buddy-header.svg"
+              alt="Museum Buddy"
+              width={320}
+              height={120}
+              priority
+              className="header-brand-image"
+              sizes="(max-width: 680px) 180px, 260px"
+            />
           </Link>
           <div className="header-links">
             <Link href="/about" className="header-link">

--- a/public/images/museum-buddy-header.svg
+++ b/public/images/museum-buddy-header.svg
@@ -1,34 +1,40 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="960" height="400" viewBox="0 0 960 400" role="img" aria-labelledby="title desc">
   <title id="title">Museum Buddy logo</title>
-  <desc id="desc">Stylised Museum Buddy logo on a soft grey gradient background.</desc>
+  <desc id="desc">Museum Buddy logotype in deep blue on a soft grey gradient background.</desc>
   <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#f1f3f8" />
-      <stop offset="35%" stop-color="#d9dce3" />
-      <stop offset="100%" stop-color="#7d838f" />
-    </linearGradient>
-    <radialGradient id="halo" cx="50%" cy="50%" r="55%">
-      <stop offset="0%" stop-color="#1f2d58" stop-opacity="0.35" />
-      <stop offset="60%" stop-color="#1f2d58" stop-opacity="0.15" />
-      <stop offset="100%" stop-color="#1f2d58" stop-opacity="0" />
+    <radialGradient id="bgGradient" cx="50%" cy="45%" r="65%">
+      <stop offset="0%" stop-color="#d5d6d8" />
+      <stop offset="55%" stop-color="#9ea0a3" />
+      <stop offset="100%" stop-color="#595a5c" />
     </radialGradient>
-    <linearGradient id="accent" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#1b3483" />
-      <stop offset="100%" stop-color="#0d1d52" />
+    <radialGradient id="glowGradient" cx="45%" cy="50%" r="55%">
+      <stop offset="0%" stop-color="#102957" stop-opacity="0.35" />
+      <stop offset="60%" stop-color="#102957" stop-opacity="0.12" />
+      <stop offset="100%" stop-color="#102957" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="pillarGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#1d3b7f" />
+      <stop offset="100%" stop-color="#0e214f" />
     </linearGradient>
-    <filter id="soften" x="-30%" y="-30%" width="160%" height="160%">
-      <feGaussianBlur stdDeviation="20" result="blur" />
+    <filter id="softGlow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="18" result="blur" />
+      <feBlend in="SourceGraphic" in2="blur" mode="screen" />
     </filter>
   </defs>
-  <rect width="960" height="400" fill="url(#bg)" />
-  <rect width="760" height="300" x="100" y="50" fill="url(#halo)" filter="url(#soften)" />
-  <g transform="translate(320 120)">
-    <rect x="-160" y="0" width="36" height="160" rx="6" fill="url(#accent)" opacity="0.9" />
-    <rect x="-110" y="0" width="36" height="160" rx="6" fill="url(#accent)" opacity="0.9" />
-    <rect x="-60" y="0" width="36" height="160" rx="6" fill="url(#accent)" opacity="0.9" />
-    <text x="0" y="118" fill="#132657" font-family="'Inter', 'Segoe UI', sans-serif" font-size="82" font-weight="600" letter-spacing="0.01em">
-      <tspan x="0" dy="-20">Museum</tspan>
-      <tspan x="0" dy="86">Buddy</tspan>
+  <rect width="960" height="400" fill="url(#bgGradient)" />
+  <ellipse cx="480" cy="210" rx="360" ry="180" fill="url(#glowGradient)" />
+  <g transform="translate(340 120)">
+    <g filter="url(#softGlow)" opacity="0.7">
+      <rect x="-180" y="20" width="38" height="164" rx="10" fill="#102957" />
+      <rect x="-126" y="20" width="38" height="164" rx="10" fill="#102957" />
+      <rect x="-72" y="20" width="38" height="164" rx="10" fill="#102957" />
+    </g>
+    <rect x="-180" y="20" width="38" height="164" rx="10" fill="url(#pillarGradient)" />
+    <rect x="-126" y="20" width="38" height="164" rx="10" fill="url(#pillarGradient)" />
+    <rect x="-72" y="20" width="38" height="164" rx="10" fill="url(#pillarGradient)" />
+    <text x="0" y="156" fill="#0c1f4a" font-family="'Inter', 'Segoe UI', sans-serif" font-size="96" font-weight="600" letter-spacing="0.01em">
+      <tspan x="0" dy="-50">Museum</tspan>
+      <tspan x="0" dy="102">Buddy</tspan>
     </text>
   </g>
 </svg>

--- a/public/images/museum-buddy-header.svg
+++ b/public/images/museum-buddy-header.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="400" viewBox="0 0 960 400" role="img" aria-labelledby="title desc">
+  <title id="title">Museum Buddy logo</title>
+  <desc id="desc">Stylised Museum Buddy logo on a soft grey gradient background.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f1f3f8" />
+      <stop offset="35%" stop-color="#d9dce3" />
+      <stop offset="100%" stop-color="#7d838f" />
+    </linearGradient>
+    <radialGradient id="halo" cx="50%" cy="50%" r="55%">
+      <stop offset="0%" stop-color="#1f2d58" stop-opacity="0.35" />
+      <stop offset="60%" stop-color="#1f2d58" stop-opacity="0.15" />
+      <stop offset="100%" stop-color="#1f2d58" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#1b3483" />
+      <stop offset="100%" stop-color="#0d1d52" />
+    </linearGradient>
+    <filter id="soften" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="20" result="blur" />
+    </filter>
+  </defs>
+  <rect width="960" height="400" fill="url(#bg)" />
+  <rect width="760" height="300" x="100" y="50" fill="url(#halo)" filter="url(#soften)" />
+  <g transform="translate(320 120)">
+    <rect x="-160" y="0" width="36" height="160" rx="6" fill="url(#accent)" opacity="0.9" />
+    <rect x="-110" y="0" width="36" height="160" rx="6" fill="url(#accent)" opacity="0.9" />
+    <rect x="-60" y="0" width="36" height="160" rx="6" fill="url(#accent)" opacity="0.9" />
+    <text x="0" y="118" fill="#132657" font-family="'Inter', 'Segoe UI', sans-serif" font-size="82" font-weight="600" letter-spacing="0.01em">
+      <tspan x="0" dy="-20">Museum</tspan>
+      <tspan x="0" dy="86">Buddy</tspan>
+    </text>
+  </g>
+</svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -396,25 +396,15 @@ img { max-width: 100%; height: auto; display: block; }
 .header-brand {
   display: inline-flex;
   align-items: center;
-  gap: 14px;
-  padding: 10px 14px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--surface) 92%, transparent);
-  border: 1px solid color-mix(in srgb, var(--panel-border) 85%, transparent);
-  box-shadow: var(--panel-shadow);
-  color: var(--text);
-  text-decoration: none;
-  transition: background-color 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease,
-    transform 0.25s ease;
+  padding: 0;
+  border-radius: 20px;
+  overflow: hidden;
+  line-height: 0;
+  transition: transform 0.25s ease;
 }
 
 .header-brand:hover {
   transform: translateY(-1px);
-  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.12);
-}
-
-[data-theme='dark'] .header-brand:hover {
-  box-shadow: 0 16px 28px rgba(2, 6, 23, 0.52);
 }
 
 .header-brand:focus-visible {
@@ -422,60 +412,10 @@ img { max-width: 100%; height: auto; display: block; }
   outline-offset: 4px;
 }
 
-.brand-square {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 44px;
-  height: 44px;
-  border-radius: 16px;
-  background: var(--text);
-  color: var(--bg);
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-size: 0.95rem;
-}
-
-[data-theme='dark'] .brand-square {
-  background: rgba(226, 232, 240, 0.14);
-  color: var(--text);
-}
-
-.brand-letter {
-  line-height: 1;
-}
-
-.brand-lockup {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.brand-title {
-  font-weight: 700;
-  font-size: 1.2rem;
-  letter-spacing: -0.02em;
-  color: var(--text);
-}
-
-.brand-tagline {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 2px 10px;
-  border-radius: 999px;
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.24em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--muted) 88%, var(--text) 12%);
-  background: color-mix(in srgb, var(--surface) 78%, transparent);
-}
-
-[data-theme='dark'] .brand-tagline {
-  background: rgba(148, 163, 184, 0.12);
-  color: color-mix(in srgb, var(--muted) 92%, #ffffff 8%);
+.header-brand-image {
+  display: block;
+  width: clamp(200px, 26vw, 320px);
+  height: auto;
 }
 
 .header-links {
@@ -664,27 +604,12 @@ button.header-link {
   }
 
   .header-brand {
-    width: auto;
-    padding: 0;
-    gap: 10px;
-    background: none;
-    border: none;
-    box-shadow: none;
+    width: 100%;
+    max-width: 220px;
   }
 
-  .brand-square {
-    width: 36px;
-    height: 36px;
-    border-radius: 12px;
-    font-size: 0.85rem;
-  }
-
-  .brand-title {
-    font-size: 1rem;
-  }
-
-  .brand-tagline {
-    display: none;
+  .header-brand-image {
+    width: 100%;
   }
 
   .header-links {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -397,8 +397,6 @@ img { max-width: 100%; height: auto; display: block; }
   display: inline-flex;
   align-items: center;
   padding: 0;
-  border-radius: 20px;
-  overflow: hidden;
   line-height: 0;
   transition: transform 0.25s ease;
 }
@@ -414,8 +412,10 @@ img { max-width: 100%; height: auto; display: block; }
 
 .header-brand-image {
   display: block;
-  width: clamp(200px, 26vw, 320px);
+  width: clamp(220px, 28vw, 340px);
   height: auto;
+  border-radius: 18px;
+  box-shadow: 0 24px 48px rgba(9, 15, 38, 0.18);
 }
 
 .header-links {


### PR DESCRIPTION
## Summary
- replace the header brand lockup with the provided Museum Buddy artwork
- update header styling to accommodate the new image asset
- add the new Museum Buddy logo artwork to the public image assets

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da960c46e483268364180f9448f2dc