### PR TITLE
Remove load button from saved scenarios

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import Head from 'next/head';
 import '../styles/globals.css';
 import Layout from '../components/Layout';
@@ -9,6 +10,48 @@ const fontStylesheetHref =
 const tailwindCdnHref = 'https://cdn.jsdelivr.net/npm/tailwindcss@3.4.10/dist/tailwind.min.css';
 
 export default function MyApp({ Component, pageProps }) {
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const keywords = ["opgeslagen scenario's", 'saved scenarios'];
+    const labels = new Set(['laden', 'load']);
+
+    const hideLoadButtons = () => {
+      const allButtons = Array.from(document.querySelectorAll('button'));
+      allButtons.forEach((button) => {
+        if (!button.isConnected) return;
+        const text = button.textContent?.trim().toLowerCase();
+        if (!text || !labels.has(text)) return;
+
+        let container = button.parentElement;
+        let shouldRemove = false;
+
+        while (container && container !== document.body) {
+          if (container.textContent) {
+            const content = container.textContent.toLowerCase();
+            if (keywords.some((keyword) => content.includes(keyword))) {
+              shouldRemove = true;
+              break;
+            }
+          }
+          container = container.parentElement;
+        }
+
+        if (shouldRemove) {
+          button.remove();
+        }
+      });
+    };
+
+    hideLoadButtons();
+
+    const observer = new MutationObserver(() => hideLoadButtons());
+    if (document.body) {
+      observer.observe(document.body, { subtree: true, childList: true });
+    }
+
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <LanguageProvider>
       <FavoritesProvider>


### PR DESCRIPTION
## Summary
- hide the saved scenario "load" button when the app renders by stripping it from the DOM
- keep the button removed when saved scenarios update by observing DOM changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de2f47193c8326a4d465a2c360fb5c