### PR TITLE
feat: redesign exhibitions cards

### DIFF
--- a/app/exhibitions/page.jsx
+++ b/app/exhibitions/page.jsx
@@ -7,6 +7,7 @@ import museumTicketUrls from '../../lib/museumTicketUrls';
 import resolveMuseumSlug from '../../lib/resolveMuseumSlug';
 import museumImages from '../../lib/museumImages';
 import museumImageCredits from '../../lib/museumImageCredits';
+import museumOpeningHours from '../../lib/museumOpeningHours';
 import FALLBACK_MUSEUMS from '../../lib/museumFallbackData';
 
 export const revalidate = 900;
@@ -95,6 +96,78 @@ async function fetchExhibitions() {
           ? FALLBACK_MUSEUMS.find((item) => item.slug === canonicalSlug)
           : null;
 
+        const city =
+          row?.stad ||
+          row?.city ||
+          row?.museum_stad ||
+          row?.museumCity ||
+          fallbackMuseum?.stad ||
+          null;
+        const province =
+          row?.provincie ||
+          row?.province ||
+          row?.museum_provincie ||
+          row?.museumProvince ||
+          fallbackMuseum?.provincie ||
+          null;
+
+        const normalisedOpeningHours = (() => {
+          const candidate =
+            row?.openingstijden ||
+            row?.openingHours ||
+            row?.opening_hours ||
+            row?.museum_openingstijden ||
+            row?.museumOpeningHours ||
+            null;
+
+          if (!candidate) return null;
+
+          if (typeof candidate === 'string') {
+            const trimmed = candidate.trim();
+            if (!trimmed) return null;
+            return { en: trimmed, nl: trimmed };
+          }
+
+          if (typeof candidate === 'object') {
+            const enValue =
+              candidate.en ||
+              candidate.En ||
+              candidate.EN ||
+              candidate.english ||
+              candidate.nl ||
+              candidate.NL ||
+              null;
+            const nlValue =
+              candidate.nl ||
+              candidate.NL ||
+              candidate.en ||
+              candidate.En ||
+              candidate.EN ||
+              null;
+
+            if (enValue || nlValue) {
+              return {
+                en: enValue || nlValue || null,
+                nl: nlValue || enValue || null,
+              };
+            }
+          }
+
+          return null;
+        })();
+
+        const fallbackOpeningHours = canonicalSlug
+          ? museumOpeningHours[canonicalSlug] || null
+          : null;
+        const openingHours = normalisedOpeningHours
+          ? normalisedOpeningHours
+          : fallbackOpeningHours
+          ? {
+              en: fallbackOpeningHours.en || fallbackOpeningHours.nl || null,
+              nl: fallbackOpeningHours.nl || fallbackOpeningHours.en || null,
+            }
+          : null;
+
         const affiliateTicketUrl =
           normalised.ticketAffiliateUrl ||
           museum?.ticket_affiliate_url ||
@@ -117,6 +190,9 @@ async function fetchExhibitions() {
           museumTicketUrl: defaultTicketUrl || null,
           museumImage: canonicalImage,
           museumImageCredit: canonicalCredit,
+          museumCity: city || null,
+          museumProvince: province || null,
+          museumOpeningHours: openingHours,
         };
       })
       .filter(Boolean)

