### PR TITLE
Improve secondary hero mobile layout

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -779,7 +779,7 @@ export default function Home({ initialMuseums = [], initialError = null }) {
           </h2>
           <p className="secondary-hero__subtitle">{t('museumnachtSubtitle')}</p>
           <a
-            className="hero-quick-link hero-quick-link--primary secondary-hero__cta"
+            className="ticket-button secondary-hero__cta"
             href="https://museumnacht.amsterdam/tickets"
             target="_blank"
             rel="noopener noreferrer"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -876,6 +876,11 @@ button.header-link {
   color: #ffffff;
   border-color: transparent;
   box-shadow: 0 18px 32px rgba(220, 38, 38, 0.35);
+  padding: var(--space-12) var(--space-20);
+  border-radius: var(--radius-md);
+  font-size: 15px;
+  min-height: 48px;
+  letter-spacing: 0.01em;
 }
 
 [data-theme='dark'] .secondary-hero {
@@ -902,10 +907,19 @@ button.header-link {
   .secondary-hero__content {
     max-width: 100%;
     gap: clamp(8px, 4vw, 16px);
+    margin-left: 0;
+    align-items: flex-start;
+    text-align: left;
   }
 
   .secondary-hero__cta {
-    width: auto;
+    width: 100%;
+    max-width: 320px;
+    justify-content: center;
+    font-size: 16px;
+    padding: var(--space-12) var(--space-24);
+    min-height: 52px;
+    box-shadow: 0 14px 28px rgba(220, 38, 38, 0.4);
   }
 }
 
@@ -921,6 +935,11 @@ button.header-link {
 
   .secondary-hero__subtitle {
     font-size: clamp(15px, 4.4vw, 17px);
+  }
+
+  .secondary-hero__cta {
+    max-width: none;
+    width: 100%;
   }
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -872,6 +872,7 @@ button.header-link {
 .secondary-hero__cta {
   align-self: flex-end;
   margin-top: clamp(4px, 1vw, 10px);
+  padding: 10px 20px;
   background: #dc2626;
   color: #ffffff;
   box-shadow: 0 18px 32px rgba(220, 38, 38, 0.35);
@@ -902,21 +903,22 @@ button.header-link {
   .secondary-hero__content {
     max-width: min(520px, 100%);
     gap: clamp(10px, 5vw, 18px);
-    margin: 0 auto;
-    align-items: center;
-    text-align: center;
-    padding-inline: clamp(12px, 8vw, 24px);
+    margin: 0;
+    align-items: flex-start;
+    text-align: left;
+    padding-inline: clamp(8px, 5vw, 20px);
   }
 
   .secondary-hero__subtitle {
-    margin-left: auto;
-    margin-right: auto;
+    margin-left: 0;
+    margin-right: 0;
     max-width: 42ch;
   }
 
   .secondary-hero__cta {
-    margin-inline: auto;
-    align-self: center;
+    margin-inline: 0;
+    align-self: flex-start;
+    padding-block: 11px;
     box-shadow: 0 16px 32px rgba(220, 38, 38, 0.4);
   }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -874,13 +874,8 @@ button.header-link {
   margin-top: clamp(4px, 1vw, 10px);
   background: #dc2626;
   color: #ffffff;
-  border-color: transparent;
   box-shadow: 0 18px 32px rgba(220, 38, 38, 0.35);
-  padding: var(--space-12) var(--space-20);
-  border-radius: var(--radius-md);
-  font-size: 15px;
-  min-height: 48px;
-  letter-spacing: 0.01em;
+  text-decoration: none;
 }
 
 [data-theme='dark'] .secondary-hero {
@@ -901,31 +896,34 @@ button.header-link {
     margin: clamp(var(--space-32), 9vw, var(--space-48)) 0;
     border-radius: var(--radius-lg);
     min-height: clamp(220px, 80vw, 360px);
-    padding: clamp(var(--space-20), 8vw, var(--space-32));
+    padding: clamp(28px, 12vw, 48px);
   }
 
   .secondary-hero__content {
-    max-width: 100%;
-    gap: clamp(8px, 4vw, 16px);
-    margin-left: 0;
-    align-items: flex-start;
-    text-align: left;
+    max-width: min(520px, 100%);
+    gap: clamp(10px, 5vw, 18px);
+    margin: 0 auto;
+    align-items: center;
+    text-align: center;
+    padding-inline: clamp(12px, 8vw, 24px);
+  }
+
+  .secondary-hero__subtitle {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 42ch;
   }
 
   .secondary-hero__cta {
-    width: 100%;
-    max-width: 320px;
-    justify-content: center;
-    font-size: 16px;
-    padding: var(--space-12) var(--space-24);
-    min-height: 52px;
-    box-shadow: 0 14px 28px rgba(220, 38, 38, 0.4);
+    margin-inline: auto;
+    align-self: center;
+    box-shadow: 0 16px 32px rgba(220, 38, 38, 0.4);
   }
 }
 
 @media (max-width: 520px) {
   .secondary-hero {
-    padding: var(--space-20);
+    padding: clamp(24px, 12vw, 36px);
     border-radius: var(--radius-md);
   }
 
@@ -938,8 +936,7 @@ button.header-link {
   }
 
   .secondary-hero__cta {
-    max-width: none;
-    width: 100%;
+    max-width: min(320px, 100%);
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust the secondary hero content alignment for smaller screens
- enlarge and center the buy tickets call-to-action on mobile for better tap targets
- tweak responsive spacing so the section reads comfortably on phones

## Testing
- npm install *(fails: 403 Forbidden fetching @capacitor/app from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68de364df6dc8326b82a734440042881