### PR TITLE
Add analytics tracking for key interactions

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -1,0 +1,91 @@
+const AnalyticsEvent = {
+  CARD_CLICK: 'card_click',
+  TICKETS_CLICK: 'tickets_click',
+  CTA_EXHIBITIONS: 'cta_exhibitions',
+  FAVORITE_ADD: 'favorite_add',
+};
+
+function sanitizeData(data) {
+  if (!data || typeof data !== 'object') {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(data).filter(([, value]) => value !== undefined && value !== null)
+  );
+}
+
+function trackWithPlausible(eventName, payload) {
+  const plausible = typeof window !== 'undefined' ? window.plausible : null;
+  if (typeof plausible !== 'function') {
+    return;
+  }
+
+  const args = [eventName];
+  if (payload && Object.keys(payload).length > 0) {
+    args.push({ props: payload });
+  }
+
+  try {
+    plausible(...args);
+  } catch (error) {
+    // Swallow analytics errors so they never impact UX
+  }
+}
+
+function trackWithUmami(eventName, payload) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const umami = window.umami;
+  if (typeof umami === 'function') {
+    try {
+      umami(eventName, payload);
+    } catch (error) {
+      // ignore
+    }
+    return;
+  }
+
+  if (umami && typeof umami.track === 'function') {
+    try {
+      umami.track(eventName, payload);
+    } catch (error) {
+      // ignore
+    }
+  }
+}
+
+export function trackEvent(eventName, data = {}) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (!eventName || typeof eventName !== 'string') {
+    return;
+  }
+
+  const payload = sanitizeData(data);
+
+  trackWithPlausible(eventName, payload);
+  trackWithUmami(eventName, payload);
+}
+
+export function trackCardClick(data = {}) {
+  trackEvent(AnalyticsEvent.CARD_CLICK, data);
+}
+
+export function trackTicketsClick(data = {}) {
+  trackEvent(AnalyticsEvent.TICKETS_CLICK, data);
+}
+
+export function trackCtaExhibitions(data = {}) {
+  trackEvent(AnalyticsEvent.CTA_EXHIBITIONS, data);
+}
+
+export function trackFavoriteAdd(data = {}) {
+  trackEvent(AnalyticsEvent.FAVORITE_ADD, data);
+}
+
+export { AnalyticsEvent };

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import Script from 'next/script';
 import '../styles/globals.css';
 import Layout from '../components/Layout';
 import { FavoritesProvider } from '../components/FavoritesContext';
@@ -9,6 +10,24 @@ const fontStylesheetHref =
 const tailwindCdnHref = 'https://cdn.jsdelivr.net/npm/tailwindcss@3.4.10/dist/tailwind.min.css';
 
 export default function MyApp({ Component, pageProps }) {
+  const plausibleDomain = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN;
+  const plausibleSrc = process.env.NEXT_PUBLIC_PLAUSIBLE_SRC || 'https://plausible.io/js/script.js';
+  const plausibleApiHost = process.env.NEXT_PUBLIC_PLAUSIBLE_API_HOST;
+
+  const umamiWebsiteId = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID;
+  const umamiSrc = process.env.NEXT_PUBLIC_UMAMI_SRC;
+  const umamiDataHost = process.env.NEXT_PUBLIC_UMAMI_DATA_HOST;
+
+  const plausibleProps = {};
+  if (plausibleApiHost) {
+    plausibleProps['data-api'] = plausibleApiHost;
+  }
+
+  const umamiProps = {};
+  if (umamiDataHost) {
+    umamiProps['data-host-url'] = umamiDataHost;
+  }
+
   return (
     <LanguageProvider>
       <FavoritesProvider>
@@ -23,6 +42,22 @@ export default function MyApp({ Component, pageProps }) {
             <link rel="stylesheet" href={tailwindCdnHref} />
           </noscript>
         </Head>
+        {plausibleDomain ? (
+          <Script
+            strategy="afterInteractive"
+            data-domain={plausibleDomain}
+            src={plausibleSrc}
+            {...plausibleProps}
+          />
+        ) : null}
+        {umamiWebsiteId && umamiSrc ? (
+          <Script
+            strategy="afterInteractive"
+            src={umamiSrc}
+            data-website-id={umamiWebsiteId}
+            {...umamiProps}
+          />
+        ) : null}
         <Layout>
           <Component {...pageProps} />
         </Layout>

--- a/pages/index.js
+++ b/pages/index.js
@@ -23,6 +23,7 @@ import { parseMuseumSearchQuery } from '../lib/museumSearch';
 import Button from '../components/ui/Button';
 import parseBooleanParam from '../lib/parseBooleanParam.js';
 import { DEFAULT_TIME_ZONE } from '../lib/openingHours.js';
+import { trackCtaExhibitions, trackTicketsClick } from '../lib/analytics';
 
 const FEATURED_SLUGS = [
   'van-gogh-museum-amsterdam',
@@ -120,7 +121,7 @@ const NEARBY_RPC_NAME = 'musea_within_radius';
 const NEARBY_RADIUS_METERS = 5000;
 
 export default function Home({ initialMuseums = [], initialError = null }) {
-  const { t } = useLanguage();
+  const { t, lang } = useLanguage();
   const router = useRouter();
   const museumnachtBlurDataURL = useMemo(() => createBlurDataUrl('#1e293b'), []);
 
@@ -819,6 +820,12 @@ export default function Home({ initialMuseums = [], initialError = null }) {
               variant="secondary"
               className="hero-cta-button hero-cta-button--secondary"
               prefetch
+              onClick={() =>
+                trackCtaExhibitions({
+                  location: 'hero',
+                  language: lang,
+                })
+              }
             >
               {t('heroViewExhibitions')}
             </Button>
@@ -899,6 +906,13 @@ export default function Home({ initialMuseums = [], initialError = null }) {
             href="https://museumnacht.amsterdam/tickets"
             target="_blank"
             rel="noopener noreferrer"
+            onClick={() =>
+              trackTicketsClick({
+                location: 'museumnacht',
+                language: lang,
+                url: 'https://museumnacht.amsterdam/tickets',
+              })
+            }
           >
             {t('buyTickets')}
           </a>


### PR DESCRIPTION
## Summary
- add a shared analytics helper that reports to Plausible or Umami when available
- load Plausible and Umami scripts when configured and wire up CTA, card, ticket, and favourite interactions to fire events
- record tickets clicks across museum, exposition, and homepage surfaces including Museumnacht CTA

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e63383f7e48326b1893b7abd00ada3