### PR TITLE
Remove Museumnacht banner from homepage

### DIFF
--- a/lib/translations.js
+++ b/lib/translations.js
@@ -13,9 +13,6 @@ const translations = {
     exhibitionsPageSubtitle: 'See what is on view across Amsterdam museums right now.',
     exhibitionsListHostedBy: 'At {museum}',
     exhibitionsListCardTitle: '{exhibition} — {museum}',
-    museumnachtTag: 'Special event',
-    museumnachtHeading: 'Museumnacht 2025',
-    museumnachtSubtitle: 'Experience the city\'s museums after dark.',
     homeValueTag: 'Why MuseumBuddy',
     homeValueHeading: 'Plan smarter, explore deeper',
     homeValueSubheading:
@@ -194,9 +191,6 @@ const translations = {
     exhibitionsPageSubtitle: 'Zie wat er nu in de Amsterdamse musea te zien is.',
     exhibitionsListHostedBy: 'Te zien in {museum}',
     exhibitionsListCardTitle: '{exhibition} — {museum}',
-    museumnachtTag: 'Speciale avond',
-    museumnachtHeading: 'Museumnacht 2025',
-    museumnachtSubtitle: 'Beleef Amsterdamse musea na sluitingstijd.',
     homeValueTag: 'Waarom MuseumBuddy',
     homeValueHeading: 'Plan slimmer, beleef meer',
     homeValueSubheading:

--- a/pages/index.js
+++ b/pages/index.js
@@ -8,7 +8,6 @@ import museumImages from '../lib/museumImages';
 import museumNames from '../lib/museumNames';
 import museumImageCredits from '../lib/museumImageCredits';
 import museumTicketUrls from '../lib/museumTicketUrls';
-import createBlurDataUrl from '../lib/createBlurDataUrl';
 import { useLanguage } from '../components/LanguageContext';
 import { supabase as supabaseClient } from '../lib/supabase';
 import SEO from '../components/SEO';
@@ -23,7 +22,7 @@ import { parseMuseumSearchQuery } from '../lib/museumSearch';
 import Button from '../components/ui/Button';
 import parseBooleanParam from '../lib/parseBooleanParam.js';
 import { DEFAULT_TIME_ZONE } from '../lib/openingHours.js';
-import { trackCtaExhibitions, trackTicketsClick } from '../lib/analytics';
+import { trackCtaExhibitions } from '../lib/analytics';
 import { getStaticMuseums } from '../lib/staticMuseums';
 
 const FEATURED_SLUGS = [
@@ -124,7 +123,6 @@ const NEARBY_RADIUS_METERS = 5000;
 export default function Home({ initialMuseums = [], initialError = null }) {
   const { t, lang } = useLanguage();
   const router = useRouter();
-  const museumnachtBlurDataURL = useMemo(() => createBlurDataUrl('#1e293b'), []);
 
   const qFromUrl = useMemo(() => {
     const q = router.query?.q;
@@ -981,43 +979,6 @@ export default function Home({ initialMuseums = [], initialError = null }) {
             )}
           </div>
         </form>
-      </section>
-
-      <section className="secondary-hero" aria-labelledby="museumnacht-hero-heading">
-        <Image
-          src="/images/Museumnacht.jpg"
-          alt="Museumnacht Amsterdam visitors enjoying exhibitions"
-          fill
-          className="secondary-hero__image"
-          sizes="(min-width: 768px) 80vw, 100vw"
-          placeholder="blur"
-          blurDataURL={museumnachtBlurDataURL}
-          priority={false}
-          style={{ objectFit: 'cover' }}
-        />
-        <div className="secondary-hero__overlay" aria-hidden="true" />
-        <div className="secondary-hero__content">
-          <p className="secondary-hero__tag">{t('museumnachtTag')}</p>
-          <h2 id="museumnacht-hero-heading" className="secondary-hero__title">
-            {t('museumnachtHeading')}
-          </h2>
-          <p className="secondary-hero__subtitle">{t('museumnachtSubtitle')}</p>
-          <a
-            className="ticket-button secondary-hero__cta"
-            href="https://museumnacht.amsterdam/tickets"
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() =>
-              trackTicketsClick({
-                location: 'museumnacht',
-                language: lang,
-                url: 'https://museumnacht.amsterdam/tickets',
-              })
-            }
-          >
-            {t('buyTickets')}
-          </a>
-        </div>
       </section>
 
       <section id="museum-results" ref={resultsRef} className="results-section">


### PR DESCRIPTION
### Motivation
- Verwijder de tijdelijke Museumnacht-promotie van de homepage zodat de site eruitziet alsof die banner nooit aanwezig was.

### Description
- Verwijderd de volledige `secondary-hero` sectie uit `pages/index.js`, inclusief de `Image` en bijbehorende content/CTA.
- Opgeruimd: de imports `createBlurDataUrl` en `trackTicketsClick` zijn uit `pages/index.js` verwijderd omdat ze niet meer gebruikt worden.
- Verwijderd de vertaalkeys `museumnachtTag`, `museumnachtHeading` en `museumnachtSubtitle` uit `lib/translations.js` in zowel `en` als `nl`.
- Kleine importaanpassing: `trackCtaExhibitions` blijft behouden en imports zijn aangepast om geen ongebruikte symbolen te importeren.

### Testing
- Gedraaid: `npm test` (wat de tests `tests/ticketCta.test.cjs`, `tests/kidFriendlyFilter.test.cjs`, `tests/nearbyFilter.test.cjs` en `tests/museumSearch.test.cjs` uitvoert) en de suite is succesvol afgerond.
- Tijdens het testen verschenen enkele module type waarschuwingen over ES modules maar deze zijn informatief en hebben de tests niet geblokkeerd.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd18fe59908326bac274cc16b8812a)