### PR TITLE
Add randomised placeholder artwork for exposition cards

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -28,6 +28,35 @@ function pickBoolean(...values) {
   return undefined;
 }
 
+const PLACEHOLDER_IMAGES = [
+  '/images/exposition-art-bridge.svg',
+  '/images/exposition-art-arch.svg',
+  '/images/exposition-art-houses.svg',
+  '/images/exposition-art-windmill.svg',
+  '/images/exposition-art-grid.svg',
+];
+
+function getPlaceholderImage(exposition) {
+  if (!exposition) {
+    return PLACEHOLDER_IMAGES[0];
+  }
+
+  const keyParts = [exposition.id, exposition.museumSlug, exposition.titel].filter(Boolean);
+  if (keyParts.length === 0) {
+    return PLACEHOLDER_IMAGES[0];
+  }
+
+  const key = keyParts.join('|');
+  let hash = 0;
+  for (let i = 0; i < key.length; i += 1) {
+    hash = (hash << 5) - hash + key.charCodeAt(i);
+    hash |= 0;
+  }
+
+  const index = Math.abs(hash) % PLACEHOLDER_IMAGES.length;
+  return PLACEHOLDER_IMAGES[index];
+}
+
 export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, museumSlug, tags = {} }) {
   if (!exposition) return null;
 
@@ -122,6 +151,7 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
   ];
   const activeTags = tagDefinitions.filter((tag) => tag.active);
   const mediaClassName = 'exposition-card__media exposition-card__media--placeholder';