--- a/components/ExhibitionsPageClient.jsx
+++ b/components/ExhibitionsPageClient.jsx
@@ -199,26 +199,13 @@ export default function ExhibitionsPageClient({ initialExhibitions = [], supabas
 
               return (
                 <li key={expo.id} className="exhibitions-results__item">
-                  <div className="exhibitions-results__card">
-                    {expo.museumName && (
-                      <p className="exhibitions-results__museum">
-                        {canonicalSlug ? (
-                          <Link href={`/museum/${canonicalSlug}`} prefetch>
-                            {t('exhibitionsHostedBy', { museum: expo.museumName })}
-                          </Link>
-                        ) : (
-                          <span>{t('exhibitionsHostedBy', { museum: expo.museumName })}</span>
-                        )}
-                      </p>
-                    )}
-                    <ExpositionCard
-                      exposition={expo}
-                      affiliateUrl={affiliateLink}
-                      ticketUrl={ticketLink}
-                      museumSlug={canonicalSlug}
-                      tags={expo.tags}
-                    />
-                  </div>
+                  <ExpositionCard
+                    exposition={expo}
+                    affiliateUrl={affiliateLink}
+                    ticketUrl={ticketLink}
+                    museumSlug={canonicalSlug}
+                    tags={expo.tags}
+                  />
                 </li>
               );
             })}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3799,40 +3799,40 @@ button.hero-quick-link {
   display: flex;
   flex-direction: column;
   height: 100%;
-  border-radius: 24px;
+  border-radius: 0.875rem;
   overflow: hidden;
-  background: rgba(255, 255, 255, 0.98);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.16);
-  transition: transform 0.35s ease, box-shadow 0.35s ease;
+  background: var(--surface);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+  transition: box-shadow 0.25s ease, transform 0.25s ease, background 0.25s ease;
 }
 
 .exposition-card:hover {
-  transform: translateY(-6px);
-  box-shadow: 0 36px 76px rgba(15, 23, 42, 0.22);
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.16);
 }
 
 [data-theme='dark'] .exposition-card {
-  background: rgba(15, 23, 42, 0.92);
+  background: rgba(15, 23, 42, 0.9);
   border-color: rgba(100, 116, 139, 0.45);
-  box-shadow: 0 30px 68px rgba(2, 6, 23, 0.62);
+  box-shadow: 0 18px 42px rgba(2, 6, 23, 0.55);
 }
 
 [data-theme='dark'] .exposition-card:hover {
-  box-shadow: 0 38px 84px rgba(2, 6, 23, 0.72);
+  box-shadow: 0 22px 52px rgba(2, 6, 23, 0.68);
 }
 
 .exposition-card__media {
   position: relative;
   width: 100%;
-  aspect-ratio: 6 / 5;
+  aspect-ratio: 4 / 3;
   overflow: hidden;
-  background: linear-gradient(135deg, rgba(51, 65, 85, 0.65), rgba(15, 23, 42, 0.85));
+  background: linear-gradient(135deg, rgba(51, 65, 85, 0.55), rgba(15, 23, 42, 0.75));
 }
 
 @media (min-width: 768px) {
   .exposition-card__media {
-    aspect-ratio: 4 / 3;
+    aspect-ratio: 16 / 9;
   }
 }
 
@@ -3862,12 +3862,12 @@ button.hero-quick-link {
 .exposition-card__media-overlay {
   position: absolute;
   inset: 0;
-  padding: 20px;
+  padding: 16px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   color: #fff;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.08) 0%, rgba(15, 23, 42, 0.58) 55%, rgba(15, 23, 42, 0.85) 100%);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.52) 55%, rgba(15, 23, 42, 0.78) 100%);
   pointer-events: none;
 }
 
@@ -3875,110 +3875,114 @@ button.hero-quick-link {
 .exposition-card__overlay-bottom {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
   pointer-events: auto;
 }
 
 .exposition-card__overlay-top {
   flex-direction: row;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  gap: 12px;
 }
 
 .exposition-card__overlay-actions {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
+  gap: 6px;
+  padding: 6px;
+  border-radius: 12px;
+  background: var(--chip-bg);
+  border: 1px solid var(--chip-border);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.14);
+  backdrop-filter: blur(10px);
 }
 
 .exposition-card .icon-button.large {
-  width: 40px;
-  height: 40px;
-  border-radius: 14px;
+  width: 34px;
+  height: 34px;
+  border-radius: 12px;
   padding: 0;
-  background: rgba(15, 23, 42, 0.55);
-  color: #fff;
-  border: 1px solid rgba(255, 255, 255, 0.28);
-  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.32);
-  backdrop-filter: blur(12px);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--text);
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.2);
+  backdrop-filter: blur(10px);
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
 }
 
 .exposition-card .icon-button.large svg {
-  width: 20px;
-  height: 20px;
+  width: 18px;
+  height: 18px;
 }
 
 .exposition-card .icon-button.large:hover,
 .exposition-card .icon-button.large:focus-visible {
   transform: translateY(-1px);
-  background: rgba(15, 23, 42, 0.78);
-  box-shadow: 0 22px 44px rgba(15, 23, 42, 0.38);
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.24);
 }
 
 .exposition-card .icon-button.large.favorited {
   background: var(--accent);
   color: var(--accent-ink);
   border-color: transparent;
-  box-shadow: 0 20px 42px rgba(37, 99, 235, 0.35);
+  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.28);
 }
 
 [data-theme='dark'] .exposition-card .icon-button.large {
-  background: rgba(15, 23, 42, 0.75);
-  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(15, 23, 42, 0.72);
+  border-color: rgba(148, 163, 184, 0.32);
+  color: var(--text);
 }
 
 [data-theme='dark'] .exposition-card .icon-button.large.favorited {
-  box-shadow: 0 20px 44px rgba(37, 99, 235, 0.4);
+  box-shadow: 0 18px 36px rgba(37, 99, 235, 0.34);
 }
 
 .exposition-card__icon-button:hover,
 .exposition-card__icon-button:focus-visible {
   transform: translateY(-1px);
-  background: rgba(15, 23, 42, 0.78);
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.4);
 }
 
 .exposition-card__ticket-badge {
   display: inline-flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
-  padding: 10px 18px;
-  border-radius: 16px;
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.95), rgba(14, 165, 233, 0.85));
-  color: #fff;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.95), rgba(37, 99, 235, 0.82));
+  color: var(--accent-ink);
   font-weight: 600;
   letter-spacing: -0.01em;
   text-decoration: none;
