### PR TITLE
Update exhibition placeholder image

### DIFF
--- a/public/images/exposition-placeholder.svg
+++ b/public/images/exposition-placeholder.svg
@@ -1,32 +1,12 @@
 <svg width="1024" height="1024" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
   <title id="title">Tentoonstelling tijdelijke afbeelding</title>
-  <desc id="desc">Diepblauwe abstracte compositie als tijdelijke afbeelding voor een tentoonstelling.</desc>
+  <desc id="desc">Donkerblauwe kleurverloopachtergrond als tijdelijke afbeelding voor een tentoonstelling.</desc>
   <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#13263b" />
-      <stop offset="100%" stop-color="#1f3550" />
-    </linearGradient>
-    <radialGradient id="highlight" cx="78%" cy="22%" r="48%">
-      <stop offset="0%" stop-color="rgba(255, 255, 255, 0.22)" />
-      <stop offset="100%" stop-color="rgba(255, 255, 255, 0)" />
-    </radialGradient>
-    <linearGradient id="curve" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#233f63" stop-opacity="0.65" />
-      <stop offset="100%" stop-color="#1a2f47" stop-opacity="0.1" />
-    </linearGradient>
-    <linearGradient id="bars" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#1d3857" stop-opacity="0.85" />
-      <stop offset="100%" stop-color="#112439" stop-opacity="0.2" />
+    <linearGradient id="background" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#2f3f53" />
+      <stop offset="45%" stop-color="#253549" />
+      <stop offset="100%" stop-color="#111c2a" />
     </linearGradient>
   </defs>
-  <rect width="1024" height="1024" fill="url(#bg)" rx="48" />
-  <rect x="96" y="180" width="96" height="664" rx="48" fill="url(#bars)" opacity="0.6" />
-  <rect x="204" y="220" width="88" height="560" rx="44" fill="url(#bars)" opacity="0.45" />
-  <rect x="312" y="260" width="80" height="456" rx="40" fill="url(#bars)" opacity="0.35" />
-  <circle cx="784" cy="248" r="164" fill="url(#highlight)" />
-  <path d="M64 736c168-120 300-176 432-176s264 64 464 240v160H64V736Z" fill="url(#curve)" />
-  <circle cx="768" cy="720" r="104" fill="rgba(35, 63, 99, 0.55)" />
-  <circle cx="720" cy="676" r="32" fill="rgba(255, 255, 255, 0.08)" />
-  <circle cx="840" cy="760" r="28" fill="rgba(255, 255, 255, 0.1)" />
-  <path d="M576 320c64 32 120 76 152 128s40 112 12 176c-56 120-216 160-320 128 96-64 168-140 212-232 28-60 36-120 36-200Z" fill="rgba(15, 24, 38, 0.4)" />
+  <rect width="1024" height="1024" fill="url(#background)" rx="64" />
 </svg>


### PR DESCRIPTION
## Summary
- replace the exhibition placeholder artwork with the supplied dark blue gradient
- update the description text to reflect the new minimalist background

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbb057c7bc8326b656f94f66b97b69