### PR TITLE
Improve favorites exposition layout

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3498,6 +3498,33 @@ button.hero-quick-link {
   padding: 0;
   display: grid;
   gap: var(--space-24);
+  grid-template-columns: 1fr;
+}
+
+.events-list > li {
+  height: 100%;
+}
+
+.events-list > li .exposition-card {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.events-list > li .exposition-card__body {
+  flex-grow: 1;
+}
+
+@media (min-width: 640px) {
+  .events-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .events-list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 
 .exposition-carousel {


### PR DESCRIPTION
## Summary
- update the favorites exhibitions list layout to use a responsive grid
- stretch exposition cards so they align with other favorites

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e63a21f898832689177245957f40a7