### PR TITLE
Add JSON-LD structured data support and SEO copy updates for home, exhibitions, and museum pages

### DIFF
--- a/components/SEO.js
+++ b/components/SEO.js
@@ -37,12 +37,21 @@ function resolveImageUrl(image, baseUrl) {
   return `${baseUrl}${normalizedPath}`;
 }
 
-export default function SEO({ title, description, image, canonical }) {
+function normalizeStructuredData(input) {
+  if (!input) return [];
+  if (Array.isArray(input)) {
+    return input.filter(Boolean);
+  }
+  return [input];
+}
+
+export default function SEO({ title, description, image, canonical, structuredData }) {
   const { asPath } = useRouter();
   const pathname = stripQueryAndHash(asPath || '/');
   const url = toAbsoluteUrl(SITE_URL, pathname);
   const canonicalUrl = resolveCanonical(canonical, SITE_URL, pathname);
   const ogImage = resolveImageUrl(image, SITE_URL);
+  const structuredDataItems = normalizeStructuredData(structuredData);
 
   return (
     <Head>
@@ -58,6 +67,13 @@ export default function SEO({ title, description, image, canonical }) {
       {description && <meta name="twitter:description" content={description} />}
       {ogImage && <meta name="twitter:image" content={ogImage} />}
       <link rel="canonical" href={canonicalUrl} />
+      {structuredDataItems.map((item, index) => (
+        <script
+          key={`ld-json-${index}`}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(item) }}
+        />
+      ))}
     </Head>
   );
 }

