### PR TITLE
Adjust header brand to text-only layout

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -26,12 +26,9 @@ export default function Layout({ children }) {
       <header className="header">
         <nav className="navbar container" aria-label={navLabel}>
           <Link href="/" className="header-brand" aria-label={t('homeLabel')}>
-            <span className="brand-square">
-              <span className="brand-letter">MB</span>
-            </span>
             <span className="brand-lockup">
-              <span className="brand-title">MuseumBuddy</span>
-              <span className="brand-tagline">{t('heroTagline')}</span>
+              <span className="brand-title-line">Museum</span>
+              <span className="brand-title-line">Buddy</span>
             </span>
           </Link>
           <div className="header-links">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -275,6 +275,30 @@ img { max-width: 100%; height: auto; display: block; }
   gap: 16px;
 }
 
+.footer .brand-square {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 16px;
+  background: var(--text);
+  color: var(--bg);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+}
+
+[data-theme='dark'] .footer .brand-square {
+  background: rgba(226, 232, 240, 0.14);
+  color: var(--text);
+}
+
+.footer .brand-letter {
+  line-height: 1;
+}
+
 .footer-logo {
   box-shadow: none;
 }
@@ -395,26 +419,20 @@ img { max-width: 100%; height: auto; display: block; }
 /* Header brand */
 .header-brand {
   display: inline-flex;
-  align-items: center;
-  gap: 14px;
-  padding: 10px 14px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--surface) 92%, transparent);
-  border: 1px solid color-mix(in srgb, var(--panel-border) 85%, transparent);
-  box-shadow: var(--panel-shadow);
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 0;
+  border: none;
+  background: none;
+  box-shadow: none;
   color: var(--text);
   text-decoration: none;
-  transition: background-color 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease,
-    transform 0.25s ease;
 }
 
-.header-brand:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.12);
-}
-
-[data-theme='dark'] .header-brand:hover {
-  box-shadow: 0 16px 28px rgba(2, 6, 23, 0.52);
+.header-brand:hover,
+.header-brand:focus-visible {
+  color: var(--text);
 }
 
 .header-brand:focus-visible {
@@ -422,60 +440,19 @@ img { max-width: 100%; height: auto; display: block; }
   outline-offset: 4px;
 }
 
-.brand-square {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 44px;
-  height: 44px;
-  border-radius: 16px;
-  background: var(--text);
-  color: var(--bg);
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-size: 0.95rem;
-}
-
-[data-theme='dark'] .brand-square {
-  background: rgba(226, 232, 240, 0.14);
-  color: var(--text);
-}
-
-.brand-letter {
-  line-height: 1;
-}
-
 .brand-lockup {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  align-items: flex-start;
+  gap: 0;
 }
 
-.brand-title {
+.brand-title-line {
   font-weight: 700;
-  font-size: 1.2rem;
+  font-size: 1.35rem;
   letter-spacing: -0.02em;
+  line-height: 1.05;
   color: var(--text);
-}
-
-.brand-tagline {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 2px 10px;
-  border-radius: 999px;
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.24em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--muted) 88%, var(--text) 12%);
-  background: color-mix(in srgb, var(--surface) 78%, transparent);
-}
-
-[data-theme='dark'] .brand-tagline {
-  background: rgba(148, 163, 184, 0.12);
-  color: color-mix(in srgb, var(--muted) 92%, #ffffff 8%);
 }
 
 .header-links {
@@ -666,25 +643,10 @@ button.header-link {
   .header-brand {
     width: auto;
     padding: 0;
-    gap: 10px;
-    background: none;
-    border: none;
-    box-shadow: none;
   }
 
-  .brand-square {
-    width: 36px;
-    height: 36px;
-    border-radius: 12px;
-    font-size: 0.85rem;
-  }
-
-  .brand-title {
-    font-size: 1rem;
-  }
-
-  .brand-tagline {
-    display: none;
+  .brand-title-line {
+    font-size: 1.15rem;
   }
 
   .header-links {


### PR DESCRIPTION
## Summary
- replace the header brand lockup with a stacked "Museum" and "Buddy" text treatment
- simplify header brand styling to remove the logo border while keeping footer branding intact

## Testing
- npm run dev *(fails: Next.js binary not installed in environment)*
- npm install *(fails: registry responded with 403 for @capacitor/app)*

------
https://chatgpt.com/codex/tasks/task_e_68da9a119cd48326a95998e305ee582a