+  const placeholderImage = useMemo(() => getPlaceholderImage(exposition), [exposition]);
 
   return (
     <article
@@ -129,7 +159,7 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
     >
       <div className={mediaClassName} aria-hidden="true">
         <img
-          src="/images/exposition-placeholder.svg"
+          src={placeholderImage}
           alt=""
           className="exposition-card__media-placeholder"
           loading="lazy"

--- a/public/images/exposition-art-arch.svg
+++ b/public/images/exposition-art-arch.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" role="img" aria-hidden="true">
+  <rect width="400" height="400" fill="#f1e4c4" />
+  <rect x="0" y="0" width="200" height="200" fill="#2f5b73" />
+  <rect x="200" y="0" width="200" height="120" fill="#87a2aa" />
+  <rect x="0" y="200" width="150" height="200" fill="#597b8d" />
+  <rect x="150" y="200" width="150" height="200" fill="#d6c49b" />
+  <rect x="300" y="200" width="100" height="200" fill="#2f5b73" />
+  <rect x="200" y="120" width="200" height="80" fill="#d6c49b" />
+  <rect x="240" y="40" width="90" height="80" fill="#f1e4c4" />
+  <path d="M220 200 A70 70 0 0 1 360 200 V360 H220 Z" fill="#caa76b" />
+  <rect x="40" y="40" width="80" height="80" fill="#87a2aa" />
+</svg>

--- a/public/images/exposition-art-bridge.svg
+++ b/public/images/exposition-art-bridge.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" role="img" aria-hidden="true">
+  <rect width="400" height="400" fill="#f1e4c4" />
+  <rect x="0" y="0" width="140" height="130" fill="#2f5b73" />
+  <rect x="140" y="0" width="140" height="130" fill="#bfa97b" />
+  <rect x="280" y="0" width="120" height="130" fill="#597b8d" />
+  <rect x="0" y="130" width="190" height="120" fill="#d6c49b" />
+  <rect x="190" y="130" width="210" height="120" fill="#87a2aa" />
+  <rect x="0" y="250" width="400" height="150" fill="#486c7e" />
+  <path d="M0 250 Q200 170 400 250 V400 H0 Z" fill="#f1e4c4" />
+  <rect x="40" y="60" width="60" height="60" fill="#d6c49b" />
+  <rect x="240" y="60" width="60" height="60" fill="#486c7e" />
+</svg>

--- a/public/images/exposition-art-grid.svg
+++ b/public/images/exposition-art-grid.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" role="img" aria-hidden="true">
+  <rect width="400" height="400" fill="#f1e4c4" />
+  <rect x="0" y="0" width="120" height="160" fill="#d6c49b" />
+  <rect x="120" y="0" width="140" height="160" fill="#597b8d" />
+  <rect x="260" y="0" width="140" height="160" fill="#87a2aa" />
+  <rect x="0" y="160" width="200" height="120" fill="#87a2aa" />
+  <rect x="200" y="160" width="200" height="120" fill="#2f5b73" />
+  <rect x="0" y="280" width="160" height="120" fill="#597b8d" />
+  <rect x="160" y="280" width="120" height="120" fill="#f1e4c4" />
+  <rect x="280" y="280" width="120" height="120" fill="#caa76b" />
+  <rect x="230" y="110" width="70" height="70" fill="#caa76b" />
+  <rect x="310" y="200" width="70" height="70" fill="#d95f2a" />
+</svg>

--- a/public/images/exposition-art-houses.svg
+++ b/public/images/exposition-art-houses.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" role="img" aria-hidden="true">
+  <rect width="400" height="400" fill="#f1e4c4" />
+  <rect x="0" y="220" width="400" height="180" fill="#87a2aa" />
+  <g fill="#2f5b73">
+    <rect x="40" y="100" width="80" height="200" />
+    <polygon points="40,100 80,60 120,100" />
+  </g>
+  <g fill="#597b8d">
+    <rect x="140" y="90" width="80" height="210" />
+    <polygon points="140,90 180,40 220,90" />
+  </g>
+  <g fill="#caa76b">
+    <rect x="240" y="110" width="90" height="190" />
+    <polygon points="240,110 240,80 300,80 330,110" />
+  </g>
+  <g fill="#f1e4c4">
+    <rect x="60" y="150" width="30" height="60" />
+    <rect x="160" y="150" width="30" height="60" />
+    <rect x="260" y="160" width="30" height="60" />
+    <rect x="200" y="160" width="30" height="60" />
+  </g>
+  <g fill="#2f5b73">
+    <rect x="60" y="240" width="30" height="50" />
+    <rect x="160" y="240" width="30" height="50" />
+    <rect x="200" y="240" width="30" height="50" />
+    <rect x="260" y="240" width="30" height="50" />
+  </g>
+  <rect x="0" y="300" width="400" height="40" fill="#597b8d" opacity="0.35" />
+</svg>

--- a/public/images/exposition-art-windmill.svg
+++ b/public/images/exposition-art-windmill.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" role="img" aria-hidden="true">
+  <rect width="400" height="400" fill="#f1e4c4" />
+  <rect x="0" y="0" width="200" height="200" fill="#f1e4c4" />
+  <rect x="200" y="0" width="200" height="200" fill="#87a2aa" />
+  <rect x="0" y="200" width="260" height="200" fill="#d6c49b" />
+  <rect x="260" y="200" width="140" height="200" fill="#597b8d" />
+  <rect x="30" y="40" width="120" height="120" fill="#87a2aa" />
+  <rect x="260" y="60" width="70" height="70" fill="#f1e4c4" />
+  <g fill="#2f5b73">
+    <rect x="220" y="180" width="80" height="140" />
+    <polygon points="260,120 220,180 300,180" />
+    <polygon points="260,120 200,140 220,200" />
+    <polygon points="260,120 320,140 300,200" />
+    <polygon points="260,120 240,60 280,60" />
+  </g>
+  <g>
+    <rect x="40" y="260" width="40" height="80" fill="#d95f2a" />
+    <rect x="110" y="260" width="40" height="80" fill="#597b8d" />
+    <rect x="330" y="260" width="40" height="80" fill="#d95f2a" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- replace the static exposition placeholder with a selection of themed artwork
- derive a deterministic pseudo-random image per exposition to keep cards varied
- add new SVG assets that match the provided illustration styles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc201789588326bd6a89a3060fb8e8