-  border: 1px solid rgba(255, 255, 255, 0.35);
-  box-shadow: 0 20px 44px rgba(15, 23, 42, 0.32);
+  border: 1px solid rgba(255, 255, 255, 0.32);
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.26);
   min-width: 0;
 }
 
 .exposition-card__ticket-badge:hover,
 .exposition-card__ticket-badge:focus-visible {
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.98), rgba(14, 165, 233, 0.9));
-  box-shadow: 0 26px 54px rgba(15, 23, 42, 0.36);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.98), rgba(14, 165, 233, 0.92));
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.3);
 }
 
 .exposition-card__ticket-badge--disabled {
-  background: rgba(15, 23, 42, 0.32);
-  color: rgba(248, 250, 252, 0.82);
+  background: rgba(15, 23, 42, 0.4);
+  color: rgba(248, 250, 252, 0.85);
   border-color: rgba(255, 255, 255, 0.22);
   box-shadow: none;
   cursor: default;
 }
 
 .exposition-card__ticket-badge-label {
-  font-size: 0.92rem;
+  font-size: 0.9rem;
 }
 
 .exposition-card__ticket-badge-sub {
-  font-size: 0.7rem;
+  font-size: 0.65rem;
   text-transform: uppercase;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.12em;
   font-weight: 700;
   opacity: 0.95;
 }
