### PR TITLE
Update About page content

### DIFF
--- a/components/LanguageContext.js
+++ b/components/LanguageContext.js
@@ -29,8 +29,21 @@ export function LanguageProvider({ children }) {
   };
 
   const t = (key, vars = {}) => {
-    const str = translations[lang][key] || key;
-    return str.replace(/\{(\w+)\}/g, (_, v) => vars[v] ?? '');
+    const value = translations[lang]?.[key];
+
+    if (typeof value === 'string') {
+      return value.replace(/\{(\w+)\}/g, (_, v) => vars[v] ?? '');
+    }
+
+    if (Array.isArray(value)) {
+      return value.map((item) =>
+        typeof item === 'string'
+          ? item.replace(/\{(\w+)\}/g, (_, v) => vars[v] ?? '')
+          : item
+      );
+    }
+
+    return value ?? key;
   };
 
   return (

--- a/lib/translations.js
+++ b/lib/translations.js
@@ -42,7 +42,25 @@ const translations = {
     noResults: 'No results.',
     noFilteredExhibitions: 'No exhibitions match the selected filters.',
     aboutTitle: 'About MuseumBuddy',
-    aboutBody: 'This page will contain information about MuseumBuddy.',
+    aboutIntro:
+      'MuseumBuddy is your cultural compass for the city. We help you quickly find the best museums and current exhibitions and plan your day wisely—without endless searching.',
+    aboutWhatTitle: 'What you can do with MuseumBuddy',
+    aboutWhatItems: [
+      'Discover exhibitions we highlight so you miss less and experience more.',
+      'See up-to-date opening hours at a glance, directly for each museum.',
+      'Save favorites to quickly revisit what you want to see.',
+      'Plan your cultural day: from MuseumBuddy you can click through to tickets, routes, and visitor information.',
+      'Filter exhibitions smartly (including Free, Kid-friendly, Temporary) and click through to the museum website or Google Maps.',
+    ],
+    aboutActiveTitle: 'Where we are active',
+    aboutActiveBody:
+      'We are currently focused on Amsterdam. (Based on the current site content: “Discover museums in Amsterdam”.)',
+    aboutResponsibleTitle: 'Responsible choices',
+    aboutResponsibleBody:
+      'We strive to provide up-to-date and accurate information, but we always ask visitors to verify details (such as opening hours and prices) with the museum itself. MuseumBuddy is an informative guide; you remain responsible for your choices.',
+    aboutContactTitle: 'Contact',
+    aboutContactBody:
+      'Questions, feedback, or want to join as a curator? Email us at {email}. We would love to hear from you.',
     favoritesTitle: 'Favorites',
     noFavorites: 'No favorites.',
     favoriteMuseums: 'Museums',
@@ -171,7 +189,25 @@ const translations = {
     noResults: 'Geen resultaten.',
     noFilteredExhibitions: 'Geen tentoonstellingen komen overeen met je filters.',
     aboutTitle: 'Over MuseumBuddy',
-    aboutBody: 'Deze pagina bevat informatie over MuseumBuddy.',
+    aboutIntro:
+      'MuseumBuddy is je cultuurkompas voor de stad. We helpen je snel de beste musea en actuele tentoonstellingen te vinden en je dag slim te plannen—zonder eindeloos te moeten zoeken.',
+    aboutWhatTitle: 'Wat je met MuseumBuddy kunt',
+    aboutWhatItems: [
+      'Ontdek tentoonstellingen die we uitlichten, zodat je minder mist en meer beleeft.',
+      'Actuele openingstijden in één oogopslag, direct bij ieder museum.',
+      'Favorieten bewaren om snel terug te vinden wat je wilt bezoeken.',
+      'Plan je cultuurdag: vanuit MuseumBuddy klik je door naar tickets, routes en bezoekersinfo.',
+      'Slim filteren bij tentoonstellingen (o.a. Gratis, Kindvriendelijk, Tijdelijk) en doorklikken naar de museumwebsite of Google Maps.',
+    ],
+    aboutActiveTitle: 'Waar we nu actief zijn',
+    aboutActiveBody:
+      'We richten ons momenteel op Amsterdam. (Gebaseerd op de huidige site-inhoud: “Ontdek musea in Amsterdam”.)',
+    aboutResponsibleTitle: 'Verantwoord kiezen',
+    aboutResponsibleBody:
+      'We streven naar actuele en juiste informatie, maar vragen bezoekers altijd om details (zoals tijden en prijzen) bij het museum zelf te controleren. MuseumBuddy is een informatieve gids; je blijft zelf verantwoordelijk voor je keuzes.',
+    aboutContactTitle: 'Contact',
+    aboutContactBody:
+      'Vragen, feedback of meedoen als curator? Mail ons via {email}. We horen graag van je.',
     favoritesTitle: 'Favorieten',
     noFavorites: 'Geen favorieten.',
     favoriteMuseums: 'Musea',

--- a/pages/about.js
+++ b/pages/about.js
@@ -3,11 +3,40 @@ import { useLanguage } from '../components/LanguageContext';
 
 export default function AboutPage() {
   const { t } = useLanguage();
+  const emailAddress = 'info@museumbuddy.nl';
+  const whatItems = t('aboutWhatItems');
+  const contactBody = t('aboutContactBody', { email: emailAddress });
+  const [contactPrefix = '', contactSuffix = ''] = contactBody.split(emailAddress);
+
   return (
     <>
       <SEO title={t('aboutTitle')} />
       <h1 className="page-title">{t('aboutTitle')}</h1>
-      <p>{t('aboutBody')}</p>
+      <p>{t('aboutIntro')}</p>
+      <section>
+        <h2>{t('aboutWhatTitle')}</h2>
+        <ul>
+          {Array.isArray(whatItems)
+            ? whatItems.map((item) => <li key={item}>{item}</li>)
+            : null}
+        </ul>
+      </section>
+      <section>
+        <h2>{t('aboutActiveTitle')}</h2>
+        <p>{t('aboutActiveBody')}</p>
+      </section>
+      <section>
+        <h2>{t('aboutResponsibleTitle')}</h2>
+        <p>{t('aboutResponsibleBody')}</p>
+      </section>
+      <section>
+        <h2>{t('aboutContactTitle')}</h2>
+        <p>
+          {contactPrefix}
+          <a href={`mailto:${emailAddress}`}>{emailAddress}</a>
+          {contactSuffix}
+        </p>
+      </section>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- replace the About page placeholder copy with full Dutch and English content, including sections and bullet list support
- update the translation helper to handle array values used by the new About page structure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc273b06408326bcf0e134a3c055ba