--- a/docs/seo-strategie-3-maanden.md
+++ b/docs/seo-strategie-3-maanden.md
@@ -1,0 +1,72 @@
+# MuseumBuddy SEO-strategie (3 maanden)
+
+Doel: structureel organisch verkeer opbouwen rond **Amsterdam + musea/tentoonstellingen**, zonder design- of featurewijzigingen.
+
+## 1) Pagina’s om als eerste te maken (op basis van bestaande structuur)
+
+| Prioriteit | Pagina | Zoekintentie | Primaire keyword | Secundaire keywords | URL slug |
+|---|---|---|---|---|---|
+| 1 | Overzichtspagina musea (NL) | Gebruiker wil snel relevante musea in Amsterdam vergelijken | musea amsterdam | beste musea amsterdam, museum amsterdam centrum, museum bezoek amsterdam | `/musea-amsterdam` |
+| 2 | Overzichtspagina tentoonstellingen (NL) | Gebruiker zoekt actuele/lopende tentoonstellingen in Amsterdam | tentoonstellingen amsterdam | expositie amsterdam, huidige tentoonstellingen amsterdam, kunst tentoonstellingen amsterdam | `/tentoonstellingen-amsterdam` |
+| 3 | Museums overview (EN) | Tourist zoekt top museums in Amsterdam in English | best museums in amsterdam | museums in amsterdam, top museums amsterdam, art museums amsterdam | `/best-museums-amsterdam` |
+| 4 | Exhibitions overview (EN) | Tourist zoekt exhibitions in Amsterdam in English | exhibitions in amsterdam | best exhibitions amsterdam, current exhibitions amsterdam, art exhibitions in amsterdam | `/exhibitions-amsterdam` |
+| 5 | Museum detailpagina’s (NL/EN copy) | Gebruiker zoekt info over specifiek museum + tentoonstelling-context | `[museum naam] amsterdam` | openingstijden [museum], tentoonstellingen [museum], tickets [museum] | `/museum/[slug]` (bestaand) |
+
+## 2) Ideale opbouw per pagina (direct inpasbaar zonder layout-wijziging)
+
+### A. Overzichtspagina musea (NL + EN variant)
+1. **SEO-titel + H1** met hoofdkeyword en Amsterdam.
+2. **Korte intro (80–120 woorden)**: wat gebruiker op deze pagina vindt.
+3. **Bestaande musealijst/cards** (ongewijzigd) als kerncontent.
+4. **Korte SEO-sectie onderaan (120–180 woorden)** met:
+   - hoe te kiezen (kunst, geschiedenis, fotografie, modern),
+   - verwijzing naar tentoonstellingenpagina,
+   - natuurlijke variaties op keywords.
+5. **Interne links** naar belangrijke museumdetailpagina’s.
+
+### B. Overzichtspagina tentoonstellingen (NL + EN variant)
+1. **SEO-titel + H1** rond "tentoonstellingen/exhibitions in Amsterdam".
+2. **Korte intro (80–120 woorden)** met focus op actuele planning.
+3. **Bestaande tentoonstellingslijst/cards** (ongewijzigd).
+4. **Ondersteunende tekst (120–180 woorden)** met context: soorten tentoonstellingen en hoe vaak aanbod wisselt.
+5. **Interne links** naar relevante museumpagina’s.
+
+### C. Museum detailpagina’s
+1. **Unieke intro per museum (70–110 woorden)** met Amsterdam-context.
+2. **Korte alinea over tentoonstellingen (60–100 woorden)** gekoppeld aan bestaande gegevens.
+3. **Interne links** terug naar overzichtspagina’s musea/tentoonstellingen.
+4. **Meta title/description uniek per museum** met natuurlijke keyword-variant.
+
+## 3) 3-maanden roadmap (praktisch)
+
+| Maand | Focus | Concrete output | KPI (primair) |
+|---|---|---|---|
+| Maand 1 | Fundament + high-intent pagina’s | NL + EN overzichtspagina’s live met sterke intro/ondertekst en metadata | Impressies op head terms (`musea amsterdam`, `tentoonstellingen amsterdam`, `best museums in amsterdam`, `exhibitions in amsterdam`) |
+| Maand 2 | Schaal op detailniveau | Top 15 museumdetailpagina’s voorzien van unieke SEO-copy + interne links | Stijging non-brand clicks op long-tail museumqueries |
+| Maand 3 | Versterken + optimaliseren | Volgende 15–20 museumpagina’s + CTR-optimalisatie van titles/descriptions op basis van Search Console | Hogere CTR en meer top-10 rankings |
+
+## 4) Snelste wins (prioriteitenlijst)
+
+1. **Metadata direct herschrijven** op de 4 belangrijkste overzichtspagina’s (NL/EN musea + NL/EN tentoonstellingen).
+2. **Korte, unieke intro’s toevoegen** boven bestaande lijsten (geen nieuw component nodig).
+3. **SEO-ondertekst toevoegen** onder bestaande lijsten voor extra semantische dekking.
+4. **Interne links aanscherpen** tussen musea-overzicht ↔ tentoonstellingen-overzicht ↔ museumdetail.
+5. **Top 15 museumpagina’s voorzien van unieke copy** (vermijd dunne/gelijke teksten).
+6. **Title/description A/B-iteratie per maand** op basis van CTR-data in Search Console.
+
+## 5) Copy-richtlijnen (anti-spam, modern)
+
+- Schrijf voor mensen eerst, zoekmachines tweede.
+- Gebruik hoofdkeyword in H1, intro en (natuurlijk) 1–2x in body.
+- Gebruik synoniemen/varianten in plaats van herhaling.
+- Houd alinea’s kort en scanbaar.
+- Benoem alleen Amsterdam, musea en tentoonstellingen (geen zijthema’s).
+
+## 6) Voorbeeld metadata (compact)
+
+| Pagina | Title tag (voorbeeld) | Meta description (voorbeeld) |
+|---|---|---|
+| Musea overzicht NL | Musea in Amsterdam ontdekken | MuseumBuddy | Ontdek musea in Amsterdam en vergelijk snel welke het best bij je bezoek past. Bekijk locaties, highlights en actuele context per museum. |
+| Tentoonstellingen overzicht NL | Tentoonstellingen in Amsterdam | Actueel overzicht | Bekijk actuele tentoonstellingen in Amsterdam en vind snel wat nu te zien is in de musea van de stad. |
+| Museums overview EN | Best museums in Amsterdam | MuseumBuddy | Discover the best museums in Amsterdam and quickly choose where to go based on your interests and what’s on view. |
+| Exhibitions overview EN | Exhibitions in Amsterdam | Current overview | Explore current exhibitions in Amsterdam and find what to see now across the city’s museums. |

