### PR TITLE
Prioritize affiliate ticket links for exhibitions

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -221,7 +221,8 @@ export default function MuseumCard({
   }, [museum.categories, t]);
   const hasTags = museum.free || resolvedCategories.length > 0;
   const locationText = [museum.city, museum.province].filter(Boolean).join(', ');
-  const showAffiliateNote = Boolean(museum.ticketUrl) && shouldShowAffiliateNote(museum.slug);
+  const hasAffiliateTicket = Boolean(museum.ticketAffiliateUrl);
+  const showAffiliateNote = hasAffiliateTicket && shouldShowAffiliateNote(museum.slug);
   const showOpenNowBadge =
     highlightOpenNow && openingStatus && openingStatus.state === 'open' && !openingStatus.fallback;
   const headingAutoId = useId();

--- a/pages/index.js
+++ b/pages/index.js
@@ -905,29 +905,35 @@ export default function Home({ initialMuseums = [], initialError = null }) {
           <p>{t('noResults')}</p>
         ) : (
           <ul className="grid" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-            {results.map((m, index) => (
-              <li key={m.id}>
-                <MuseumCard
-                  museum={{
-                    id: m.id,
-                    slug: m.slug,
-                    title: museumNames[m.slug] || m.naam,
-                    city: m.stad,
-                    province: m.provincie,
-                    free: m.gratis_toegankelijk,
-                    categories: Array.isArray(m.categories)
-                      ? m.categories
-                      : getMuseumCategories(m.slug),
-                    image: museumImages[m.slug] || m.afbeelding_url || m.image_url || null,
-                    imageCredit: museumImageCredits[m.slug],
-                    ticketUrl: m.ticket_affiliate_url || museumTicketUrls[m.slug] || m.website_url,
-                  }}
-                  priority={index < 6}
-                  onCategoryClick={handleCategoryFilterClick}
-                  highlightOpenNow={activeFilters.openNow}
-                />
-              </li>
-            ))}
+            {results.map((m, index) => {
+              const ticketAffiliateUrl = m.ticket_affiliate_url || museumTicketUrls[m.slug] || null;
+              const ticketUrl = ticketAffiliateUrl || m.website_url || null;
+
+              return (
+                <li key={m.id}>
+                  <MuseumCard
+                    museum={{
+                      id: m.id,
+                      slug: m.slug,
+                      title: museumNames[m.slug] || m.naam,
+                      city: m.stad,
+                      province: m.provincie,
+                      free: m.gratis_toegankelijk,
+                      categories: Array.isArray(m.categories)
+                        ? m.categories
+                        : getMuseumCategories(m.slug),
+                      image: museumImages[m.slug] || m.afbeelding_url || m.image_url || null,
+                      imageCredit: museumImageCredits[m.slug],
+                      ticketUrl,
+                      ticketAffiliateUrl,
+                    }}
+                    priority={index < 6}
+                    onCategoryClick={handleCategoryFilterClick}
+                    highlightOpenNow={activeFilters.openNow}
+                  />
+                </li>
+              );
+            })}
           </ul>
         )}
       </section>

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -329,6 +329,7 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
       image: heroImageUrl,
       imageCredit,
       ticketUrl,
+      ticketAffiliateUrl: affiliateTicketUrl,
       type: 'museum',
     }),
     [
@@ -341,6 +342,7 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
       heroImageUrl,
       imageCredit,
       ticketUrl,
+      affiliateTicketUrl,
     ]
   );
 

--- a/pages/tentoonstellingen.js
+++ b/pages/tentoonstellingen.js
@@ -195,14 +195,14 @@ function mapExhibitionToCard(exhibition, lang, t) {
   );
   const categories = ['exhibition', ...getMuseumCategories(slug)].filter(Boolean);
   const uniqueCategories = Array.from(new Set(categories));
-  const ticketUrl =
+  const affiliateTicketUrl =
     exhibition.ticket_affiliate_url ||
-    exhibition.ticket_url ||
-    exhibition.bron_url ||
     museum.ticket_affiliate_url ||
     museumTicketUrls[slug] ||
-    museum.website_url ||
     null;
+  const directTicketUrl = exhibition.ticket_url || museum.website_url || null;
+  const infoTicketUrl = exhibition.bron_url || null;
+  const ticketUrl = affiliateTicketUrl || directTicketUrl || infoTicketUrl;
 
   return {
     exhibitionId: exhibition.id,
@@ -216,6 +216,7 @@ function mapExhibitionToCard(exhibition, lang, t) {
     image: resolvedImage,
     imageCredit: museumImageCredits[slug],
     ticketUrl,
+    ticketAffiliateUrl: affiliateTicketUrl,
     summary,
     metaTag,
   };


### PR DESCRIPTION
## Summary
- ensure exhibition cards prioritise affiliate ticket URLs ahead of information pages
- surface affiliate ticket URLs to museum cards and favorite payloads so disclosures remain accurate
- update the home results mapping to keep affiliate metadata when building museum cards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3b9f4c790832684361b5353b81dd9