### PR TITLE
Adjust mobile navigation language toggle placement

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -88,6 +88,8 @@ export default function Layout({ children }) {
               >
                 {t('favoritesLabel')}
               </NavLink>
+            </NavSection>
+            <NavSection className="ds-nav__section--lang">
               <Button
                 variant="ghost"
                 tone="brand"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -687,6 +687,10 @@ img { max-width: 100%; height: auto; display: block; }
     min-width: 0;
   }
 
+  .ds-nav__section--lang {
+    order: -1;
+  }
+
   .ds-nav__section--actions .ds-nav__link,
   .ds-nav__section--actions .ds-nav__link--button,
   .ds-nav__section--actions .ds-button {


### PR DESCRIPTION
## Summary
- move the language switch into its own navigation section
- reorder the mobile navigation so the language toggle stays at the leading edge

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68f5ff94d36083268109c9397315f505