### PR TITLE
Enrich homepage and exhibitions JSON-LD ItemList with concrete ListItem entries

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -854,23 +854,48 @@ export default function Home({ initialMuseums = [], initialError = null }) {
     [t]
   );
   const homeStructuredData = useMemo(
-    () => ({
-      '@context': 'https://schema.org',
-      '@type': 'CollectionPage',
-      name: t('homeTitle'),
-      description: t('homeDescription'),
-      url: `${SITE_URL}/`,
-      inLanguage: lang === 'nl' ? 'nl-NL' : 'en',
-      about: {
-        '@type': 'Place',
-        name: 'Amsterdam',
-      },
-      mainEntity: {
-        '@type': 'ItemList',
-        name: lang === 'nl' ? 'Musea in Amsterdam' : 'Museums in Amsterdam',
-      },
-    }),
-    [lang, t]
+    () => {
+      const schemaMuseumsSource =
+        initialSortedMuseums.length > 0 ? initialSortedMuseums : staticMuseumsWithCategories;
+      const schemaMuseums = schemaMuseumsSource
+        .filter((museum) => museum?.slug && museum.slug !== 'amsterdam-tulip-museum-amsterdam')
+        .slice(0, 30);
+
+      return {
+        '@context': 'https://schema.org',
+        '@type': 'CollectionPage',
+        name: t('homeTitle'),
+        description: t('homeDescription'),
+        url: `${SITE_URL}/`,
+        inLanguage: lang === 'nl' ? 'nl-NL' : 'en',
+        about: {
+          '@type': 'Place',
+          name: 'Amsterdam',
+        },
+        mainEntity: {
+          '@type': 'ItemList',
+          name: lang === 'nl' ? 'Musea in Amsterdam' : 'Museums in Amsterdam',
+          numberOfItems: schemaMuseums.length,
+          itemListElement: schemaMuseums.map((museum, index) => {
+            const museumName = museumNames[museum.slug] || museum.naam || museum.name || museum.slug;
+            const museumUrl = `${SITE_URL}/museum/${museum.slug}`;
+            return {
+              '@type': 'ListItem',
+              position: index + 1,
+              url: museumUrl,
+              name: museumName,
+              item: {
+                '@type': 'WebPage',
+                '@id': museumUrl,
+                url: museumUrl,
+                name: museumName,
+              },
+            };
+          }),
+        },
+      };
+    },
+    [initialSortedMuseums, lang, staticMuseumsWithCategories, t]
   );
 
   if (error) {

--- a/pages/tentoonstellingen.js
+++ b/pages/tentoonstellingen.js
@@ -796,23 +796,54 @@ export default function ExhibitionsPage({ exhibitions = [], error = null }) {
   const hasBaseCards = allCards.length > 0;
   const hasVisibleCards = visibleCards.length > 0;
   const exhibitionsStructuredData = useMemo(
-    () => ({
-      '@context': 'https://schema.org',
-      '@type': 'CollectionPage',
-      name: t('exhibitionsPageTitle'),
-      description: t('exhibitionsPageDescription'),
-      url: `${SITE_URL}/tentoonstellingen`,
-      inLanguage: lang === 'nl' ? 'nl-NL' : 'en',
-      about: {
-        '@type': 'Place',
-        name: 'Amsterdam',
-      },
-      mainEntity: {
-        '@type': 'ItemList',
-        name: lang === 'nl' ? 'Tentoonstellingen in Amsterdam' : 'Exhibitions in Amsterdam',
-      },
-    }),
-    [lang, t]
+    () => {
+      const schemaCards = allCards
+        .filter((card) => card?.title && card?.slug)
+        .slice(0, 40);
+
+      return {
+        '@context': 'https://schema.org',
+        '@type': 'CollectionPage',
+        name: t('exhibitionsPageTitle'),
+        description: t('exhibitionsPageDescription'),
+        url: `${SITE_URL}/tentoonstellingen`,
+        inLanguage: lang === 'nl' ? 'nl-NL' : 'en',
+        about: {
+          '@type': 'Place',
+          name: 'Amsterdam',
+        },
+        mainEntity: {
+          '@type': 'ItemList',
+          name: lang === 'nl' ? 'Tentoonstellingen in Amsterdam' : 'Exhibitions in Amsterdam',
+          numberOfItems: schemaCards.length,
+          itemListElement: schemaCards.map((card, index) => {
+            const exhibitionUrl = `${SITE_URL}/tentoonstellingen?museums=${encodeURIComponent(card.slug)}`;
+            const museumUrl = `${SITE_URL}/museum/${card.slug}`;
+            const exhibitionName = card.title;
+
+            return {
+              '@type': 'ListItem',
+              position: index + 1,
+              url: exhibitionUrl,
+              name: exhibitionName,
+              item: {
+                '@type': 'Event',
+                name: exhibitionName,
+                url: exhibitionUrl,
+                location: {
+                  '@type': 'Place',
+                  name: card.museumName || museumNames[card.slug] || card.slug,
+                  url: museumUrl,
+                },
+                ...(card.startDate ? { startDate: card.startDate } : {}),
+                ...(card.endDate ? { endDate: card.endDate } : {}),
+              },
+            };
+          }),
+        },
+      };
+    },
+    [allCards, lang, t]
   );
 
   return (


### PR DESCRIPTION
### Motivation
- Improve Google’s understanding of the most important SEO pages by providing richer, concrete schema for lists (CollectionPage → ItemList → ListItem).  
- Reuse existing, already-working patterns (other landing pages) and only surface data that is present in the codebase.  
- Keep JSON-LD valid and conservative (no invented claims) while preserving visible UI text.

### Description
- Homepage: build a populated `ItemList` from `initialSortedMuseums` (fallback `staticMuseumsWithCategories`), add `numberOfItems` and `itemListElement` entries with stable absolute URLs (`https://.../museum/{slug}`) and per-item `WebPage` objects for clearer entity targeting. Files changed: `pages/index.js` (homeStructuredData).  
- Exhibitions page: build `ItemList` entries from `allCards`, add `numberOfItems` and `itemListElement` entries that map each list item to an `Event` object including `location` (museum), and optional `startDate`/`endDate` when available; use stable absolute URLs for the filtered exhibition links and museum pages. Files changed: `pages/tentoonstellingen.js` (exhibitionsStructuredData).  
- Safe limits and reuse: entries are sliced (`.slice(0, 30/40)`) to avoid extremely large payloads, and existing helpers/data like `museumNames` and the `allCards` mapping are reused; visible UI copy was not changed.

### Testing
- Ran the project test suite with `npm test`, which runs `tests/ticketCta.test.cjs`, `tests/kidFriendlyFilter.test.cjs`, `tests/nearbyFilter.test.cjs`, and `tests/museumSearch.test.cjs`, and all tests passed.  
- No additional automated validation (lint/build) was run as part of this change; unit tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c15c78ee5483268a908a3a1f08a868)