### PR TITLE
Add crawlable links to museum detail pages from listing cards

### DIFF
--- a/components/MuseumCard.js
+++ b/components/MuseumCard.js
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 import { Fragment, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useFavorites } from './FavoritesContext';
@@ -528,6 +529,28 @@ export default function MuseumCard({
     [isInteractiveEvent, navigateToMuseum]
   );
 
+  const handleDetailLinkClick = useCallback(
+    (event) => {
+      const openInNewTab = event.metaKey || event.ctrlKey;
+      trackCardClick({
+        ...analyticsData,
+        openInNewTab,
+      });
+    },
+    [analyticsData]
+  );
+
+  const handleDetailLinkAuxClick = useCallback(
+    (event) => {
+      if (event.button !== 1) return;
+      trackCardClick({
+        ...analyticsData,
+        openInNewTab: true,
+      });
+    },
+    [analyticsData]
+  );
+
   return (
     <article
       className="museum-card"
@@ -541,37 +564,46 @@ export default function MuseumCard({
       onKeyDown={handleCardKeyDown}
     >
       <div className="museum-card-image">
-        {normalizedImage && (
-          <Image
-            src={normalizedImage}
-            alt={imageAlt}
-            fill
-            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-            className="museum-card-media"
-            style={{ objectFit: 'cover' }}
-            {...(placeholderDataUrl ? { placeholder: 'blur', blurDataURL: placeholderDataUrl } : {})}
-            priority={priority}
-            loading={priority ? 'eager' : 'lazy'}
-            fetchPriority={priority ? 'high' : 'auto'}
-            quality={70}
-          />
-        )}
-        <div className="museum-card-overlay" aria-hidden="true">
-          <span className="museum-card-overlay-label">{t('view')}</span>
-          <span className="museum-card-overlay-icon">
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M5 12h14" />
-              <path d="M13 6l6 6-6 6" />
-            </svg>
-          </span>
-        </div>
+        <Link
+          href={detailHref}
+          className="museum-card-media-link"
+          aria-label={`${t('view')} ${displayName}`}
+          data-card-interactive="true"
+          onClick={handleDetailLinkClick}
+          onAuxClick={handleDetailLinkAuxClick}
+        >
+          {normalizedImage && (
+            <Image
+              src={normalizedImage}
+              alt={imageAlt}
+              fill
+              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+              className="museum-card-media"
+              style={{ objectFit: 'cover' }}
+              {...(placeholderDataUrl ? { placeholder: 'blur', blurDataURL: placeholderDataUrl } : {})}
+              priority={priority}
+              loading={priority ? 'eager' : 'lazy'}
+              fetchPriority={priority ? 'high' : 'auto'}
+              quality={70}
+            />
+          )}
+          <div className="museum-card-overlay" aria-hidden="true">
+            <span className="museum-card-overlay-label">{t('view')}</span>
+            <span className="museum-card-overlay-icon">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M5 12h14" />
+                <path d="M13 6l6 6-6 6" />
+              </svg>
+            </span>
+          </div>
+        </Link>
         <div className="museum-card-ticket" data-card-interactive="true">
           {renderTicketButton('ticket-button--card')}
         </div>
@@ -627,7 +659,15 @@ export default function MuseumCard({
             </p>
           )}
           <h3 className="museum-card-title" id={headingId}>
-            {museum.title}
+            <Link
+              href={detailHref}
+              className="museum-card-title-link"
+              data-card-interactive="true"
+              onClick={handleDetailLinkClick}
+              onAuxClick={handleDetailLinkAuxClick}
+            >
+              {museum.title}
+            </Link>
           </h3>
           {summary && (
             <p className="museum-card-summary" id={summaryId}>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3367,6 +3367,21 @@ button.hero-quick-link {
   line-height: 1.25;
 }
 
+.museum-card-title-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.museum-card-title-link:hover {
+  text-decoration: underline;
+}
+
+.museum-card-title-link:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.45);
+  outline-offset: 3px;
+  border-radius: 0.25rem;
+}
+
 .museum-card-location {
   margin: 0;
   display: inline-flex;


### PR DESCRIPTION
### Motivation
- Museum detail pages were only reachable via JS-driven card interactions (`role="link"` + `router.push`), which prevents search engines from discovering internal museum detail URLs from listing pages. 
- Improving crawlability of the museum listings is the highest-impact SEO fix from the audit, while preserving existing click/keyboard UX and analytics.

### Description
- Added `next/link` to `MuseumCard` and rendered real crawlable links (`href` -> `/museum/[slug]`) for the image/overlay area and the museum title to expose detail URLs in the HTML. 
- Preserved the existing card-level click/keyboard behavior as a supplemental navigation fallback and kept analytics by adding link `onClick` / `onAuxClick` handlers that call `trackCardClick` for normal, cmd/ctrl and middle-clicks. 
- Avoided nested interactive elements by keeping ticket/share/favorite/category controls outside the link regions and marking link regions with `data-card-interactive="true"` to keep the card event guard working. 
- Added minimal CSS for `.museum-card-title-link` to maintain visual appearance and provide a clear focus ring for accessibility. 
- Files changed: `components/MuseumCard.js`, `styles/globals.css`.

### Testing
- Ran the project test suite with `npm test` and all automated tests passed (`Ticket CTA copy tests`, `Kid-friendly filter tests`, `Nearby filter tests`, `Museum search parsing tests`).
- No visual regressions were introduced intentionally and CSS changes were minimal to preserve current styling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c12f177ad083269f3fa3f89c6b316f)