### PR TITLE
Enable static exhibition fallback on museum detail pages

### DIFF
--- a/lib/staticExhibitions.js
+++ b/lib/staticExhibitions.js
@@ -117,6 +117,7 @@ const STATIC_EXHIBITIONS = STATIC_EXHIBITIONS_SOURCE.map((entry) => {
 
   return {
     id: entry.id,
+    museumSlug: entry.museumSlug || museum?.slug || null,
     titel: entry.titel || fallbackTitle,
     start_datum: entry.start_datum || null,
     eind_datum: entry.eind_datum || null,
@@ -143,6 +144,26 @@ export function getStaticExhibitions() {
     ...exhibition,
     museum: exhibition.museum ? { ...exhibition.museum } : null,
   }));
+}
+
+export function getStaticExhibitionsByMuseumSlug(slug) {
+  if (!slug) {
+    return [];
+  }
+
+  const normalisedSlug = String(slug).trim().toLowerCase();
+  if (!normalisedSlug) {
+    return [];
+  }
+
+  return getStaticExhibitions().filter((exhibition) => {
+    if (!exhibition) return false;
+    if (exhibition.museumSlug) {
+      return exhibition.museumSlug === normalisedSlug;
+    }
+    const museumSlug = exhibition.museum?.slug;
+    return typeof museumSlug === 'string' && museumSlug.toLowerCase() === normalisedSlug;
+  });
 }
 
 export default STATIC_EXHIBITIONS;

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -21,6 +21,7 @@ import { shouldShowAffiliateNote } from '../../lib/nonAffiliateMuseums';
 import kidFriendlyMuseums, { isKidFriendly as resolveKidFriendly } from '../../lib/kidFriendlyMuseums';
 import { trackFavoriteAdd, trackTicketsClick } from '../../lib/analytics';
 import { getStaticMuseumBySlug, getStaticMuseums } from '../../lib/staticMuseums';
+import { getStaticExhibitionsByMuseumSlug } from '../../lib/staticExhibitions';
 
 function todayYMD(tz = 'Europe/Amsterdam') {
   try {
@@ -1030,6 +1031,7 @@ export async function getStaticProps({ params }) {
   }
 
   const fallbackStaticRow = getStaticMuseumBySlug(slug);
+  const fallbackExpositions = getStaticExhibitionsByMuseumSlug(slug);
 
   if (!supabaseClient) {
     if (!fallbackStaticRow) {
@@ -1040,7 +1042,7 @@ export async function getStaticProps({ params }) {
       props: {
         error: null,
         museum,
-        expositions: [],
+        expositions: fallbackExpositions,
       },
     };
   }
@@ -1059,7 +1061,7 @@ export async function getStaticProps({ params }) {
           props: {
             error: null,
             museum,
-            expositions: [],
+            expositions: fallbackExpositions,
           },
         };
       }
@@ -1082,7 +1084,7 @@ export async function getStaticProps({ params }) {
           props: {
             error: null,
             museum,
-            expositions: [],
+            expositions: fallbackExpositions,
           },
         };
       }
@@ -1108,10 +1110,12 @@ export async function getStaticProps({ params }) {
       expoRows = expoData;
     }
 
+    const resolvedExpositions = expoRows.length > 0 ? expoRows : fallbackExpositions;
+
     return {
       props: {
         museum,
-        expositions: expoRows,
+        expositions: resolvedExpositions,
         error: null,
       },
     };
@@ -1122,7 +1126,7 @@ export async function getStaticProps({ params }) {
         props: {
           error: null,
           museum,
-          expositions: [],
+          expositions: fallbackExpositions,
         },
       };
     }


### PR DESCRIPTION
## Summary
- add a helper to retrieve static exhibition data by museum slug
- ensure museum detail pages use static exhibitions whenever Supabase data is unavailable or empty

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f65680da50832689ee3e20f438bcd2