### PR TITLE
Reduce homepage hero vertical padding

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1013,7 +1013,8 @@ img { max-width: 100%; height: auto; display: block; }
   gap: clamp(var(--space-24), 5vw, 48px);
   align-items: center;
   margin: clamp(24px, 6vw, 64px) 0 clamp(16px, 5vw, 48px);
-  padding: clamp(var(--space-24), 6vw, var(--space-32));
+  padding: clamp(var(--space-16), 4.5vw, var(--space-24))
+    clamp(var(--space-24), 6vw, var(--space-32));
   border-radius: var(--radius-md);
   overflow: hidden;
   background: #0f172a;
@@ -1595,12 +1596,21 @@ button.hero-quick-link {
 }
 
 @media (max-width: 768px) {
-  .hero { margin-top: 20px; padding: clamp(var(--space-24), 6vw, var(--space-32)); border-radius: var(--radius-md); }
+  .hero {
+    margin-top: 20px;
+    padding: clamp(var(--space-16), 5vw, var(--space-24))
+      clamp(var(--space-24), 6vw, var(--space-32));
+    border-radius: var(--radius-md);
+  }
   .hero-card { border-radius: var(--radius-md); }
 }
 
 @media (max-width: 600px) {
-  .hero { gap: var(--space-24); padding: var(--space-24); border-radius: var(--radius-md); }
+  .hero {
+    gap: var(--space-24);
+    padding: clamp(var(--space-16), 6vw, var(--space-24)) var(--space-24);
+    border-radius: var(--radius-md);
+  }
   .hero::before { background-position: center 46%; }
   .hero-card { padding: var(--space-16); }
   .hero-content {


### PR DESCRIPTION
## Summary
- reduce the homepage hero's vertical padding so more content appears above the fold
- align tablet and mobile hero padding with the tighter vertical spacing

## Testing
- npm run dev -- --hostname 0.0.0.0 --port 3000 *(fails: `next` binary unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e61c0e1c708326bb642054e2805554