--- a/lib/museumSummaries.js
+++ b/lib/museumSummaries.js
@@ -8,20 +8,20 @@ const museumSummaries = {
     nl: 'Verhalen over Amsterdams verleden, heden en toekomst.',
   },
   'anne-frank-huis-amsterdam': {
-    en: 'Secret annex where Anne Frank wrote her diary.',
-    nl: 'Achterhuis waar Anne Frank haar dagboek schreef.',
+    en: 'Visit the Anne Frank House in Amsterdam and experience the Secret Annex with historical context, visitor information, and related exhibitions.',
+    nl: 'Bezoek het Anne Frank Huis in Amsterdam en ervaar het Achterhuis met historische context, bezoekersinformatie en gerelateerde tentoonstellingen.',
   },
   'body-worlds-amsterdam': {
     en: 'Interactive exhibits about the human body.',
     nl: 'Interactieve tentoonstellingen over het menselijk lichaam.',
   },
   'eye-filmmuseum-amsterdam': {
-    en: 'Dutch film heritage and cinema culture.',
-    nl: 'Nederlands filmerfgoed en bioscoopcultuur.',
+    en: 'EYE Filmmuseum in Amsterdam presents film heritage, visual culture, and rotating exhibitions for cinema lovers.',
+    nl: 'EYE Filmmuseum in Amsterdam brengt filmerfgoed, beeldcultuur en wisselende tentoonstellingen voor filmliefhebbers.',
   },
   'foam-fotografiemuseum-amsterdam': {
-    en: 'Contemporary photography exhibitions.',
-    nl: 'Tentoonstellingen van hedendaagse fotografie.',
+    en: 'FOAM in Amsterdam focuses on contemporary photography with changing exhibitions from established and emerging makers.',
+    nl: 'FOAM in Amsterdam richt zich op hedendaagse fotografie met wisselende tentoonstellingen van gevestigde en opkomende makers.',
   },
   'hart-museum-amsterdam': {
     en: 'The H’ART Museum, housed in the 17th-century Amstelhof on the Amstel, presents major rotating art exhibitions from international top collections and also hosts the Amsterdam Museum aan de Amstel.',
@@ -52,56 +52,56 @@ const museumSummaries = {
     nl: 'De wereld van microben en onzichtbaar leven.',
   },
   'moco-museum-amsterdam': {
-    en: 'Modern and contemporary art in a townhouse.',
-    nl: 'Moderne en hedendaagse kunst in een herenhuis.',
+    en: 'Moco Museum Amsterdam combines modern and contemporary art with popular, rotating exhibitions in a historic townhouse setting.',
+    nl: 'Moco Museum Amsterdam combineert moderne en hedendaagse kunst met populaire, wisselende tentoonstellingen in een historisch herenhuis.',
   },
   'museum-van-loon-amsterdam': {
     en: '18th-century canal house and family life.',
     nl: '18e-eeuws grachtenpand en familieleven.',
   },
   'nemo-science-museum-amsterdam': {
-    en: 'Hands-on science and technology exhibits.',
-    nl: 'Interactieve tentoonstellingen over wetenschap en technologie.',
+    en: 'NEMO Science Museum in Amsterdam offers interactive science experiences and hands-on exhibitions for curious visitors.',
+    nl: 'NEMO Science Museum in Amsterdam biedt interactieve wetenschapservaringen en hands-on tentoonstellingen voor nieuwsgierige bezoekers.',
   },
   'nxt-museum-amsterdam': {
-    en: 'Immersive digital art installations.',
-    nl: 'Immersieve digitale kunstinstallaties.',
+    en: 'Nxt Museum Amsterdam explores immersive digital art through innovative exhibitions and audiovisual installations.',
+    nl: 'Nxt Museum Amsterdam verkent immersieve digitale kunst met innovatieve tentoonstellingen en audiovisuele installaties.',
   },
   'ons-lieve-heer-op-solder-amsterdam': {
     en: 'Secret attic church from the 17th century.',
     nl: 'Verborgen zolderkerk uit de 17e eeuw.',
   },
   'rembrandthuis-amsterdam': {
-    en: 'Home and studio of painter Rembrandt.',
-    nl: 'Huis en atelier van schilder Rembrandt.',
+    en: 'Discover Rembrandt House Museum in Amsterdam, where the artist lived and worked, with exhibitions on his life and technique.',
+    nl: 'Ontdek Museum Rembrandthuis in Amsterdam, waar de kunstenaar woonde en werkte, met tentoonstellingen over zijn leven en techniek.',
   },
   'rijksmuseum-amsterdam': {
-    en: 'Dutch art and history with masterpieces.',
-    nl: 'Nederlandse kunst en geschiedenis met meesterwerken.',
+    en: 'Rijksmuseum Amsterdam showcases Dutch art and history, from iconic masterpieces to temporary exhibitions across multiple periods.',
+    nl: 'Rijksmuseum Amsterdam toont Nederlandse kunst en geschiedenis, van iconische meesterwerken tot tijdelijke tentoonstellingen uit meerdere periodes.',
   },
   'scheepvaartmuseum-amsterdam': {
-    en: 'Maritime history and seafaring.',
-    nl: 'Maritieme geschiedenis en zeevaart.',
+    en: 'The National Maritime Museum in Amsterdam presents maritime history through permanent displays and changing exhibitions.',
+    nl: 'Het Scheepvaartmuseum in Amsterdam presenteert maritieme geschiedenis via vaste opstellingen en wisselende tentoonstellingen.',
   },
   'stedelijk-museum-amsterdam': {
-    en: 'Modern and contemporary art collections.',
-    nl: 'Collecties van moderne en hedendaagse kunst.',
+    en: 'Stedelijk Museum Amsterdam is a leading museum for modern and contemporary art, design, and experimental exhibitions.',
+    nl: 'Stedelijk Museum Amsterdam is een toonaangevend museum voor moderne en hedendaagse kunst, design en experimentele tentoonstellingen.',
   },
   'straat-museum-amsterdam': {
-    en: 'Street art and graffiti in a huge warehouse.',
-    nl: 'Street art en graffiti in een enorme loods.',
+    en: 'STRAAT Museum Amsterdam highlights street art and graffiti with large-scale works and rotating exhibitions in an industrial venue.',
+    nl: 'STRAAT Museum Amsterdam toont street art en graffiti met grootschalige werken en wisselende tentoonstellingen in een industriële locatie.',
   },
   'tropenmuseum-amsterdam': {
     en: 'World cultures and ethnographic collections.',
     nl: 'Wereldculturen en etnografische collecties.',
   },
   'van-gogh-museum-amsterdam': {
-    en: 'Van Gogh\'s paintings and letters.',
-    nl: 'Van Goghs schilderijen en brieven.',
+    en: 'Van Gogh Museum Amsterdam presents Vincent van Gogh’s paintings and letters alongside temporary exhibitions with broader art-historical context.',
+    nl: 'Van Gogh Museum Amsterdam toont Vincent van Goghs schilderijen en brieven, aangevuld met tijdelijke tentoonstellingen in bredere kunsthistorische context.',
   },
   'wereldmuseum-amsterdam': {
-    en: 'World cultures and ethnography in Amsterdam.',
-    nl: 'Wereldculturen en etnografie in Amsterdam.',
+    en: 'Wereldmuseum Amsterdam explores global cultures and stories through collection highlights and curated exhibitions.',
+    nl: 'Wereldmuseum Amsterdam verkent wereldculturen en verhalen via collectiehoogtepunten en samengestelde tentoonstellingen.',
   },
   'woonbootmuseum-amsterdam': {
     en: 'Life on Amsterdam\'s houseboats.',

--- a/lib/translations.js
+++ b/lib/translations.js
@@ -1,16 +1,25 @@
 const translations = {
   en: {
-    homeTitle: 'MuseumBuddy — Amsterdam museums',
-    homeDescription: 'Plan your Amsterdam museum day with current exhibitions.',
+    homeTitle: 'Museums in Amsterdam | MuseumBuddy',
+    homeDescription: 'Discover museums in Amsterdam and plan your visit with current exhibitions in one clear overview.',
     heroTagline: 'Culture compass',
     heroTitle: 'Plan your Amsterdam museum day',
-    heroSubtitle: 'Find museums and exhibitions tailored to your mood in minutes.',
+    heroSubtitle: 'Find museums in Amsterdam and current exhibitions in minutes.',
+    homeSeoIntro:
+      'MuseumBuddy helps you compare museums in Amsterdam quickly, so you can choose what to visit based on your interests and what is on view now.',
+    homeSeoFooter:
+      'Looking for exhibitions in Amsterdam? View the latest overview and connect each exhibition directly to the museum page for practical planning.',
     heroDiscoverMuseums: 'Discover museums',
     heroViewExhibitions: 'View exhibitions',
-    exhibitionsPageTitle: 'MuseumBuddy — Amsterdam exhibitions',
-    exhibitionsPageDescription: 'Browse every current and upcoming exhibition in Amsterdam museums.',
-    exhibitionsPageHeading: 'All exhibitions',
+    exhibitionsPageTitle: 'Exhibitions in Amsterdam | MuseumBuddy',
+    exhibitionsPageDescription:
+      'Browse current and upcoming exhibitions in Amsterdam museums and quickly decide what to see next.',
+    exhibitionsPageHeading: 'Exhibitions in Amsterdam',
     exhibitionsPageSubtitle: 'See what is on view across Amsterdam museums right now.',
+    exhibitionsSeoIntro:
+      'Use this overview to discover exhibitions in Amsterdam across art, history, photography, and contemporary museum programs.',
+    exhibitionsSeoFooter:
+      'Prefer starting with museums first? Explore the full Amsterdam museums overview and then narrow down by exhibition.',
     exhibitionsListHostedBy: 'At {museum}',
     exhibitionsListCardTitle: '{exhibition} — {museum}',
     homeValueTag: 'Why MuseumBuddy',
@@ -148,7 +157,9 @@ const translations = {
     categoryCulture: 'World cultures',
     categoryReligion: 'Religion & heritage',
     categoryFilm: 'Film & media',
-    museumDescription: 'Information and exhibitions of {name}.',
+    museumDescription: 'Discover {name} in Amsterdam, including practical information and current exhibitions.',
+    museumDetailSeoBody:
+      'Explore this Amsterdam museum page for practical visitor details and current exhibition context.',
     museumLabel: 'Museum',
     imageCreditLabel: 'Image credit',
     imageCreditBy: 'by',
@@ -178,17 +189,27 @@ const translations = {
       'Some links on this website are affiliate links. That means we may receive a small commission if you buy a ticket or make a reservation via such a link. This costs you nothing extra; prices may vary. We only include links that match the content of MuseumBuddy.',
   },
   nl: {
-    homeTitle: 'MuseumBuddy — Amsterdamse musea',
-    homeDescription: 'Plan je museumdag in Amsterdam met actuele tentoonstellingen.',
+    homeTitle: 'Musea in Amsterdam | MuseumBuddy',
+    homeDescription:
+      'Ontdek musea in Amsterdam en plan je bezoek met actuele tentoonstellingen in één duidelijk overzicht.',
     heroTagline: 'Cultuurkompas',
     heroTitle: 'Plan je museumdag in Amsterdam',
-    heroSubtitle: 'Vind in een paar minuten musea en tentoonstellingen die bij je stemming passen.',
+    heroSubtitle: 'Vind in een paar minuten musea in Amsterdam en actuele tentoonstellingen.',
+    homeSeoIntro:
+      'MuseumBuddy helpt je snel musea in Amsterdam te vergelijken, zodat je eenvoudig kiest wat je wilt bezoeken op basis van interesse en actuele tentoonstellingen.',
+    homeSeoFooter:
+      'Zoek je vooral tentoonstellingen in Amsterdam? Bekijk het actuele overzicht en ga direct door naar het juiste museum.',
     heroDiscoverMuseums: 'Ontdek musea',
     heroViewExhibitions: 'Bekijk tentoonstellingen',
-    exhibitionsPageTitle: 'MuseumBuddy — Tentoonstellingen in Amsterdam',
-    exhibitionsPageDescription: 'Bekijk alle lopende en komende tentoonstellingen in Amsterdamse musea.',
-    exhibitionsPageHeading: 'Alle tentoonstellingen',
+    exhibitionsPageTitle: 'Tentoonstellingen in Amsterdam | MuseumBuddy',
+    exhibitionsPageDescription:
+      'Bekijk lopende en komende tentoonstellingen in Amsterdamse musea en beslis snel wat je nu wilt zien.',
+    exhibitionsPageHeading: 'Tentoonstellingen in Amsterdam',
     exhibitionsPageSubtitle: 'Zie wat er nu in de Amsterdamse musea te zien is.',
+    exhibitionsSeoIntro:
+      'Gebruik dit overzicht om tentoonstellingen in Amsterdam te ontdekken in kunst, geschiedenis, fotografie en moderne museumprogrammering.',
+    exhibitionsSeoFooter:
+      'Begin je liever bij een museum? Bekijk het volledige overzicht van musea in Amsterdam en ga daarna door naar lopende tentoonstellingen.',
     exhibitionsListHostedBy: 'Te zien in {museum}',
     exhibitionsListCardTitle: '{exhibition} — {museum}',
     homeValueTag: 'Waarom MuseumBuddy',
@@ -326,7 +347,9 @@ const translations = {
     categoryCulture: 'Wereldculturen',
     categoryReligion: 'Religie & erfgoed',
     categoryFilm: 'Film & media',
-    museumDescription: 'Informatie en tentoonstellingen van {name}.',
+    museumDescription: 'Ontdek {name} in Amsterdam met praktische bezoekersinformatie en actuele tentoonstellingen.',
+    museumDetailSeoBody:
+      'Bekijk deze museum pagina in Amsterdam voor praktische bezoekersinformatie en context over actuele tentoonstellingen.',
     museumLabel: 'Museum',
     imageCreditLabel: 'Fotocredit',
     imageCreditBy: 'door',

--- a/pages/index.js
+++ b/pages/index.js
@@ -851,6 +851,25 @@ export default function Home({ initialMuseums = [], initialError = null }) {
     ],
     [t]
   );
+  const homeStructuredData = useMemo(
+    () => ({
+      '@context': 'https://schema.org',
+      '@type': 'CollectionPage',
+      name: t('homeTitle'),
+      description: t('homeDescription'),
+      url: 'https://www.museumbuddy.app/',
+      inLanguage: lang === 'nl' ? 'nl-NL' : 'en',
+      about: {
+        '@type': 'Place',
+        name: 'Amsterdam',
+      },
+      mainEntity: {
+        '@type': 'ItemList',
+        name: lang === 'nl' ? 'Musea in Amsterdam' : 'Museums in Amsterdam',
+      },
+    }),
+    [lang, t]
+  );
 
   if (error) {
     return (
@@ -860,6 +879,7 @@ export default function Home({ initialMuseums = [], initialError = null }) {
           description={t('homeDescription')}
           canonical="/"
           image="/images/og-home.svg"
+          structuredData={homeStructuredData}
         />
         <main className="container" style={{ maxWidth: 800 }}>
           <p>{t('somethingWrong')}</p>
@@ -875,6 +895,7 @@ export default function Home({ initialMuseums = [], initialError = null }) {
         description={t('homeDescription')}
         canonical="/"
         image="/images/og-home.svg"
+        structuredData={homeStructuredData}
       />
       <FiltersSheet
         open={filtersSheetOpen}
@@ -902,6 +923,7 @@ export default function Home({ initialMuseums = [], initialError = null }) {
           <span className="hero-tagline">{t('heroTagline')}</span>
           <h1 className="hero-title">{t('heroTitle')}</h1>
           <p className="hero-subtext">{t('heroSubtitle')}</p>
+          <p className="hero-subtext">{t('homeSeoIntro')}</p>
           <div className="hero-ctas">
             <Button
               type="button"
@@ -1027,6 +1049,14 @@ export default function Home({ initialMuseums = [], initialError = null }) {
             })}
           </ul>
         )}
+      </section>
+      <section className="page-intro" aria-label="SEO content">
+        <p className="page-subtitle">
+          {t('homeSeoFooter')}{' '}
+          <Link href="/tentoonstellingen">{
+            lang === 'nl' ? 'Tentoonstellingen in Amsterdam' : 'Exhibitions in Amsterdam'
+          }</Link>.
+        </p>
       </section>
     </>
   );

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -501,7 +501,39 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
   );
 
   const seoDescription = summary || t('museumDescription', { name: displayName });
+  const seoTitle = `${displayName} in Amsterdam | MuseumBuddy`;
   const canonical = `/museum/${slug}`;
+  const museumStructuredData = useMemo(
+    () => ({
+      '@context': 'https://schema.org',
+      '@type': 'Museum',
+      name: displayName,
+      description: seoDescription,
+      url: `https://www.museumbuddy.app${canonical}`,
+      image: heroImageUrl || undefined,
+      address: locationLines.length
+        ? {
+            '@type': 'PostalAddress',
+            streetAddress: resolvedMuseum.address || undefined,
+            postalCode: resolvedMuseum.postalCode || undefined,
+            addressLocality: resolvedMuseum.city || 'Amsterdam',
+            addressRegion: resolvedMuseum.province || undefined,
+            addressCountry: 'NL',
+          }
+        : undefined,
+    }),
+    [
+      canonical,
+      displayName,
+      heroImageUrl,
+      locationLines.length,
+      resolvedMuseum.address,
+      resolvedMuseum.city,
+      resolvedMuseum.postalCode,
+      resolvedMuseum.province,
+      seoDescription,
+    ]
+  );
 
   const expositionItems = useMemo(
     () =>
@@ -852,10 +884,11 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
   return (
     <section className={`museum-detail${heroImage ? ' has-hero' : ''}`}>
       <SEO
-        title={`${displayName} — MuseumBuddy`}
+        title={seoTitle}
         description={seoDescription}
         image={heroImageUrl}
         canonical={canonical}
+        structuredData={museumStructuredData}
       />
       <div className="museum-detail-container museum-hero-heading-container">
         <div className="museum-hero-heading">
@@ -912,6 +945,18 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
       <div className="museum-detail-container">
         <div className="museum-detail-grid">
           <div className="museum-detail-main">
+            <section className="page-intro" aria-label="Museum SEO content">
+              <p className="page-subtitle">
+                {t('museumDetailSeoBody')}{' '}
+                <Link href="/tentoonstellingen">
+                  {lang === 'nl' ? 'Tentoonstellingen in Amsterdam' : 'Exhibitions in Amsterdam'}
+                </Link>{' '}
+                ·{' '}
+                <Link href="/">
+                  {lang === 'nl' ? 'Musea in Amsterdam' : 'Museums in Amsterdam'}
+                </Link>
+              </p>
+            </section>
             <div className="museum-tablist" role="tablist" aria-label={t('museumTabsLabel')}>
               {tabDefinitions.map((tab, index) => {
                 const isActive = activeTab === tab.id;

--- a/pages/tentoonstellingen.js
+++ b/pages/tentoonstellingen.js
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import MuseumCard from '../components/MuseumCard';
 import SEO from '../components/SEO';
@@ -764,6 +765,25 @@ export default function ExhibitionsPage({ exhibitions = [], error = null }) {
 
   const hasBaseCards = allCards.length > 0;
   const hasVisibleCards = visibleCards.length > 0;
+  const exhibitionsStructuredData = useMemo(
+    () => ({
+      '@context': 'https://schema.org',
+      '@type': 'CollectionPage',
+      name: t('exhibitionsPageTitle'),
+      description: t('exhibitionsPageDescription'),
+      url: 'https://www.museumbuddy.app/tentoonstellingen',
+      inLanguage: lang === 'nl' ? 'nl-NL' : 'en',
+      about: {
+        '@type': 'Place',
+        name: 'Amsterdam',
+      },
+      mainEntity: {
+        '@type': 'ItemList',
+        name: lang === 'nl' ? 'Tentoonstellingen in Amsterdam' : 'Exhibitions in Amsterdam',
+      },
+    }),
+    [lang, t]
+  );
 
   return (
     <>
@@ -772,6 +792,7 @@ export default function ExhibitionsPage({ exhibitions = [], error = null }) {
         description={t('exhibitionsPageDescription')}
         canonical="/tentoonstellingen"
         image="/images/og-exhibitions.svg"
+        structuredData={exhibitionsStructuredData}
       />
       <FiltersSheet
         open={filtersSheetOpen}
@@ -800,6 +821,7 @@ export default function ExhibitionsPage({ exhibitions = [], error = null }) {
           {t('exhibitionsPageHeading')}
         </h1>
         <p className="page-subtitle">{t('exhibitionsPageSubtitle')}</p>
+        <p className="page-subtitle">{t('exhibitionsSeoIntro')}</p>
       </section>
       <p className="count">
         {visibleCards.length} {t('exhibitions')}
@@ -844,6 +866,12 @@ export default function ExhibitionsPage({ exhibitions = [], error = null }) {
           ))}
         </ul>
       )}
+      <section className="page-intro" aria-label="SEO content">
+        <p className="page-subtitle">
+          {t('exhibitionsSeoFooter')}{' '}
+          <Link href="/">{lang === 'nl' ? 'Musea in Amsterdam' : 'Museums in Amsterdam'}</Link>.
+        </p>
+      </section>
     </>
   );
 }


### PR DESCRIPTION
### Motivation
- Improve search visibility and rich results by embedding JSON-LD structured data on key pages (`home`, `exhibitions`, and `museum` detail).
- Provide on-page SEO copy blocks to give pages stronger semantic content without layout changes.
- Enrich metadata and content strings to present clearer titles/descriptions and better museum summaries for users and search engines.

### Description
- Extended `components/SEO.js` to accept a `structuredData` prop, added `normalizeStructuredData` helper, and render one or more `<script type="application/ld+json">` entries safely (using `dangerouslySetInnerHTML`).
- Added structured data generation and wiring to `pages/index.js`, `pages/tentoonstellingen.js`, and `pages/museum/[slug].js` and passed the resulting objects to `SEO` via the new `structuredData` prop; also added small SEO intro/footer copy sections to those pages.
- Updated copy and metadata in `lib/translations.js` and expanded/rewrote many entries in `lib/museumSummaries.js` to provide richer descriptions suitable for page content and structured data.
- Added a new documentation file `docs/seo-strategie-3-maanden.md` with a 3-month SEO strategy and minor import fix (`Link` added to `pages/tentoonstellingen.js`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be7271f4e483269e5964bd8260e348)