### PR TITLE
Reduce spacing in museum detail hero

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1300,9 +1300,9 @@ button.hero-quick-link {
 
 .museum-detail { position: relative; background: var(--body-bg); padding-bottom: 64px; }
 .museum-detail-container { position: relative; z-index: 2; }
-.museum-hero-heading-container { position: relative; z-index: 5; margin-bottom: clamp(16px, 4vw, 32px); }
-.museum-hero-heading { display: flex; flex-direction: column; align-items: stretch; gap: clamp(16px, 3vw, 24px); }
-.museum-hero-layout { display: flex; flex-direction: column; gap: clamp(16px, 3vw, 24px); width: 100%; }
+.museum-hero-heading-container { position: relative; z-index: 5; margin-bottom: clamp(12px, 3vw, 24px); }
+.museum-hero-heading { display: flex; flex-direction: column; align-items: stretch; gap: clamp(12px, 2.5vw, 20px); }
+.museum-hero-layout { display: flex; flex-direction: column; gap: clamp(12px, 2.5vw, 20px); width: 100%; }
 .museum-hero-media { display: flex; flex-direction: column; gap: 12px; }
 .museum-hero-media-inner {
   position: relative;
@@ -1346,8 +1346,8 @@ button.hero-quick-link {
 .museum-hero-location { margin: 0; font-size: 12px; letter-spacing: 0.16em; text-transform: uppercase; font-weight: 600; color: var(--muted); }
 .museum-hero-title { margin: 0; font-size: clamp(34px, 4.5vw, 48px); font-weight: 800; letter-spacing: -0.02em; line-height: 1.05; }
 .museum-hero-tagline { margin: 0; color: var(--muted); font-size: 16px; line-height: 1.5; }
-.museum-hero-sidebar { display: flex; flex-direction: column; gap: clamp(12px, 2.5vw, var(--space-16)); }
-.museum-visitor-card { display: flex; flex-direction: column; gap: var(--space-24); }
+.museum-hero-sidebar { display: flex; flex-direction: column; gap: clamp(10px, 2vw, 18px); }
+.museum-visitor-card { display: flex; flex-direction: column; gap: clamp(12px, 2vw, var(--space-16)); }
 .museum-visitor-card--hero { height: 100%; }
 .museum-visitor-actions {
   display: flex;
@@ -1594,7 +1594,7 @@ button.hero-quick-link {
 .museum-mobile-actions {
   display: none;
 }
-.museum-detail-grid { display: grid; gap: 32px; grid-template-columns: minmax(0, 1fr); align-items: start; }
+.museum-detail-grid { display: grid; gap: 24px; grid-template-columns: minmax(0, 1fr); align-items: start; }
 .museum-detail-main {
   display: flex;
   flex-direction: column;
@@ -1849,7 +1849,7 @@ button.hero-quick-link {
     display: grid;
     grid-template-columns: minmax(0, 5fr) minmax(320px, 3fr);
     align-items: stretch;
-    gap: clamp(24px, 4vw, 40px);
+    gap: clamp(16px, 2.5vw, 28px);
   }
   .museum-hero-sidebar {
     height: 100%;
@@ -2077,7 +2077,7 @@ button.hero-quick-link {
 
 @media (max-width: 600px) {
   .museum-detail { padding-bottom: calc(196px + env(safe-area-inset-bottom, 0px)); }
-  .museum-hero-layout { gap: var(--space-24); }
+  .museum-hero-layout { gap: clamp(12px, 4vw, var(--space-16)); }
   .museum-hero-media-inner { min-height: clamp(200px, 72vw, 300px); }
   .museum-detail-grid { gap: 24px; }
   .museum-expositions-card,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1300,9 +1300,9 @@ button.hero-quick-link {
 
 .museum-detail { position: relative; background: var(--body-bg); padding-bottom: 64px; }
 .museum-detail-container { position: relative; z-index: 2; }
-.museum-hero-heading-container { position: relative; z-index: 5; margin-bottom: clamp(24px, 5vw, 48px); }
-.museum-hero-heading { display: flex; flex-direction: column; align-items: stretch; gap: clamp(20px, 4vw, 32px); }
-.museum-hero-layout { display: flex; flex-direction: column; gap: clamp(20px, 4vw, 32px); width: 100%; }
+.museum-hero-heading-container { position: relative; z-index: 5; margin-bottom: clamp(16px, 4vw, 32px); }
+.museum-hero-heading { display: flex; flex-direction: column; align-items: stretch; gap: clamp(16px, 3vw, 24px); }
+.museum-hero-layout { display: flex; flex-direction: column; gap: clamp(16px, 3vw, 24px); width: 100%; }
 .museum-hero-media { display: flex; flex-direction: column; gap: 12px; }
 .museum-hero-media-inner {
   position: relative;
@@ -1346,7 +1346,7 @@ button.hero-quick-link {
 .museum-hero-location { margin: 0; font-size: 12px; letter-spacing: 0.16em; text-transform: uppercase; font-weight: 600; color: var(--muted); }
 .museum-hero-title { margin: 0; font-size: clamp(34px, 4.5vw, 48px); font-weight: 800; letter-spacing: -0.02em; line-height: 1.05; }
 .museum-hero-tagline { margin: 0; color: var(--muted); font-size: 16px; line-height: 1.5; }
-.museum-hero-sidebar { display: flex; flex-direction: column; gap: var(--space-16); }
+.museum-hero-sidebar { display: flex; flex-direction: column; gap: clamp(12px, 2.5vw, var(--space-16)); }
 .museum-visitor-card { display: flex; flex-direction: column; gap: var(--space-24); }
 .museum-visitor-card--hero { height: 100%; }
 .museum-visitor-actions {


### PR DESCRIPTION
## Summary
- decrease vertical gaps around the hero section on museum detail pages
- tighten spacing inside the visitor information sidebar so content sits closer together

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da9d2ae0a88326aff2d436ffea1ef8