### PR TITLE
Remove gratis toegang and kindvriendelijk filters

### DIFF
--- a/components/FiltersSheet.js
+++ b/components/FiltersSheet.js
@@ -17,9 +17,7 @@ function resolveSections(sections, labels) {
       id: 'availability',
       title: labels?.availability,
       options: [
-        { name: 'free', label: labels?.free },
         { name: 'exhibitions', label: labels?.exhibitions },
-        { name: 'kidFriendly', label: labels?.kidFriendly },
         { name: 'nearby', label: labels?.distance, hidden: true },
       ],
     },


### PR DESCRIPTION
## Summary
- remove the free and kid-friendly filter options from the shared sheet component
- drop gratis/kindvriendelijk filter handling on the home page so only exhibitions and nearby remain

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3880746948326b3c5d8a92793e1ae