### PR TITLE
Switch home OG image to SVG asset

### DIFF
--- a/components/SEO.js
+++ b/components/SEO.js
@@ -27,11 +27,21 @@ function resolveCanonical(customCanonical, baseUrl, fallbackPath) {
   return toAbsoluteUrl(baseUrl, customCanonical);
 }
 
+function resolveImageUrl(image, baseUrl) {
+  if (!image) return null;
+  if (/^https?:\/\//i.test(image)) {
+    return image;
+  }
+  const normalizedPath = image.startsWith('/') ? image : `/${image}`;
+  return `${baseUrl}${normalizedPath}`;
+}
+
 export default function SEO({ title, description, image, canonical }) {
   const { asPath } = useRouter();
   const pathname = stripQueryAndHash(asPath || '/');
   const url = toAbsoluteUrl(SITE_URL, pathname);
   const canonicalUrl = resolveCanonical(canonical, SITE_URL, pathname);
+  const ogImage = resolveImageUrl(image, SITE_URL);
 
   return (
     <Head>
@@ -41,11 +51,11 @@ export default function SEO({ title, description, image, canonical }) {
       {title && <meta property="og:title" content={title} />}
       {description && <meta property="og:description" content={description} />}
       <meta property="og:url" content={url} />
-      {image && <meta property="og:image" content={image} />}
+      {ogImage && <meta property="og:image" content={ogImage} />}
       <meta name="twitter:card" content="summary_large_image" />
       {title && <meta name="twitter:title" content={title} />}
       {description && <meta name="twitter:description" content={description} />}
-      {image && <meta name="twitter:image" content={image} />}
+      {ogImage && <meta name="twitter:image" content={ogImage} />}
       <link rel="canonical" href={canonicalUrl} />
     </Head>
   );

--- a/pages/index.js
+++ b/pages/index.js
@@ -755,7 +755,12 @@ export default function Home({ initialMuseums = [], initialError = null }) {
   if (error) {
     return (
       <>
-        <SEO title={t('homeTitle')} description={t('homeDescription')} />
+        <SEO
+          title={t('homeTitle')}
+          description={t('homeDescription')}
+          canonical="/"
+          image="/images/og-home.svg"
+        />
         <main className="container" style={{ maxWidth: 800 }}>
           <p>{t('somethingWrong')}</p>
         </main>
@@ -765,7 +770,12 @@ export default function Home({ initialMuseums = [], initialError = null }) {
 
   return (
     <>
-      <SEO title={t('homeTitle')} description={t('homeDescription')} />
+      <SEO
+        title={t('homeTitle')}
+        description={t('homeDescription')}
+        canonical="/"
+        image="/images/og-home.svg"
+      />
       <FiltersSheet
         open={filtersSheetOpen}
         filters={sheetFilters}

--- a/pages/tentoonstellingen.js
+++ b/pages/tentoonstellingen.js
@@ -537,7 +537,12 @@ export default function ExhibitionsPage({ exhibitions = [], error = null }) {
 
   return (
     <>
-      <SEO title={t('exhibitionsPageTitle')} description={t('exhibitionsPageDescription')} />
+      <SEO
+        title={t('exhibitionsPageTitle')}
+        description={t('exhibitionsPageDescription')}
+        canonical="/tentoonstellingen"
+        image="/images/og-exhibitions.svg"
+      />
       <section className="page-intro" aria-labelledby="exhibitions-heading">
         <h1 id="exhibitions-heading" className="page-title">
           {t('exhibitionsPageHeading')}

--- a/public/images/og-exhibitions.svg
+++ b/public/images/og-exhibitions.svg
@@ -1,0 +1,24 @@
+<svg width="1024" height="1024" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Tentoonstelling tijdelijke afbeelding</title>
+  <desc id="desc">Diepblauwe verloopachtergrond met subtiel kader als tijdelijke afbeelding voor een tentoonstelling.</desc>
+  <defs>
+    <linearGradient id="background" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#304458" />
+      <stop offset="45%" stop-color="#223142" />
+      <stop offset="100%" stop-color="#141c28" />
+    </linearGradient>
+    <linearGradient id="gloss" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.12" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </linearGradient>
+    <radialGradient id="vignette" cx="50%" cy="45%" r="70%">
+      <stop offset="0%" stop-color="#000000" stop-opacity="0" />
+      <stop offset="75%" stop-color="#000000" stop-opacity="0.22" />
+      <stop offset="100%" stop-color="#000000" stop-opacity="0.35" />
+    </radialGradient>
+  </defs>
+  <rect width="1024" height="1024" fill="url(#background)" rx="64" />
+  <rect x="32" y="32" width="960" height="960" rx="56" fill="none" stroke="#243243" stroke-width="4" />
+  <rect x="32" y="32" width="960" height="960" rx="56" fill="url(#gloss)" opacity="0.18" />
+  <rect width="1024" height="1024" fill="url(#vignette)" rx="64" />
+</svg>

--- a/public/images/og-home.svg
+++ b/public/images/og-home.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="ogHomeTitle ogHomeDescription">
+  <title id="ogHomeTitle">MuseumBuddy Amsterdam musea</title>
+  <desc id="ogHomeDescription">Verloopachtergrond met titelkaart voor MuseumBuddy.</desc>
+  <defs>
+    <linearGradient id="homeGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1e3a8a" />
+      <stop offset="50%" stop-color="#312e81" />
+      <stop offset="100%" stop-color="#020617" />
+    </linearGradient>
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f8fafc" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#cbd5f5" stop-opacity="0.7" />
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-20%" width="120%" height="160%">
+      <feDropShadow dx="0" dy="20" stdDeviation="30" flood-color="rgba(15,23,42,0.4)" />
+    </filter>
+  </defs>
+  <rect width="1200" height="630" fill="url(#homeGradient)" rx="48" />
+  <g transform="translate(120 120)">
+    <rect width="960" height="390" rx="36" fill="url(#cardGradient)" filter="url(#shadow)" />
+    <g transform="translate(72 96)">
+      <text font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="56" font-weight="700" fill="#111827">
+        MuseumBuddy
+      </text>
+      <text y="96" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="36" font-weight="600" fill="#1e293b">
+        Ontdek Amsterdamse musea en tentoonstellingen
+      </text>
+      <text y="168" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="28" fill="#334155">
+        Plan je museumdag met actuele highlights, openingstijden en favorieten.
+      </text>
+    </g>
+  </g>
+  <rect width="1200" height="630" rx="48" fill="none" stroke="rgba(248,250,252,0.18)" stroke-width="4" />
+</svg>


### PR DESCRIPTION
## Summary
- update the homepage SEO configuration to use a text-based SVG OG image
- add an accessible SVG illustration for the home OG image and remove the prior binary JPG asset

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e627a83c2883268fe389472f93813f