### PR TITLE
Group visitor information tags on museum detail page

### DIFF
--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -780,17 +780,14 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
               </div>
             )}
 
-            {resolvedMuseum.free && (
+            {(resolvedMuseum.free || isKidFriendlyMuseum) && (
               <div className="museum-info-item">
                 <span className="museum-info-label">{t('visitorInformation')}</span>
-                <p className="museum-info-value">{t('free')}</p>
-              </div>
-            )}
-
-            {isKidFriendlyMuseum && (
-              <div className="museum-info-item">
-                <span className="museum-info-label">{t('filtersKidFriendly')}</span>
-                <p className="museum-info-value">{t('tagChildFriendly')}</p>
+                <p className="museum-info-value">
+                  {[resolvedMuseum.free && t('free'), isKidFriendlyMuseum && t('tagChildFriendly')]
+                    .filter(Boolean)
+                    .join(' · ')}
+                </p>
               </div>
             )}
 


### PR DESCRIPTION
## Summary
- combine the free and child-friendly visitor information into a single entry to prevent the duplicated "Kindvriendelijk" label on museum detail pages

## Testing
- npm install *(fails: 403 Forbidden when downloading @capacitor/app)*

------
https://chatgpt.com/codex/tasks/task_e_68df9d4928cc8326bf3608d334990847