@@ -3990,16 +3994,17 @@ button.hero-quick-link {
 .exposition-card__overlay-cta {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  padding: 12px 20px;
+  gap: 8px;
+  padding: 10px 18px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.14);
   color: #fff;
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.015em;
+  font-size: 0.9rem;
   text-decoration: none;
-  border: 1px solid rgba(255, 255, 255, 0.28);
-  box-shadow: 0 22px 48px rgba(15, 23, 42, 0.28);
+  border: 1px solid rgba(255, 255, 255, 0.32);
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.24);
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
@@ -4007,22 +4012,22 @@ button.hero-quick-link {
 .exposition-card__overlay-cta:focus-visible {
   transform: translateY(-1px);
   background: rgba(255, 255, 255, 0.22);
-  box-shadow: 0 26px 58px rgba(15, 23, 42, 0.34);
+  box-shadow: 0 20px 44px rgba(15, 23, 42, 0.3);
 }
 
 .exposition-card__overlay-cta-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
   background: rgba(255, 255, 255, 0.22);
 }
 
 .exposition-card__overlay-cta-icon svg {
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
 }
 
 .exposition-card__image-credit--overlay {
@@ -4072,18 +4077,20 @@ button.hero-quick-link {
   transform: scale(1.06);
 }
 
- .exposition-card__body {
+.exposition-card__body {
   display: flex;
   flex-direction: column;
-  gap: 18px;
-  padding: 26px 28px 24px;
+  gap: 16px;
+  padding: 24px;
+  padding-bottom: 20px;
   min-height: 0;
 }
 
 @media (max-width: 720px) {
-.exposition-card__body {
-    padding: 22px 22px 20px;
-    gap: 16px;
+  .exposition-card__body {
+    padding: 20px;
+    padding-bottom: 16px;
+    gap: 14px;
   }
 }
 
@@ -4103,11 +4110,11 @@ button.hero-quick-link {
 
 .exposition-card__subtitle {
   margin: 0;
-  font-size: 0.82rem;
-  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  font-weight: 700;
-  color: rgba(59, 130, 246, 0.9);
+  font-weight: 600;
+  color: var(--accent);
 }
 
 [data-theme='dark'] .exposition-card__subtitle {
@@ -4116,10 +4123,11 @@ button.hero-quick-link {
 
 .exposition-card__title {
   margin: 0;
-  font-size: clamp(1.25rem, 2.6vw, 1.6rem);
+  font-size: clamp(1.2rem, 0.6vw + 1.1rem, 1.5rem);
   letter-spacing: -0.015em;
-  font-weight: 700;
-  color: rgba(15, 23, 42, 0.95);
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--text);
 }
 
 [data-theme='dark'] .exposition-card__title {
@@ -4129,32 +4137,31 @@ button.hero-quick-link {
 .exposition-card__meta {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
 }
 
 .exposition-card__meta-item {
   display: flex;
-  align-items: center;
-  gap: 12px;
-  font-size: 0.95rem;
+  align-items: flex-start;
+  gap: 10px;
+  font-size: 0.9375rem;
   font-weight: 500;
-  color: rgba(71, 85, 105, 0.92);
+  line-height: 1.45;
+  color: var(--muted);
 }
 
 [data-theme='dark'] .exposition-card__meta-item {
-  color: rgba(203, 213, 225, 0.92);
+  color: rgba(203, 213, 225, 0.9);
 }
 
 .exposition-card__meta-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: 12px;
-  background: rgba(37, 99, 235, 0.12);
-  color: rgba(37, 99, 235, 0.95);
-  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.18);
+  width: 18px;
+  height: 18px;
+  margin-top: 2px;
+  color: var(--accent);
 }
 
 .exposition-card__meta-icon svg {
@@ -4162,17 +4169,12 @@ button.hero-quick-link {
   height: 18px;
 }
 
-[data-theme='dark'] .exposition-card__meta-icon {
-  background: rgba(59, 130, 246, 0.15);
-  color: rgba(191, 219, 254, 0.95);
-  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.32);
-}
-
 .exposition-card__summary {
   margin: 0;
-  color: rgba(71, 85, 105, 0.92);
-  font-size: 0.95rem;
-  line-height: 1.55;
+  color: var(--muted);
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  letter-spacing: 0.005em;
 }
 
 [data-theme='dark'] .exposition-card__summary {
@@ -4182,7 +4184,7 @@ button.hero-quick-link {
 .exposition-card__tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 8px;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -4192,11 +4194,11 @@ button.hero-quick-link {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 14px;
+  padding: 3px 9px;
   border-radius: 999px;
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   background: rgba(37, 99, 235, 0.1);
   color: rgba(37, 99, 235, 0.95);
@@ -4215,10 +4217,10 @@ button.hero-quick-link {
 
 .exposition-card__footer {
   margin-top: auto;
-  padding: 0 28px 24px;
+  padding: 0 24px 20px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
 }
 
 .event-card__footer {
@@ -4272,11 +4274,11 @@ button.hero-quick-link {
     grid-auto-columns: minmax(190px, 58vw);
   }
   .exposition-card__body {
-    padding: var(--space-16);
-    padding-bottom: 0;
+    padding: 20px;
+    padding-bottom: 16px;
   }
   .exposition-card__footer {
-    padding: var(--space-16);
+    padding: 0 20px 16px;
   }
   .exposition-card__topline {
     align-items: center;
@@ -4302,11 +4304,11 @@ button.hero-quick-link {
     box-shadow: 0 12px 28px rgba(15,23,42,0.18);
   }
   .exposition-card__body {
-    padding: var(--space-16);
-    padding-bottom: 0;
+    padding: 20px;
+    padding-bottom: 16px;
   }
   .exposition-card__footer {
-    padding: var(--space-16);
+    padding: 0 20px 16px;
   }
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3795,122 +3795,253 @@ button.hero-quick-link {
 }
 
 .exposition-card {
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  background: linear-gradient(
-    160deg,
-    rgba(248, 250, 252, 0.96) 0%,
-    rgba(255, 247, 237, 0.94) 48%,
-    rgba(253, 242, 248, 0.94) 100%
-  );
-  box-shadow: 0 14px 34px rgba(15, 23, 42, 0.14);
-  transition: box-shadow 0.3s ease, transform 0.3s ease, background 0.3s ease;
-}
-
-.event-card {
-  gap: var(--space-16);
-  padding: var(--space-24);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border-radius: 24px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.98);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.16);
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
 }
 
 .exposition-card:hover {
-  transform: translateY(-6px) scale(1.01);
-  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.2);
-  background: linear-gradient(
-    170deg,
-    rgba(255, 255, 255, 0.96) 0%,
-    rgba(255, 250, 240, 0.96) 52%,
-    rgba(250, 245, 255, 0.96) 100%
-  );
+  transform: translateY(-6px);
+  box-shadow: 0 36px 76px rgba(15, 23, 42, 0.22);
 }
 
-.event-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.18);
-}
-
-[data-theme='dark'] .exposition-card,
-[data-theme='dark'] .event-card {
-  background: rgba(15, 23, 42, 0.9);
+[data-theme='dark'] .exposition-card {
+  background: rgba(15, 23, 42, 0.92);
   border-color: rgba(100, 116, 139, 0.45);
-  box-shadow: 0 20px 50px rgba(2, 6, 23, 0.6);
+  box-shadow: 0 30px 68px rgba(2, 6, 23, 0.62);
 }
 
-
+[data-theme='dark'] .exposition-card:hover {
+  box-shadow: 0 38px 84px rgba(2, 6, 23, 0.72);
+}
 
 .exposition-card__media {
   position: relative;
+  width: 100%;
+  aspect-ratio: 6 / 5;
   overflow: hidden;
-  aspect-ratio: 21 / 10;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.22);
-  border-radius: var(--radius-md) var(--radius-md) 0 0;
-  background: linear-gradient(140deg, rgba(226, 232, 240, 0.45), rgba(203, 213, 225, 0.25));
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: transform 0.35s ease, background-color 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease;
+  background: linear-gradient(135deg, rgba(51, 65, 85, 0.65), rgba(15, 23, 42, 0.85));
 }
 
-.exposition-card__media::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background-image: linear-gradient(135deg, rgba(148, 163, 184, 0.12) 0%, rgba(148, 163, 184, 0.06) 45%, transparent 100%),
-    repeating-linear-gradient(-45deg, rgba(148, 163, 184, 0.12) 0 1px, transparent 1px 12px);
-  opacity: 0.45;
-  pointer-events: none;
+@media (min-width: 768px) {
+  .exposition-card__media {
+    aspect-ratio: 4 / 3;
+  }
 }
-
 
 .exposition-card__media--placeholder {
-  color: rgba(100, 116, 139, 0.38);
-  background: linear-gradient(140deg, rgba(226, 232, 240, 0.65), rgba(203, 213, 225, 0.4));
-}
-
-.exposition-card__media--placeholder::before {
-  opacity: 0.15;
-}
-
-[data-theme='dark'] .exposition-card__media {
-  border-color: rgba(71, 85, 105, 0.55);
-  background: rgba(15, 23, 42, 0.92);
-  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.55);
-}
-
-[data-theme='dark'] .exposition-card__media::before {
-  background-image: linear-gradient(135deg, rgba(100, 116, 139, 0.35) 0%, rgba(100, 116, 139, 0.18) 45%, transparent 100%),
-    repeating-linear-gradient(-45deg, rgba(100, 116, 139, 0.28) 0 1px, transparent 1px 12px);
-  opacity: 0.45;
-}
-
-[data-theme='dark'] .exposition-card__media--placeholder {
-  color: rgba(148, 163, 184, 0.55);
-  background: rgba(15, 23, 42, 0.92);
+  background: linear-gradient(135deg, rgba(100, 116, 139, 0.35), rgba(148, 163, 184, 0.18));
 }
 
 .exposition-card__media-placeholder {
   position: absolute;
   inset: 0;
   display: block;
-  background-image: linear-gradient(135deg, rgba(226, 232, 240, 0.85), rgba(203, 213, 225, 0.55));
+  background-image: linear-gradient(135deg, rgba(226, 232, 240, 0.8), rgba(203, 213, 225, 0.45));
 }
 
-[data-theme='dark'] .exposition-card__media-placeholder {
-  opacity: 1;
+.exposition-card__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.45s ease, filter 0.45s ease;
 }
 
-@media (max-width: 640px) {
-  .exposition-card__media {
-    aspect-ratio: 16 / 9;
-  }
+.exposition-card:hover .exposition-card__image {
+  transform: scale(1.06);
+  filter: saturate(1.05) contrast(1.03);
 }
 
-.exposition-card__skeleton {
+.exposition-card__media-overlay {
   position: absolute;
   inset: 0;
-  border-radius: inherit;
-  background: var(--skeleton-base);
-  overflow: hidden;
-  opacity: 0;
-  transition: opacity 0.25s ease;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  color: #fff;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.08) 0%, rgba(15, 23, 42, 0.58) 55%, rgba(15, 23, 42, 0.85) 100%);
+  pointer-events: none;
+}
+
+.exposition-card__overlay-top,
+.exposition-card__overlay-bottom {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  pointer-events: auto;
+}
+
+.exposition-card__overlay-top {
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.exposition-card__overlay-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.exposition-card .icon-button.large {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  padding: 0;
+  background: rgba(15, 23, 42, 0.55);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.32);
+  backdrop-filter: blur(12px);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.exposition-card .icon-button.large svg {
+  width: 20px;
+  height: 20px;
+}
+
+.exposition-card .icon-button.large:hover,
+.exposition-card .icon-button.large:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(15, 23, 42, 0.78);
+  box-shadow: 0 22px 44px rgba(15, 23, 42, 0.38);
+}
+
+.exposition-card .icon-button.large.favorited {
+  background: var(--accent);
+  color: var(--accent-ink);
+  border-color: transparent;
+  box-shadow: 0 20px 42px rgba(37, 99, 235, 0.35);
+}
+
+[data-theme='dark'] .exposition-card .icon-button.large {
+  background: rgba(15, 23, 42, 0.75);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+[data-theme='dark'] .exposition-card .icon-button.large.favorited {
+  box-shadow: 0 20px 44px rgba(37, 99, 235, 0.4);
+}
+
+.exposition-card__icon-button:hover,
+.exposition-card__icon-button:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(15, 23, 42, 0.78);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.4);
+}
+
+.exposition-card__ticket-badge {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 10px 18px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.95), rgba(14, 165, 233, 0.85));
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  text-decoration: none;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  box-shadow: 0 20px 44px rgba(15, 23, 42, 0.32);
+  min-width: 0;
+}
+
+.exposition-card__ticket-badge:hover,
+.exposition-card__ticket-badge:focus-visible {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.98), rgba(14, 165, 233, 0.9));
+  box-shadow: 0 26px 54px rgba(15, 23, 42, 0.36);
+}
+
+.exposition-card__ticket-badge--disabled {
+  background: rgba(15, 23, 42, 0.32);
+  color: rgba(248, 250, 252, 0.82);
+  border-color: rgba(255, 255, 255, 0.22);
+  box-shadow: none;
+  cursor: default;
+}
+
+.exposition-card__ticket-badge-label {
+  font-size: 0.92rem;
+}
+
+.exposition-card__ticket-badge-sub {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-weight: 700;
+  opacity: 0.95;
+}
+
+.exposition-card__overlay-bottom {
+  align-items: flex-start;
+}
+
+.exposition-card__overlay-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 20px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  box-shadow: 0 22px 48px rgba(15, 23, 42, 0.28);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.exposition-card__overlay-cta:hover,
+.exposition-card__overlay-cta:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.22);
+  box-shadow: 0 26px 58px rgba(15, 23, 42, 0.34);
+}
+
+.exposition-card__overlay-cta-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.exposition-card__overlay-cta-icon svg {
+  width: 14px;
+  height: 14px;
+}
+
+.exposition-card__image-credit--overlay {
+  position: static;
+  margin: 0;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.68);
+  color: rgba(248, 250, 252, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  box-shadow: none;
+  backdrop-filter: blur(12px);
+  font-size: 0.72rem;
+}
+
+[data-theme='dark'] .exposition-card__image-credit--overlay {
+  background: rgba(15, 23, 42, 0.75);
+  color: rgba(226, 232, 240, 0.9);
+  border-color: rgba(148, 163, 184, 0.35);
 }
 
 .exposition-card__skeleton-shimmer {
@@ -3941,7 +4072,21 @@ button.hero-quick-link {
   transform: scale(1.06);
 }
 
-.exposition-card__body,
+ .exposition-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 26px 28px 24px;
+  min-height: 0;
+}
+
+@media (max-width: 720px) {
+.exposition-card__body {
+    padding: 22px 22px 20px;
+    gap: 16px;
+  }
+}
+
 .event-card__body {
   display: flex;
   flex-direction: column;
@@ -3950,86 +4095,89 @@ button.hero-quick-link {
   min-height: 0;
 }
 
-.exposition-card__topline {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--space-8);
-}
-
-
-.exposition-card__date {
+.exposition-card__header {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  font-size: 0.75rem;
-  color: var(--muted);
-  font-weight: 600;
-  letter-spacing: 0.02em;
+  gap: 6px;
 }
 
-.exposition-card__date-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 4px 12px;
-  border-radius: 999px;
-  font-size: 0.65rem;
-  letter-spacing: 0.12em;
+.exposition-card__subtitle {
+  margin: 0;
+  font-size: 0.82rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   font-weight: 700;
-  background: rgba(148, 163, 184, 0.22);
-  color: var(--text);
+  color: rgba(59, 130, 246, 0.9);
 }
 
-.exposition-card__date-label::before {
-  content: '';
-  width: 6px;
-  height: 6px;
-  border-radius: 999px;
-  background: currentColor;
-  opacity: 0.55;
+[data-theme='dark'] .exposition-card__subtitle {
+  color: rgba(148, 197, 255, 0.88);
 }
-
-[data-theme='dark'] .exposition-card__date-label {
-  background: rgba(148, 163, 184, 0.32);
-  color: rgba(226, 232, 240, 0.92);
-}
-
-.exposition-card__date-value {
-  font-size: 0.9rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  color: var(--text);
-  text-transform: uppercase;
-}
-
 
 .exposition-card__title {
   margin: 0;
-  font-size: clamp(16px, 1.4vw, 19px);
-  letter-spacing: -0.01em;
+  font-size: clamp(1.25rem, 2.6vw, 1.6rem);
+  letter-spacing: -0.015em;
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.95);
 }
 
-.exposition-card__title a {
-  color: inherit;
-  text-decoration: none;
+[data-theme='dark'] .exposition-card__title {
+  color: rgba(241, 245, 249, 0.96);
 }
 
-.exposition-card__title a:hover,
-.exposition-card__title a:focus-visible {
-  text-decoration: underline;
+.exposition-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
+.exposition-card__meta-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: rgba(71, 85, 105, 0.92);
+}
+
+[data-theme='dark'] .exposition-card__meta-item {
+  color: rgba(203, 213, 225, 0.92);
+}
+
+.exposition-card__meta-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: rgba(37, 99, 235, 0.12);
+  color: rgba(37, 99, 235, 0.95);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.18);
+}
+
+.exposition-card__meta-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+[data-theme='dark'] .exposition-card__meta-icon {
+  background: rgba(59, 130, 246, 0.15);
+  color: rgba(191, 219, 254, 0.95);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.32);
+}
 
 .exposition-card__summary {
   margin: 0;
-  color: var(--muted);
-  font-size: 13px;
-  line-height: 1.45;
+  color: rgba(71, 85, 105, 0.92);
+  font-size: 0.95rem;
+  line-height: 1.55;
 }
 
