### PR TITLE
Add dede monogram to exhibition placeholder

### DIFF
--- a/public/images/exposition-placeholder.svg
+++ b/public/images/exposition-placeholder.svg
@@ -1,32 +1,22 @@
 <svg width="1024" height="1024" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
   <title id="title">Tentoonstelling tijdelijke afbeelding</title>
-  <desc id="desc">Diepblauwe abstracte compositie als tijdelijke afbeelding voor een tentoonstelling.</desc>
+  <desc id="desc">Donkerblauwe kleurverloopachtergrond met subtiel kader en monogram "dede" als tijdelijke afbeelding voor een tentoonstelling.</desc>
   <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#13263b" />
-      <stop offset="100%" stop-color="#1f3550" />
+    <linearGradient id="background" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#3c4a5a" />
+      <stop offset="45%" stop-color="#2c3644" />
+      <stop offset="100%" stop-color="#1c2430" />
     </linearGradient>
-    <radialGradient id="highlight" cx="78%" cy="22%" r="48%">
-      <stop offset="0%" stop-color="rgba(255, 255, 255, 0.22)" />
-      <stop offset="100%" stop-color="rgba(255, 255, 255, 0)" />
-    </radialGradient>
-    <linearGradient id="curve" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#233f63" stop-opacity="0.65" />
-      <stop offset="100%" stop-color="#1a2f47" stop-opacity="0.1" />
-    </linearGradient>
-    <linearGradient id="bars" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#1d3857" stop-opacity="0.85" />
-      <stop offset="100%" stop-color="#112439" stop-opacity="0.2" />
+    <linearGradient id="gloss" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.1" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
     </linearGradient>
   </defs>
-  <rect width="1024" height="1024" fill="url(#bg)" rx="48" />
-  <rect x="96" y="180" width="96" height="664" rx="48" fill="url(#bars)" opacity="0.6" />
-  <rect x="204" y="220" width="88" height="560" rx="44" fill="url(#bars)" opacity="0.45" />
-  <rect x="312" y="260" width="80" height="456" rx="40" fill="url(#bars)" opacity="0.35" />
-  <circle cx="784" cy="248" r="164" fill="url(#highlight)" />
-  <path d="M64 736c168-120 300-176 432-176s264 64 464 240v160H64V736Z" fill="url(#curve)" />
-  <circle cx="768" cy="720" r="104" fill="rgba(35, 63, 99, 0.55)" />
-  <circle cx="720" cy="676" r="32" fill="rgba(255, 255, 255, 0.08)" />
-  <circle cx="840" cy="760" r="28" fill="rgba(255, 255, 255, 0.1)" />
-  <path d="M576 320c64 32 120 76 152 128s40 112 12 176c-56 120-216 160-320 128 96-64 168-140 212-232 28-60 36-120 36-200Z" fill="rgba(15, 24, 38, 0.4)" />
+  <rect width="1024" height="1024" fill="url(#background)" rx="64" />
+  <rect x="32" y="32" width="960" height="960" rx="56" fill="none" stroke="#253142" stroke-width="4" />
+  <rect x="32" y="32" width="960" height="960" rx="56" fill="url(#gloss)" opacity="0.2" />
+  <g fill="#f2f6fb" transform="translate(512 512)">
+    <path d="M-116 -20c0 -64 52 -116 116 -116s116 52 116 116-52 116-116 116-116-52-116-116zm24 0c0 51 41 92 92 92s92-41 92-92-41-92-92-92-92 41-92 92z" opacity="0.35" />
+    <text x="0" y="24" font-family="'DM Sans', 'Segoe UI', sans-serif" font-size="120" font-weight="600" text-anchor="middle" letter-spacing="0.08em">DEDE</text>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- refresh the exhibition placeholder gradient to match the supplied artwork tones
- add a subtle border, highlight, and centered "DEDE" monogram to reflect the requested addition

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbb057c7bc8326b656f94f66b97b69