### PR TITLE
Remove museum exposition filters and temporary tag

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -141,14 +141,9 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
     return `${cleaned.slice(0, 157)}…`;
   }, [description]);
 
-  let temporaryTag = pickBoolean(tags.temporary, exposition?.tijdelijk, exposition?.temporary, exposition?.tijdelijkeTentoonstelling);
-  if (temporaryTag === undefined && start && end) {
-    temporaryTag = true;
-  }
   const tagDefinitions = [
     { key: 'childFriendly', label: t('tagChildFriendly'), active: pickBoolean(tags.childFriendly, exposition?.kindvriendelijk, exposition?.childFriendly, exposition?.familievriendelijk, exposition?.familyFriendly) === true },
     { key: 'free', label: t('tagFree'), active: pickBoolean(tags.free, exposition?.gratis, exposition?.free, exposition?.kosteloos, exposition?.freeEntry) === true },
-    { key: 'temporary', label: t('tagTemporary'), active: temporaryTag === true },
   ];
   const activeTags = tagDefinitions.filter((tag) => tag.active);
   const mediaClassName = 'exposition-card__media exposition-card__media--placeholder';


### PR DESCRIPTION
## Summary
- remove the exhibition filters UI and related state from the museum detail page so all expositions are shown without chips
- stop rendering the temporary exhibition tag on exposition cards

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e3ac9837dc8326a6f21775be3695fe