### PR TITLE
SEO: unify site URL in JSON-LD, add <html lang>, and provide meta descriptions for about/favorites

### DIFF
--- a/docs/seo-audit-2026-03-21.md
+++ b/docs/seo-audit-2026-03-21.md
@@ -1,0 +1,72 @@
+# SEO-audit MuseumBuddy (21 maart 2026)
+
+## Scope
+Deze audit is een codebase-analyse van de Next.js app (geen live crawl met Search Console/Lighthouse).
+
+## Eindoordeel (codebase)
+**SEO-basis: goed (7.5/10)**
+
+Sterke punten:
+- Canonical, title, meta description, Open Graph en Twitter-tags zijn centraal geregeld in `components/SEO.js`.
+- Structured data (JSON-LD) is aanwezig op home, tentoonstellingsoverzicht en museum-detailpagina's.
+- `robots.txt` en `sitemap.xml` worden automatisch gegenereerd via `scripts/generateSeoFiles.mjs`.
+- Schone URL-structuur met slugs (`/museum/[slug]`) en duidelijke H1's op kernpagina's.
+
+Belangrijkste verbeterpunten:
+1. **Domein-inconsistentie**: canonical/robots/sitemap gebruiken standaard `museumbuddy.nl`, maar structured data hardcodeert `museumbuddy.app` op meerdere pagina's.
+2. **Geen hreflang/taal-varianten**: er zijn NL/EN teksten, maar geen expliciete hreflang-linkset en geen `_document` met `<html lang=...>`.
+3. **Niet elke pagina heeft description**: o.a. `/about` en `/favorites` zetten alleen title.
+4. **Sitemap `lastmod` is build-tijd, niet content-tijd**: nuttig als fallback, maar suboptimaal voor indexeringssignalen.
+5. **Gefilterde varianten worden niet als indexeerbare landingspagina's gemodelleerd**: filtering loopt via query params; dat is prima UX, maar beperkt long-tail SEO als er geen dedicated SEO-pagina's zijn.
+
+## Bevindingen per onderdeel
+
+### 1) Technische SEO
+- ✅ Robots en sitemap aanwezig in `public/` en generator in `scripts/generateSeoFiles.mjs`.
+- ✅ Canonical wordt op URL-niveau goed opgebouwd in `components/SEO.js`.
+- ⚠️ Domein mismatch tussen site URL (`museumbuddy.nl`) en JSON-LD URL's (`www.museumbuddy.app`).
+- ⚠️ Geen `_document.js`; dus geen gegarandeerde `lang` op `<html>`.
+
+### 2) On-page SEO
+- ✅ Kernpagina's bevatten duidelijke H1's en semantische secties.
+- ✅ Museum-detailpagina's hebben unieke titels en beschrijvingen.
+- ⚠️ Sommige informatieve pagina's hebben geen meta description.
+
+### 3) Structured data
+- ✅ `CollectionPage` op home en tentoonstellingen.
+- ✅ `Museum` schema op detailpagina.
+- ⚠️ URL-attributen in schema gebruiken ander domein dan canonical/sitemap.
+
+### 4) Indexeerbaarheid & crawling
+- ✅ `Allow: /` en sitemapverwijzing aanwezig.
+- ✅ Statische export (`output: 'export'`) maakt crawlbaarheid in principe eenvoudig.
+- ⚠️ Geen expliciete strategie zichtbaar voor duplicate handling van filtervarianten (index/noindex policy).
+
+### 5) Snelle winst (prioriteit)
+
+#### P0 (hoog)
+1. **Domein uniformeren**
+   - Gebruik overal dezelfde bron (`getSiteUrl()`), ook in JSON-LD URL-velden.
+2. **`<html lang>` toevoegen**
+   - Voeg `pages/_document.js` toe met correcte taaldefault.
+3. **Meta descriptions aanvullen op `/about` en `/favorites`**
+
+#### P1 (middel)
+4. **hreflang toevoegen**
+   - Voor NL/EN varianten (ook als het dezelfde URL is met runtime taalwisseling, dan duidelijke voorkeur kiezen).
+5. **Sitemap verbeteren**
+   - `lastmod` per pagina op basis van echte contentwijziging indien mogelijk.
+
+#### P2 (laag)
+6. **SEO-landingspagina's voor long-tail intenties**
+   - Bijv. “kindvriendelijke musea Amsterdam”, “gratis musea Amsterdam”, etc.
+
+## KPI's om dit te valideren
+- Index Coverage (GSC): aantal geldige geïndexeerde pagina's.
+- CTR op branded vs non-branded queries.
+- Gemiddelde positie op top-20 museum-gerelateerde queries.
+- Aantal pagina's met rich results / schema-detectie (Rich Results Test).
+- Organisch verkeer naar museum-detailpagina's.
+
+## Conclusie
+MuseumBuddy heeft een solide technische SEO-basis. Met name de centrale SEO-component, canonical-opzet en JSON-LD zijn goed neergezet. De grootste risico's zitten nu in **consistente domeinsignalen** en **meertalige SEO-signalen** (lang/hreflang), gevolgd door een paar snelle on-page verbeteringen.

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html lang="nl">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/pages/about.js
+++ b/pages/about.js
@@ -2,15 +2,19 @@ import SEO from '../components/SEO';
 import { useLanguage } from '../components/LanguageContext';
 
 export default function AboutPage() {
-  const { t } = useLanguage();
+  const { lang, t } = useLanguage();
   const emailAddress = 'info@museumbuddy.nl';
+  const description =
+    lang === 'en'
+      ? 'Learn what MuseumBuddy does and how to contact us.'
+      : 'Lees wat MuseumBuddy doet en hoe je contact opneemt.';
   const whatItems = t('aboutWhatItems');
   const contactBody = t('aboutContactBody', { email: emailAddress });
   const [contactPrefix = '', contactSuffix = ''] = contactBody.split(emailAddress);
 
   return (
     <>
-      <SEO title={t('aboutTitle')} />
+      <SEO title={t('aboutTitle')} description={description} />
       <h1 className="page-title">{t('aboutTitle')}</h1>
       <p>{t('aboutIntro')}</p>
       <section>

--- a/pages/favorites.js
+++ b/pages/favorites.js
@@ -9,7 +9,11 @@ import createBlurDataUrl from '../lib/createBlurDataUrl';
 
 export default function FavoritesPage() {
   const { favorites } = useFavorites();
-  const { t } = useLanguage();
+  const { lang, t } = useLanguage();
+  const description =
+    lang === 'en'
+      ? 'View your saved museums and exhibitions in MuseumBuddy.'
+      : 'Bekijk je opgeslagen musea en tentoonstellingen in MuseumBuddy.';
 
   const museumFavorites = favorites.filter((f) => f.type === 'museum');
   const expositionFavorites = favorites.filter((f) => f.type === 'exposition');
@@ -17,7 +21,7 @@ export default function FavoritesPage() {
 
   return (
     <>
-      <SEO title={t('favoritesTitle')} />
+      <SEO title={t('favoritesTitle')} description={description} />
       <h1 className="page-title">{t('favoritesTitle')}</h1>
       {favorites.length === 0 ? (
         <section

--- a/pages/index.js
+++ b/pages/index.js
@@ -24,6 +24,7 @@ import parseBooleanParam from '../lib/parseBooleanParam.js';
 import { DEFAULT_TIME_ZONE } from '../lib/openingHours.js';
 import { trackCtaExhibitions } from '../lib/analytics';
 import { getStaticMuseums } from '../lib/staticMuseums';
+import { getSiteUrl } from '../lib/siteUrl';
 
 const FEATURED_SLUGS = [
   'van-gogh-museum-amsterdam',
@@ -36,6 +37,7 @@ const FEATURED_SLUGS = [
   'hart-museum-amsterdam',
   'rembrandthuis-amsterdam',
 ];
+const SITE_URL = getSiteUrl();
 
 function sortMuseums(museums) {
   return [...museums].sort((a, b) => {
@@ -857,7 +859,7 @@ export default function Home({ initialMuseums = [], initialError = null }) {
       '@type': 'CollectionPage',
       name: t('homeTitle'),
       description: t('homeDescription'),
-      url: 'https://www.museumbuddy.app/',
+      url: `${SITE_URL}/`,
       inLanguage: lang === 'nl' ? 'nl-NL' : 'en',
       about: {
         '@type': 'Place',

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -21,6 +21,7 @@ import { shouldShowAffiliateNote } from '../../lib/nonAffiliateMuseums';
 import kidFriendlyMuseums, { isKidFriendly as resolveKidFriendly } from '../../lib/kidFriendlyMuseums';
 import { trackFavoriteAdd, trackTicketsClick } from '../../lib/analytics';
 import { getStaticMuseumBySlug, getStaticMuseums } from '../../lib/staticMuseums';
+import { getSiteUrl } from '../../lib/siteUrl';
 
 function todayYMD(tz = 'Europe/Amsterdam') {
   try {
@@ -188,6 +189,7 @@ function FavoriteButton({ active, onToggle, label }) {
 }
 
 const DEFAULT_TAB = 'exhibitions';
+const SITE_URL = getSiteUrl();
 const TAB_IDS = ['exhibitions', 'map'];
 const TAB_HASHES = {
   exhibitions: 'tentoonstellingen',
@@ -509,7 +511,7 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
       '@type': 'Museum',
       name: displayName,
       description: seoDescription,
-      url: `https://www.museumbuddy.app${canonical}`,
+      url: `${SITE_URL}${canonical}`,
       image: heroImageUrl || undefined,
       address: locationLines.length
         ? {
@@ -532,6 +534,7 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
       resolvedMuseum.postalCode,
       resolvedMuseum.province,
       seoDescription,
+      SITE_URL,
     ]
   );
 

--- a/pages/tentoonstellingen.js
+++ b/pages/tentoonstellingen.js
@@ -20,8 +20,10 @@ import {
   CATEGORY_TRANSLATION_KEYS,
 } from '../lib/museumCategories';
 import { getStaticExhibitions } from '../lib/staticExhibitions';
+import { getSiteUrl } from '../lib/siteUrl';
 
 const FILTERS_EVENT = 'museumBuddy:openFilters';
+const SITE_URL = getSiteUrl();
 
 const MUSEUM_SELECT_COLUMNS = [
   'id',
@@ -771,7 +773,7 @@ export default function ExhibitionsPage({ exhibitions = [], error = null }) {
       '@type': 'CollectionPage',
       name: t('exhibitionsPageTitle'),
       description: t('exhibitionsPageDescription'),
-      url: 'https://www.museumbuddy.app/tentoonstellingen',
+      url: `${SITE_URL}/tentoonstellingen`,
       inLanguage: lang === 'nl' ? 'nl-NL' : 'en',
       about: {
         '@type': 'Place',


### PR DESCRIPTION
### Motivation
- Ensure consistent domain signals in structured data and site-wide HTML language for better SEO and rich result detection.
- Add missing page descriptions for `/about` and `/favorites` so pages expose useful meta descriptions to search engines.
- Provide an on-codebase SEO audit document summarizing findings and recommended priorities.

### Description
- Added `pages/_document.js` to render `<Html lang="nl">` so the root HTML element has an explicit language attribute.
- Replaced hardcoded JSON-LD URLs with a centralized `getSiteUrl()` by importing it and setting `SITE_URL` in `pages/index.js`, `pages/museum/[slug].js`, and `pages/tentoonstellingen.js` so structured data uses the same domain as the site.
- Updated `pages/about.js` and `pages/favorites.js` to read `lang` from `useLanguage()` and pass a localized `description` to the `SEO` component.
- Added an audit document `docs/seo-audit-2026-03-21.md` that records the codebase SEO findings and prioritized remediation steps.

### Testing
- Performed a production build with `next build` which completed successfully and did not report build-time errors.
- Ran the project's automated test suite with `npm test` which passed without failures.
- Executed lint/type checks (project linters/typecheck) and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69befc1f1e488326b0d6a27a84df022b)