-
+[data-theme='dark'] .exposition-card__summary {
+  color: rgba(203, 213, 225, 0.9);
+}
 
 .exposition-card__tags {
   display: flex;
@@ -4040,45 +4188,39 @@ button.hero-quick-link {
   padding: 0;
 }
 
-
 .exposition-card__tag {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   padding: 6px 14px;
   border-radius: 999px;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   font-weight: 700;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  background: linear-gradient(135deg, rgba(226, 232, 240, 0.92) 0%, rgba(203, 213, 225, 0.78) 100%);
-  border: 1px solid rgba(148, 163, 184, 0.45);
-  color: rgba(30, 41, 59, 0.82);
-  box-shadow: 0 12px 22px rgba(15, 23, 42, 0.08);
+  background: rgba(37, 99, 235, 0.1);
+  color: rgba(37, 99, 235, 0.95);
+  border: 1px solid rgba(37, 99, 235, 0.2);
 }
 
 [data-theme='dark'] .exposition-card__tag {
-  background: linear-gradient(135deg, rgba(30, 41, 59, 0.88) 0%, rgba(51, 65, 85, 0.88) 100%);
-  border-color: rgba(148, 163, 184, 0.35);
-  color: rgba(226, 232, 240, 0.9);
-  box-shadow: 0 14px 26px rgba(15, 23, 42, 0.45);
+  background: rgba(59, 130, 246, 0.16);
+  color: rgba(191, 219, 254, 0.95);
+  border-color: rgba(37, 99, 235, 0.35);
 }
 
 .exposition-card__tag::before {
-  content: '';
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: currentColor;
-  opacity: 0.55;
+  content: none;
 }
 
-[data-theme='dark'] .exposition-card__tag::before {
-  opacity: 0.7;
+.exposition-card__footer {
+  margin-top: auto;
+  padding: 0 28px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
-
-.exposition-card__footer,
 .event-card__footer {
   margin-top: auto;
   padding: var(--space-16);
@@ -4087,108 +4229,8 @@ button.hero-quick-link {
   gap: var(--space-16);
 }
 
-
-.exposition-card__footer-actions {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-12);
-}
-
-@media (min-width: 640px) {
-  .exposition-card__footer-actions {
-    flex-direction: row;
-    align-items: center;
-  }
-}
-
-.exposition-card__info-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 12px 18px;
-  border-radius: 999px;
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  background: rgba(15, 23, 42, 0.96);
-  color: #f8fafc;
-  box-shadow: 0 10px 26px rgba(15, 23, 42, 0.24);
-  border: 1px solid rgba(15, 23, 42, 0.85);
-  text-decoration: none;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
-}
-
-.exposition-card__info-button:hover,
-.exposition-card__info-button:focus-visible {
-  background: rgba(15, 23, 42, 1);
-  color: #ffffff;
-  transform: translateY(-2px);
-  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.3);
-}
-
-.exposition-card__info-button:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-.exposition-card__cta {
-  width: 100%;
-  justify-content: center;
-  font-size: 13px;
-  font-weight: 600;
-  box-shadow: 0 10px 24px rgba(15,23,42,0.18);
-}
-
-.exposition-card__cta[disabled],
-.exposition-card__cta[aria-disabled='true'] {
-  box-shadow: none;
-}
-
-.exposition-card__image-credit {
-  position: absolute;
-  left: 16px;
-  bottom: 16px;
+.exposition-card__affiliate-note {
   margin: 0;
-  padding: 6px 12px;
-  border-radius: 999px;
-  background: rgba(248, 250, 252, 0.9);
-  color: rgba(15, 23, 42, 0.7);
-  backdrop-filter: blur(6px);
-  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.14);
-}
-
-.exposition-card__image-credit .image-credit-divider {
-  margin: 0 6px;
-}
-
-[data-theme='dark'] .exposition-card__image-credit {
-  background: rgba(15, 23, 42, 0.78);
-  color: rgba(226, 232, 240, 0.85);
-  box-shadow: 0 8px 22px rgba(2, 6, 23, 0.55);
-}
-
-
-.exposition-card .icon-button.large {
-  width: 32px;
-  height: 32px;
-  background: rgba(255,255,255,0.92);
-  border: 1px solid var(--panel-border);
-  box-shadow: none;
-}
-
-[data-theme='dark'] .exposition-card .icon-button.large {
-  background: rgba(148,163,184,0.18);
-  border-color: rgba(148,163,184,0.32);
-}
-
-
-.exposition-card .icon-button.large.favorited {
-  background: var(--accent);
-  color: var(--accent-ink);
-  border-color: transparent;
-  box-shadow: 0 8px 22px rgba(255,90,60,0.3);
 }
 
 .exposition-card.is-bouncing .icon-button.large {


### PR DESCRIPTION
## Summary
- redesign the exhibitions card component with a new hero overlay, share control, and metadata layout
- surface museum city, province, and opening hours data when fetching exhibitions
- refresh exhibitions styles to match the updated card visuals and spacing

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68df7bb3baf48326a77e62a9fad8c509