### PR TITLE
Remove outdated static exhibitions from website

### DIFF
--- a/lib/staticExhibitions.js
+++ b/lib/staticExhibitions.js
@@ -54,62 +54,7 @@ function createMuseumForSlug(slug) {
   };
 }
 
-const STATIC_EXHIBITIONS_SOURCE = [
-  {
-    id: 'static-exhibition-van-gogh-paris-2024',
-    museumSlug: 'van-gogh-museum-amsterdam',
-    titel: 'Van Gogh in Parijs',
-    start_datum: '2024-03-01',
-    eind_datum: '2024-09-01',
-    beschrijving:
-      'Verdiep je in de Parijse jaren van Vincent van Gogh met schilderijen, tekeningen en brieven die laten zien hoe de stad zijn werk veranderde.',
-    description:
-      'Explore Vincent van Gogh\'s transformative Paris years through paintings, drawings and letters that reveal how the city reshaped his art.',
-    ticket_url:
-      'https://www.vangoghmuseum.nl/nl/zien-en-doen/tentoonstellingen/van-gogh-in-parijs',
-    bron_url:
-      'https://www.vangoghmuseum.nl/nl/bezoek/agenda',
-  },
-  {
-    id: 'static-exhibition-rijksmuseum-rijks-2024',
-    museumSlug: 'rijksmuseum-amsterdam',
-    titel: 'Vermeer Highlights',
-    start_datum: '2024-02-15',
-    eind_datum: '2024-12-31',
-    beschrijving:
-      'Een intieme selectie van Johannes Vermeers meesterwerken, aangevuld met röntgenbeelden en schetsen die nieuwe inzichten geven in zijn techniek.',
-    description:
-      'An intimate presentation of Johannes Vermeer\'s masterpieces, paired with X-rays and sketches that uncover new insights into his technique.',
-    ticket_url: 'https://www.rijksmuseum.nl/nl/tentoonstellingen',
-    bron_url: 'https://www.rijksmuseum.nl/nl/tickets/artikel',
-  },
-  {
-    id: 'static-exhibition-stedelijk-futures-2024',
-    museumSlug: 'stedelijk-museum-amsterdam',
-    titel: 'Futures of Form',
-    start_datum: '2024-04-20',
-    eind_datum: '2024-10-20',
-    beschrijving:
-      'Ontdek experimentele installaties, design en nieuwe media die speculeren over de toekomst van stedelijk leven en vormgeving.',
-    description:
-      'Discover experimental installations, design and new media works that speculate on the future of urban life and design.',
-    ticket_url: 'https://www.stedelijk.nl/nl/tentoonstellingen',
-    bron_url: 'https://www.stedelijk.nl/nl/bezoek',
-  },
-  {
-    id: 'static-exhibition-straat-graffiti-2024',
-    museumSlug: 'straat-museum-amsterdam',
-    titel: 'Graffiti Masters',
-    start_datum: '2024-01-10',
-    eind_datum: '2024-08-31',
-    beschrijving:
-      'Internationale street art-pioniers vullen de loodsen van STRAAT met kleurrijke muurschilderingen, sculpturen en multimediawerken.',
-    description:
-      'International street art pioneers take over STRAAT\'s warehouses with vibrant murals, sculptures and multimedia works.',
-    ticket_url: 'https://straatmuseum.com/nl/tentoonstellingen',
-    bron_url: 'https://straatmuseum.com/nl/bezoek',
-  },
-];
+const STATIC_EXHIBITIONS_SOURCE = [];
 
 const STATIC_EXHIBITIONS = STATIC_EXHIBITIONS_SOURCE.map((entry) => {
   const museum = createMuseumForSlug(entry.museumSlug);


### PR DESCRIPTION
### Motivation
- The site included four hard-coded static exhibitions that are no longer current and caused stale content to appear.

### Description
- Emptied `STATIC_EXHIBITIONS_SOURCE` in `lib/staticExhibitions.js` to remove the four hard-coded exhibition entries.
- Kept the existing mapping logic and `getStaticExhibitions` export intact so the code returns no fallback exhibitions when the source is empty.
- Changed file: `lib/staticExhibitions.js`.

### Testing
- Ran `npm test -- --runInBand`, and all automated tests passed (Ticket CTA copy tests, Kid-friendly filter tests, Nearby filter output, and Museum search parsing tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bed7b0e4248326bccfe830f3ce0f90)