### PR TITLE
Ensure exhibitions use Dutch date ranges

### DIFF
--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -5,7 +5,7 @@ import { useFavorites } from './FavoritesContext';
 import { shouldShowAffiliateNote } from '../lib/nonAffiliateMuseums';
 import createBlurDataUrl from '../lib/createBlurDataUrl';
 import TicketButtonNote from './TicketButtonNote';
-import { formatDutchDateRange } from '../lib/formatDateRange';
+import { formatDateRange } from '../lib/formatDateRange';
 
 function pickBoolean(...values) {
   for (const value of values) {
@@ -47,9 +47,9 @@ export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, mu
   if (!exposition) return null;
 
   const description = typeof exposition.description === 'string' ? exposition.description.trim() : '';
-  const { t } = useLanguage();
+  const { t, lang } = useLanguage();
   const { favorites, toggleFavorite } = useFavorites();
-  const rangeLabel = formatDutchDateRange(exposition.start_datum, exposition.eind_datum);
+  const rangeLabel = formatDateRange(exposition.start_datum, exposition.eind_datum, { language: lang });
   const isFavorite = favorites.some((f) => f.id === exposition.id && f.type === 'exposition');
   const slug = museumSlug || exposition.museumSlug;
   const primaryAffiliateUrl = exposition.ticketAffiliateUrl || affiliateUrl || null;

--- a/components/ExpositionCard.js
+++ b/components/ExpositionCard.js
@@ -5,23 +5,7 @@ import { useFavorites } from './FavoritesContext';
 import { shouldShowAffiliateNote } from '../lib/nonAffiliateMuseums';
 import createBlurDataUrl from '../lib/createBlurDataUrl';
 import TicketButtonNote from './TicketButtonNote';
-
-function formatRange(start, end, locale) {
-  if (!start) return '';
-  const opts = { day: '2-digit', month: 'short' };
-  const startFmt = start.toLocaleDateString(locale, opts).toUpperCase();
-  if (!end) return startFmt;
-  const endFmt = end.toLocaleDateString(locale, opts).toUpperCase();
-  const sameMonth = start.getMonth() === end.getMonth() && start.getFullYear() === end.getFullYear();
-  if (sameMonth) {
-    const month = startFmt.split(' ')[1];
-    return `${start.getDate().toString().padStart(2, '0')} - ${end
-      .getDate()
-      .toString()
-      .padStart(2, '0')} ${month}`;
-  }
-  return `${startFmt} - ${endFmt}`;
-}
+import { formatDutchDateRange } from '../lib/formatDateRange';
 
 function pickBoolean(...values) {
   for (const value of values) {
@@ -62,13 +46,10 @@ function getPlaceholderImage(exposition) {
 export default function ExpositionCard({ exposition, ticketUrl, affiliateUrl, museumSlug, tags = {} }) {
   if (!exposition) return null;
 
-  const start = exposition.start_datum ? new Date(exposition.start_datum + 'T00:00:00') : null;
-  const end = exposition.eind_datum ? new Date(exposition.eind_datum + 'T00:00:00') : null;
   const description = typeof exposition.description === 'string' ? exposition.description.trim() : '';
-  const { lang, t } = useLanguage();
+  const { t } = useLanguage();
   const { favorites, toggleFavorite } = useFavorites();
-  const locale = lang === 'en' ? 'en-US' : 'nl-NL';
-  const rangeLabel = formatRange(start, end, locale);
+  const rangeLabel = formatDutchDateRange(exposition.start_datum, exposition.eind_datum);
   const isFavorite = favorites.some((f) => f.id === exposition.id && f.type === 'exposition');
   const slug = museumSlug || exposition.museumSlug;
   const primaryAffiliateUrl = exposition.ticketAffiliateUrl || affiliateUrl || null;

--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -54,7 +54,7 @@ function parseTime(value) {
 
 function getLocalMinutes(timeZone = LOCAL_TIME_ZONE) {
   try {
-    const formatter = new Intl.DateTimeFormat('en-GB', {
+    const formatter = new Intl.DateTimeFormat('nl-NL', {
       timeZone,
       hour: '2-digit',
       minute: '2-digit',

--- a/lib/formatDateRange.js
+++ b/lib/formatDateRange.js
@@ -1,0 +1,114 @@
+const DUTCH_LOCALE = 'nl-NL';
+
+function normaliseDate(value) {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const isoDate = new Date(`${trimmed}T00:00:00`);
+    if (!Number.isNaN(isoDate.getTime())) {
+      return isoDate;
+    }
+    const parsed = new Date(trimmed);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function formatLabel(date, includeYear = false) {
+  const formatter = new Intl.DateTimeFormat(DUTCH_LOCALE, {
+    day: 'numeric',
+    month: 'short',
+    ...(includeYear ? { year: 'numeric' } : {}),
+  });
+
+  const parts = formatter.formatToParts(date);
+  const dayPart = parts.find((part) => part.type === 'day');
+  const monthPart = parts.find((part) => part.type === 'month');
+  const yearPart = parts.find((part) => part.type === 'year');
+
+  if (!dayPart || !monthPart) {
+    return '';
+  }
+
+  const day = Number.parseInt(dayPart.value, 10).toString();
+  const month = (monthPart.value || '').toLowerCase();
+
+  if (!month) {
+    return '';
+  }
+
+  let label = `${day} ${month}`;
+
+  if (includeYear && yearPart?.value) {
+    label = `${label} ${yearPart.value}`;
+  }
+
+  return label;
+}
+
+export function formatDutchDate(dateInput, { includeYear, currentDate = new Date() } = {}) {
+  const date = normaliseDate(dateInput);
+  if (!date) {
+    return '';
+  }
+
+  let needsYear;
+  if (typeof includeYear === 'boolean') {
+    needsYear = includeYear;
+  } else {
+    const referenceYear =
+      currentDate instanceof Date && !Number.isNaN(currentDate.getTime())
+        ? currentDate.getFullYear()
+        : new Date().getFullYear();
+    needsYear = date.getFullYear() !== referenceYear;
+  }
+
+  return formatLabel(date, needsYear);
+}
+
+export function formatDutchDateRange(startInput, endInput, { currentDate = new Date() } = {}) {
+  const startDate = normaliseDate(startInput);
+  if (!startDate) {
+    return '';
+  }
+
+  const endDate = normaliseDate(endInput);
+  const referenceYear =
+    currentDate instanceof Date && !Number.isNaN(currentDate.getTime())
+      ? currentDate.getFullYear()
+      : new Date().getFullYear();
+
+  const startYear = startDate.getFullYear();
+  const endYear = endDate ? endDate.getFullYear() : startYear;
+
+  const startNeedsYear = endDate ? startYear !== endYear : startYear !== referenceYear;
+  const endNeedsYear = endDate
+    ? startYear !== endYear || endYear !== referenceYear
+    : startNeedsYear;
+
+  const startLabel = formatLabel(startDate, startNeedsYear);
+  if (!startLabel) {
+    return '';
+  }
+
+  if (!endDate) {
+    return startLabel;
+  }
+
+  const endLabel = formatLabel(endDate, endNeedsYear);
+  if (!endLabel) {
+    return startLabel;
+  }
+
+  return `${startLabel} – ${endLabel}`;
+}
+
+export default formatDutchDateRange;

--- a/lib/formatDateRange.js
+++ b/lib/formatDateRange.js
@@ -1,4 +1,24 @@
-const DUTCH_LOCALE = 'nl-NL';
+const LANGUAGE_CONFIG = {
+  nl: {
+    locale: 'nl-NL',
+    transformMonth: (value) => value.toLowerCase(),
+  },
+  en: {
+    locale: 'en-GB',
+    transformMonth: (value) => {
+      if (!value) return value;
+      const lower = value.toLowerCase();
+      return lower.charAt(0).toUpperCase() + lower.slice(1);
+    },
+  },
+};
+
+function getLanguageConfig(language) {
+  if (language && LANGUAGE_CONFIG[language]) {
+    return LANGUAGE_CONFIG[language];
+  }
+  return LANGUAGE_CONFIG.nl;
+}
 
 function normaliseDate(value) {
   if (!value) return null;
@@ -22,8 +42,8 @@ function normaliseDate(value) {
   return null;
 }
 
-function formatLabel(date, includeYear = false) {
-  const formatter = new Intl.DateTimeFormat(DUTCH_LOCALE, {
+function formatLabel(date, includeYear = false, { locale, transformMonth }) {
+  const formatter = new Intl.DateTimeFormat(locale, {
     day: 'numeric',
     month: 'short',
     ...(includeYear ? { year: 'numeric' } : {}),
@@ -39,7 +59,8 @@ function formatLabel(date, includeYear = false) {
   }
 
   const day = Number.parseInt(dayPart.value, 10).toString();
-  const month = (monthPart.value || '').toLowerCase();
+  const rawMonth = monthPart.value || '';
+  const month = typeof transformMonth === 'function' ? transformMonth(rawMonth) : rawMonth;
 
   if (!month) {
     return '';
@@ -54,11 +75,17 @@ function formatLabel(date, includeYear = false) {
   return label;
 }
 
-export function formatDutchDate(dateInput, { includeYear, currentDate = new Date() } = {}) {
+export function formatDate(dateInput, {
+  includeYear,
+  currentDate = new Date(),
+  language,
+} = {}) {
   const date = normaliseDate(dateInput);
   if (!date) {
     return '';
   }
+
+  const languageConfig = getLanguageConfig(language);
 
   let needsYear;
   if (typeof includeYear === 'boolean') {
@@ -71,16 +98,20 @@ export function formatDutchDate(dateInput, { includeYear, currentDate = new Date
     needsYear = date.getFullYear() !== referenceYear;
   }
 
-  return formatLabel(date, needsYear);
+  return formatLabel(date, needsYear, languageConfig);
 }
 
-export function formatDutchDateRange(startInput, endInput, { currentDate = new Date() } = {}) {
+export function formatDateRange(startInput, endInput, {
+  currentDate = new Date(),
+  language,
+} = {}) {
   const startDate = normaliseDate(startInput);
   if (!startDate) {
     return '';
   }
 
   const endDate = normaliseDate(endInput);
+  const languageConfig = getLanguageConfig(language);
   const referenceYear =
     currentDate instanceof Date && !Number.isNaN(currentDate.getTime())
       ? currentDate.getFullYear()
@@ -94,7 +125,7 @@ export function formatDutchDateRange(startInput, endInput, { currentDate = new D
     ? startYear !== endYear || endYear !== referenceYear
     : startNeedsYear;
 
-  const startLabel = formatLabel(startDate, startNeedsYear);
+  const startLabel = formatLabel(startDate, startNeedsYear, languageConfig);
   if (!startLabel) {
     return '';
   }
@@ -103,12 +134,28 @@ export function formatDutchDateRange(startInput, endInput, { currentDate = new D
     return startLabel;
   }
 
-  const endLabel = formatLabel(endDate, endNeedsYear);
+  const endLabel = formatLabel(endDate, endNeedsYear, languageConfig);
   if (!endLabel) {
     return startLabel;
   }
 
   return `${startLabel} – ${endLabel}`;
+}
+
+export function formatDutchDate(dateInput, options = {}) {
+  return formatDate(dateInput, { ...options, language: 'nl' });
+}
+
+export function formatDutchDateRange(startInput, endInput, options = {}) {
+  return formatDateRange(startInput, endInput, { ...options, language: 'nl' });
+}
+
+export function formatEnglishDate(dateInput, options = {}) {
+  return formatDate(dateInput, { ...options, language: 'en' });
+}
+
+export function formatEnglishDateRange(startInput, endInput, options = {}) {
+  return formatDateRange(startInput, endInput, { ...options, language: 'en' });
 }
 
 export default formatDutchDateRange;

--- a/lib/openingHours.js
+++ b/lib/openingHours.js
@@ -16,7 +16,7 @@ function parseTime(value) {
 
 export function getLocalMinutes(timeZone = DEFAULT_TIME_ZONE) {
   try {
-    const formatter = new Intl.DateTimeFormat('en-GB', {
+    const formatter = new Intl.DateTimeFormat('nl-NL', {
       timeZone,
       hour: '2-digit',
       minute: '2-digit',

--- a/pages/tentoonstellingen.js
+++ b/pages/tentoonstellingen.js
@@ -12,7 +12,7 @@ import { supabase as supabaseClient } from '../lib/supabase';
 import Button from '../components/ui/Button';
 import parseBooleanParam from '../lib/parseBooleanParam.js';
 import { isMuseumOpenNow } from '../lib/openingHours.js';
-import { formatDutchDateRange } from '../lib/formatDateRange';
+import { formatDateRange } from '../lib/formatDateRange';
 
 const FILTERS_EVENT = 'museumBuddy:openFilters';
 
@@ -127,7 +127,7 @@ function pickImage(row, museum) {
   return null;
 }
 
-function mapExhibitionToCard(exhibition, t) {
+function mapExhibitionToCard(exhibition, t, language) {
   if (!exhibition?.museum || !exhibition.museum.slug) {
     return null;
   }
@@ -139,7 +139,9 @@ function mapExhibitionToCard(exhibition, t) {
   const titleBase = museumName
     ? t('exhibitionsListCardTitle', { exhibition: exhibitionTitle, museum: museumName })
     : exhibitionTitle;
-  const rangeLabel = formatDutchDateRange(exhibition.start_datum, exhibition.eind_datum);
+  const rangeLabel = formatDateRange(exhibition.start_datum, exhibition.eind_datum, {
+    language,
+  });
   const descriptionText = truncate(
     exhibition.beschrijving || exhibition.omschrijving || exhibition.description || ''
   );
@@ -435,15 +437,15 @@ async function loadExhibitionsForStaticProps() {
 }
 
 export default function ExhibitionsPage({ exhibitions = [], error = null }) {
-  const { t } = useLanguage();
+  const { t, lang } = useLanguage();
   const router = useRouter();
 
   const allCards = useMemo(
     () =>
       (Array.isArray(exhibitions) ? exhibitions : [])
-        .map((exhibition) => mapExhibitionToCard(exhibition, t))
+        .map((exhibition) => mapExhibitionToCard(exhibition, t, lang))
         .filter(Boolean),
-    [exhibitions, t]
+    [exhibitions, t, lang]
   );
 
   const openNowActive = useMemo(() => {


### PR DESCRIPTION
## Summary
- add a shared formatter that outputs Dutch date labels with lowercase month names and en dashes
- use the shared formatter in exhibition cards and listings to eliminate uppercase slider dates
- align time formatting helpers to rely on the Dutch locale for consistency

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e62a19c7ac8326bd3830ccff225ef5