### PR TITLE
Add SEO intro/footer headings and expanded copy, surface them on Home and Exhibitions pages

### DIFF
--- a/lib/translations.js
+++ b/lib/translations.js
@@ -1,25 +1,30 @@
 const translations = {
   en: {
-    homeTitle: 'Museums in Amsterdam | MuseumBuddy',
-    homeDescription: 'Discover museums in Amsterdam and plan your visit with current exhibitions in one clear overview.',
+    homeTitle: 'Museums in Amsterdam: plan your visit | MuseumBuddy',
+    homeDescription:
+      'Discover museums in Amsterdam, compare highlights by interest, and plan your visit with current exhibitions, practical visitor info, and quick links in one clear overview.',
     heroTagline: 'Culture compass',
-    heroTitle: 'Plan your Amsterdam museum day',
+    heroTitle: 'Museums in Amsterdam: plan your museum day',
     heroSubtitle: 'Find museums in Amsterdam and current exhibitions in minutes.',
+    homeSeoIntroHeading: 'Museums in Amsterdam for every interest',
     homeSeoIntro:
-      'MuseumBuddy helps you compare museums in Amsterdam quickly, so you can choose what to visit based on your interests and what is on view now.',
+      'Looking for museums in Amsterdam and wondering where to start? MuseumBuddy gives you one practical overview to compare museums by theme, atmosphere, and what is currently on view. Whether you prefer art, history, photography, design, or science, you can quickly see which museum fits your day. Use search and filters to narrow options, then open each museum page for opening hours, location details, and direct links for tickets or planning your route.',
+    homeSeoFooterHeading: 'Plan your next museum stop in Amsterdam',
     homeSeoFooter:
-      'Looking for exhibitions in Amsterdam? View the latest overview and connect each exhibition directly to the museum page for practical planning.',
+      'Use this page as your starting point to explore museums in Amsterdam efficiently, especially when your time in the city is limited. You can shortlist options, check practical details, and move from inspiration to planning in a few clicks. If you want to decide based on what is currently on display, continue to our exhibitions overview and connect each exhibition to the right museum page for a smoother day plan.',
     heroDiscoverMuseums: 'Discover museums',
-    heroViewExhibitions: 'View exhibitions',
-    exhibitionsPageTitle: 'Exhibitions in Amsterdam | MuseumBuddy',
+    heroViewExhibitions: 'View exhibitions in Amsterdam',
+    exhibitionsPageTitle: 'Exhibitions in Amsterdam: current overview | MuseumBuddy',
     exhibitionsPageDescription:
-      'Browse current and upcoming exhibitions in Amsterdam museums and quickly decide what to see next.',
+      'Browse current and upcoming exhibitions in Amsterdam museums, compare themes quickly, and decide what to see next with direct links to each museum.',
     exhibitionsPageHeading: 'Exhibitions in Amsterdam',
     exhibitionsPageSubtitle: 'See what is on view across Amsterdam museums right now.',
+    exhibitionsSeoIntroHeading: 'Current exhibitions in Amsterdam, clearly grouped',
     exhibitionsSeoIntro:
-      'Use this overview to discover exhibitions in Amsterdam across art, history, photography, and contemporary museum programs.',
+      'This exhibitions overview helps you discover what is currently on view in Amsterdam without opening dozens of separate museum websites. Compare exhibition topics, timing, and museum context in one place so you can choose faster. From contemporary art and photography to history and design, you can scan what matches your interests and click through to the relevant museum page for practical details before your visit.',
+    exhibitionsSeoFooterHeading: 'From exhibitions to museums in Amsterdam',
     exhibitionsSeoFooter:
-      'Prefer starting with museums first? Explore the full Amsterdam museums overview and then narrow down by exhibition.',
+      'If you already know the type of exhibition you want to see, this page is the quickest route to plan your museum visit. For broader orientation, start with our museums overview to compare locations and museum profiles first, then return here to select the exhibitions that fit your schedule. Together, both pages help you build a practical Amsterdam museum itinerary with less searching and better choices.',
     exhibitionsListHostedBy: 'At {museum}',
     exhibitionsListCardTitle: '{exhibition} — {museum}',
     homeValueTag: 'Why MuseumBuddy',
@@ -189,27 +194,31 @@ const translations = {
       'Some links on this website are affiliate links. That means we may receive a small commission if you buy a ticket or make a reservation via such a link. This costs you nothing extra; prices may vary. We only include links that match the content of MuseumBuddy.',
   },
   nl: {
-    homeTitle: 'Musea in Amsterdam | MuseumBuddy',
+    homeTitle: 'Musea in Amsterdam: plan je bezoek | MuseumBuddy',
     homeDescription:
-      'Ontdek musea in Amsterdam en plan je bezoek met actuele tentoonstellingen in één duidelijk overzicht.',
+      'Ontdek musea in Amsterdam, vergelijk highlights op interesse en plan je bezoek met actuele tentoonstellingen, praktische bezoekersinfo en snelle links in één duidelijk overzicht.',
     heroTagline: 'Cultuurkompas',
-    heroTitle: 'Plan je museumdag in Amsterdam',
+    heroTitle: 'Musea in Amsterdam: plan je museumdag',
     heroSubtitle: 'Vind in een paar minuten musea in Amsterdam en actuele tentoonstellingen.',
+    homeSeoIntroHeading: 'Musea in Amsterdam voor elke interesse',
     homeSeoIntro:
-      'MuseumBuddy helpt je snel musea in Amsterdam te vergelijken, zodat je eenvoudig kiest wat je wilt bezoeken op basis van interesse en actuele tentoonstellingen.',
+      'Zoek je musea in Amsterdam en wil je snel bepalen waar je naartoe gaat? Met MuseumBuddy vergelijk je in één overzicht musea op thema, sfeer en wat er nu te zien is. Of je nu vooral kunst, geschiedenis, fotografie, design of wetenschap zoekt: je krijgt direct een praktisch startpunt voor je museumdag. Gebruik zoeken en filters om gericht te kiezen en klik daarna door naar de museumpagina voor openingstijden, locatiegegevens en links naar tickets of routeplanning.',
+    homeSeoFooterHeading: 'Plan je volgende museumbezoek in Amsterdam',
     homeSeoFooter:
-      'Zoek je vooral tentoonstellingen in Amsterdam? Bekijk het actuele overzicht en ga direct door naar het juiste museum.',
+      'Gebruik deze pagina als centraal overzicht om musea in Amsterdam efficiënt te vergelijken, zeker als je beperkte tijd hebt in de stad. Je kunt snel favorieten selecteren, praktische details checken en in een paar klikken van inspiratie naar planning gaan. Wil je vooral kiezen op basis van wat er nu loopt? Ga dan door naar het tentoonstellingsoverzicht en koppel elke tentoonstelling direct aan het juiste museum voor een soepelere dagindeling.',
     heroDiscoverMuseums: 'Ontdek musea',
-    heroViewExhibitions: 'Bekijk tentoonstellingen',
-    exhibitionsPageTitle: 'Tentoonstellingen in Amsterdam | MuseumBuddy',
+    heroViewExhibitions: 'Bekijk tentoonstellingen in Amsterdam',
+    exhibitionsPageTitle: 'Tentoonstellingen in Amsterdam: actueel overzicht | MuseumBuddy',
     exhibitionsPageDescription:
-      'Bekijk lopende en komende tentoonstellingen in Amsterdamse musea en beslis snel wat je nu wilt zien.',
+      'Bekijk lopende en komende tentoonstellingen in Amsterdamse musea, vergelijk thema’s snel en beslis wat je nu wilt zien met directe links naar elk museum.',
     exhibitionsPageHeading: 'Tentoonstellingen in Amsterdam',
     exhibitionsPageSubtitle: 'Zie wat er nu in de Amsterdamse musea te zien is.',
+    exhibitionsSeoIntroHeading: 'Actuele tentoonstellingen in Amsterdam, overzichtelijk bij elkaar',
     exhibitionsSeoIntro:
-      'Gebruik dit overzicht om tentoonstellingen in Amsterdam te ontdekken in kunst, geschiedenis, fotografie en moderne museumprogrammering.',
+      'Met dit overzicht ontdek je snel welke tentoonstellingen in Amsterdam nu te zien zijn, zonder tientallen losse museumsites te openen. Vergelijk onderwerpen, looptijden en musea in één lijst, zodat je sneller beslist wat bij jouw interesse past. Van hedendaagse kunst en fotografie tot geschiedenis en design: je ziet direct waar je moet zijn en klikt vervolgens door naar de juiste museumpagina voor praktische bezoekersinformatie.',
+    exhibitionsSeoFooterHeading: 'Van tentoonstelling naar museumbezoek in Amsterdam',
     exhibitionsSeoFooter:
-      'Begin je liever bij een museum? Bekijk het volledige overzicht van musea in Amsterdam en ga daarna door naar lopende tentoonstellingen.',
+      'Weet je al welk type tentoonstelling je zoekt, dan is dit de snelste manier om je museumdag te plannen. Wil je eerst breder oriënteren op locaties en museumprofielen, start dan op het overzicht van musea in Amsterdam en kom daarna terug om lopende tentoonstellingen te kiezen. Samen geven deze pagina’s je een praktisch en actueel vertrekpunt voor een goed geplande culturele dag in de stad.',
     exhibitionsListHostedBy: 'Te zien in {museum}',
     exhibitionsListCardTitle: '{exhibition} — {museum}',
     homeValueTag: 'Waarom MuseumBuddy',

--- a/pages/index.js
+++ b/pages/index.js
@@ -925,6 +925,7 @@ export default function Home({ initialMuseums = [], initialError = null }) {
           <span className="hero-tagline">{t('heroTagline')}</span>
           <h1 className="hero-title">{t('heroTitle')}</h1>
           <p className="hero-subtext">{t('heroSubtitle')}</p>
+          <h2 className="page-subtitle">{t('homeSeoIntroHeading')}</h2>
           <p className="hero-subtext">{t('homeSeoIntro')}</p>
           <div className="hero-ctas">
             <Button
@@ -1053,10 +1054,13 @@ export default function Home({ initialMuseums = [], initialError = null }) {
         )}
       </section>
       <section className="page-intro" aria-label="SEO content">
+        <h2 className="page-subtitle">{t('homeSeoFooterHeading')}</h2>
         <p className="page-subtitle">
           {t('homeSeoFooter')}{' '}
           <Link href="/tentoonstellingen">{
-            lang === 'nl' ? 'Tentoonstellingen in Amsterdam' : 'Exhibitions in Amsterdam'
+            lang === 'nl'
+              ? 'Bekijk alle tentoonstellingen in Amsterdam'
+              : 'View all exhibitions in Amsterdam'
           }</Link>.
         </p>
       </section>

--- a/pages/tentoonstellingen.js
+++ b/pages/tentoonstellingen.js
@@ -823,6 +823,7 @@ export default function ExhibitionsPage({ exhibitions = [], error = null }) {
           {t('exhibitionsPageHeading')}
         </h1>
         <p className="page-subtitle">{t('exhibitionsPageSubtitle')}</p>
+        <h2 className="page-subtitle">{t('exhibitionsSeoIntroHeading')}</h2>
         <p className="page-subtitle">{t('exhibitionsSeoIntro')}</p>
       </section>
       <p className="count">
@@ -869,9 +870,10 @@ export default function ExhibitionsPage({ exhibitions = [], error = null }) {
         </ul>
       )}
       <section className="page-intro" aria-label="SEO content">
+        <h2 className="page-subtitle">{t('exhibitionsSeoFooterHeading')}</h2>
         <p className="page-subtitle">
           {t('exhibitionsSeoFooter')}{' '}
-          <Link href="/">{lang === 'nl' ? 'Musea in Amsterdam' : 'Museums in Amsterdam'}</Link>.
+          <Link href="/">{lang === 'nl' ? 'Bekijk alle musea in Amsterdam' : 'View all museums in Amsterdam'}</Link>.
         </p>
       </section>
     </>


### PR DESCRIPTION
### Motivation
- Improve on-page SEO and user guidance by adding explicit intro and footer headings and richer explanatory copy for the Home and Exhibitions pages in both languages.
- Make the new SEO copy visible in the UI so users and search engines can find clearer context for the listings.

### Description
- Expanded and refined translation text in `lib/translations.js` for `en` and `nl`, added `homeSeoIntroHeading`, `homeSeoFooterHeading`, `exhibitionsSeoIntroHeading`, and `exhibitionsSeoFooterHeading`, and adjusted multiple page title/description strings.
- Updated `pages/index.js` to render the new `homeSeoIntroHeading` above the intro paragraph and `homeSeoFooterHeading` in the footer SEO section, and updated the footer link text to `View all exhibitions in Amsterdam` / `Bekijk alle tentoonstellingen in Amsterdam`.
- Updated `pages/tentoonstellingen.js` to render the new `exhibitionsSeoIntroHeading` above the exhibitions intro and `exhibitionsSeoFooterHeading` in the footer SEO section, and updated the footer link text to `View all museums in Amsterdam` / `Bekijk alle musea in Amsterdam`.
- Small copy tweaks to existing translation keys (titles, subtitles, and page descriptions) to improve clarity and consistency.

### Testing
- Ran the local development server and verified the Home and Exhibitions pages display the new headings and copy without runtime errors.
- Ran linting and static checks with `npm run lint` and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf0219ca648326a8e8dd2b2738bcc7)