### PR TITLE
Standaard UI-schaal ~90% op desktop (voeg `--ui-scale` toe)

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,6 @@
 :root {
+  --ui-scale: 1;
+
   /* Typography */
   --ds-font-family-sans: 'Inter';
   --ds-font-family-brand: 'Inter';
@@ -8,14 +10,14 @@
   --ds-font-weight-bold: 700;
 
   /* Spacing scale (4px baseline) */
-  --ds-space-1: 4px;
-  --ds-space-2: 8px;
-  --ds-space-3: 12px;
-  --ds-space-4: 16px;
-  --ds-space-5: 20px;
-  --ds-space-6: 24px;
-  --ds-space-7: 28px;
-  --ds-space-8: 32px;
+  --ds-space-1: calc(4px * var(--ui-scale));
+  --ds-space-2: calc(8px * var(--ui-scale));
+  --ds-space-3: calc(12px * var(--ui-scale));
+  --ds-space-4: calc(16px * var(--ui-scale));
+  --ds-space-5: calc(20px * var(--ui-scale));
+  --ds-space-6: calc(24px * var(--ui-scale));
+  --ds-space-7: calc(28px * var(--ui-scale));
+  --ds-space-8: calc(32px * var(--ui-scale));
 
   --space-8: var(--ds-space-2);
   --space-16: calc(var(--ds-space-2) * 2);
@@ -23,9 +25,9 @@
   --space-32: calc(var(--ds-space-2) * 4);
 
   /* Radii */
-  --ds-radius-sm: 12px;
-  --ds-radius-md: 16px;
-  --ds-radius-lg: 20px;
+  --ds-radius-sm: calc(12px * var(--ui-scale));
+  --ds-radius-md: calc(16px * var(--ui-scale));
+  --ds-radius-lg: calc(20px * var(--ui-scale));
   --radius-sm: var(--ds-radius-sm);
   --radius-md: var(--ds-radius-md);
 
@@ -83,6 +85,12 @@
   --skeleton-highlight: #f8fafc;
   --focus-ring-outline: var(--ds-color-focus-outline);
   --focus-ring-shadow: var(--ds-color-focus-shadow);
+}
+
+@media (min-width: 768px) {
+  :root {
+    --ui-scale: 0.9;
+  }
 }
 
 [data-theme='dark'] {
@@ -151,7 +159,7 @@ body {
   font-family: var(--font-body), system-ui, -apple-system, 'Segoe UI', Ubuntu, Cantarell, 'Noto Sans', 'Helvetica Neue', Arial,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
   font-weight: var(--ds-font-weight-regular);
-  font-size: 16px;
+  font-size: calc(16px * var(--ui-scale));
   line-height: 1.65;
   letter-spacing: 0;
   transition: background-color 0.3s ease, color 0.3s ease;
@@ -4258,5 +4266,4 @@ button.hero-quick-link {
   background: linear-gradient(145deg, rgba(30, 41, 59, 0.78), rgba(15, 23, 42, 0.82));
   border-color: rgba(71, 85, 105, 0.42);
 }
-
 


### PR DESCRIPTION
### Motivation

- De pagina en kaarten voelden te groot aan, waardoor het overzicht bij het openen van de pagina ontbreekt.
- Doel is een consistente, subtiele verkleining die aanvoelt als 90% browser-zoom zonder browser-`zoom` zelf te gebruiken.
- Mobiele leesbaarheid en interactiegrootte moeten onveranderd blijven.

### Description

- Voeg een globale CSS-variabele `--ui-scale` toe in `styles/globals.css` met default `1` om UI-schaal centraal te regelen.
- Laat kerntokens meeschalen door `--ui-scale` toe te passen op spacing (`--ds-space-*`), corner radii (`--ds-radius-*`) en de basis `body` `font-size` via `calc(... * var(--ui-scale))`.
- Stel `--ui-scale: 0.9` in binnen `@media (min-width: 768px)` zodat tablet/desktop layouts standaard ~90% renderen terwijl mobiel op `1` blijft.

### Testing

- Voer `npm test -- --runInBand` uit en alle geautomatiseerde tests zijn geslaagd.
- Concrete tests die uitgevoerd werden: `ticketCta`, `kidFriendlyFilter`, `nearbyFilter` en `museumSearch`, en ze gaven geen fouten.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bece00c11083268d3680d3d35739b5)