### PR TITLE
Add 'Back to homepage' button to Exhibitions page

### DIFF
--- a/lib/translations.js
+++ b/lib/translations.js
@@ -20,6 +20,7 @@ const translations = {
       'Browse current and upcoming exhibitions in Amsterdam museums, compare themes quickly, and decide what to see next with direct links to each museum.',
     exhibitionsPageHeading: 'Exhibitions in Amsterdam',
     exhibitionsPageSubtitle: 'See what is on view across Amsterdam museums right now.',
+    exhibitionsBackHome: 'Back to homepage',
     exhibitionsSeoIntroHeading: 'Current exhibitions in Amsterdam, clearly grouped',
     exhibitionsSeoIntro:
       'This exhibitions overview helps you discover what is currently on view in Amsterdam without opening dozens of separate museum websites. Compare exhibition topics, timing, and museum context in one place so you can choose faster. From contemporary art and photography to history and design, you can scan what matches your interests and click through to the relevant museum page for practical details before your visit.',
@@ -215,6 +216,7 @@ const translations = {
       'Bekijk lopende en komende tentoonstellingen in Amsterdamse musea, vergelijk thema’s snel en beslis wat je nu wilt zien met directe links naar elk museum.',
     exhibitionsPageHeading: 'Tentoonstellingen in Amsterdam',
     exhibitionsPageSubtitle: 'Zie wat er nu in de Amsterdamse musea te zien is.',
+    exhibitionsBackHome: 'Terug naar homepage',
     exhibitionsSeoIntroHeading: 'Actuele tentoonstellingen in Amsterdam, overzichtelijk bij elkaar',
     exhibitionsSeoIntro:
       'Met dit overzicht ontdek je snel welke tentoonstellingen in Amsterdam nu te zien zijn, zonder tientallen losse museumsites te openen. Vergelijk onderwerpen, looptijden en musea in één lijst, zodat je sneller beslist wat bij jouw interesse past. Van hedendaagse kunst en fotografie tot geschiedenis en design: je ziet direct waar je moet zijn en klikt vervolgens door naar de juiste museumpagina voor praktische bezoekersinformatie.',

--- a/pages/tentoonstellingen.js
+++ b/pages/tentoonstellingen.js
@@ -851,6 +851,9 @@ export default function ExhibitionsPage({ exhibitions = [], error = null }) {
           {t('exhibitionsPageHeading')}
         </h1>
         <p className="page-subtitle">{t('exhibitionsPageSubtitle')}</p>
+        <Button href="/" variant="secondary" size="sm">
+          {t('exhibitionsBackHome')}
+        </Button>
         <h2 className="page-subtitle">{t('exhibitionsSeoIntroHeading')}</h2>
         <p className="page-subtitle">{t('exhibitionsSeoIntro')}</p>
       </section>


### PR DESCRIPTION
### Motivation
- Provide an explicit, accessible way for users to navigate from the exhibitions overview back to the site homepage by adding a visible button in the page intro. 
- No special skill was used — the update is a small UI change applied directly to the page files.

### Description
- Added a secondary `Button` linking to the homepage (`href="/"`) in `pages/tentoonstellingen.js` under the exhibitions intro section. 
- Added a new translation key `exhibitionsBackHome` in `lib/translations.js` for both English and Dutch to keep the button label localised. 
- Modified files: `pages/tentoonstellingen.js` and `lib/translations.js`.

### Testing
- Ran the project's test suite with `npm test`, which executes `tests/ticketCta.test.cjs`, `tests/kidFriendlyFilter.test.cjs`, `tests/nearbyFilter.test.cjs`, and `tests/museumSearch.test.cjs`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf0ef7e6d08326989120166ab9ebd0)