### PR TITLE
Improve homepage SEO for Amsterdam museum search intent

### DIFF
--- a/lib/translations.js
+++ b/lib/translations.js
@@ -1,18 +1,24 @@
 const translations = {
   en: {
-    homeTitle: 'Museums in Amsterdam: plan your visit | MuseumBuddy',
+    homeTitle: 'Best museums in Amsterdam & current exhibitions | MuseumBuddy',
     homeDescription:
-      'Discover museums in Amsterdam, compare highlights by interest, and plan your visit with current exhibitions, practical visitor info, and quick links in one clear overview.',
+      'Discover the best museums in Amsterdam, current exhibitions, and practical tips for family-friendly and free museums in one clear overview.',
     heroTagline: 'Culture compass',
-    heroTitle: 'Museums in Amsterdam: plan your museum day',
+    heroTitle: 'Find the best museums in Amsterdam for your day',
     heroSubtitle:
-      'Discover museums in Amsterdam in one clear overview and quickly see what is currently on view across the city.',
+      'Compare museums in Amsterdam, see current exhibitions, and quickly pick family-friendly or free options that match your plans.',
     homeSeoIntroHeading: 'Discover museums in Amsterdam',
     homeSeoIntro:
-      'Looking for museums in Amsterdam and not sure where to start? MuseumBuddy gives you one practical overview to compare museums by theme, atmosphere, and what is currently on view. Whether you prefer art, history, photography, design, or science, you can quickly see which museum fits your day. Use search and filters to narrow your options, then open each museum page for opening hours, location details, and direct links for tickets or route planning.',
+      'Looking for museums in Amsterdam and not sure where to start? MuseumBuddy gives you one practical overview to compare the best museums in Amsterdam by theme, atmosphere, and what is currently on view. Whether you prefer art, history, photography, design, or science, you can quickly see which museum fits your day. Use search and filters to narrow your options, then open each museum page for opening hours, location details, and direct links for tickets or route planning.',
     homeSeoFooterHeading: 'Plan your next museum stop in Amsterdam',
     homeSeoFooter:
       'Use this page as your starting point to explore museums in Amsterdam efficiently, especially when your time in the city is limited. You can shortlist options, check practical details, and move from inspiration to planning in a few clicks. If you want to decide based on what is currently on display, continue to our exhibitions overview and connect each exhibition to the right museum page for a smoother day plan.',
+    homeSeoLinksIntro: 'Popular museum guides:',
+    homeSeoLinkExhibitions: 'Exhibitions in Amsterdam',
+    homeSeoLinkKidFriendly: 'Kid-friendly museums in Amsterdam',
+    homeSeoLinkFree: 'Free museums in Amsterdam',
+    homeSeoLinkRijksmuseum: 'Rijksmuseum',
+    homeSeoLinkVanGogh: 'Van Gogh Museum',
     heroDiscoverMuseums: 'Discover museums',
     heroViewExhibitions: 'View exhibitions in Amsterdam',
     exhibitionsPageTitle: 'Exhibitions in Amsterdam: current overview | MuseumBuddy',
@@ -196,19 +202,25 @@ const translations = {
       'Some links on this website are affiliate links. That means we may receive a small commission if you buy a ticket or make a reservation via such a link. This costs you nothing extra; prices may vary. We only include links that match the content of MuseumBuddy.',
   },
   nl: {
-    homeTitle: 'Musea in Amsterdam: plan je bezoek | MuseumBuddy',
+    homeTitle: 'Beste musea in Amsterdam & actuele tentoonstellingen | MuseumBuddy',
     homeDescription:
-      'Ontdek musea in Amsterdam, vergelijk highlights op interesse en plan je bezoek met actuele tentoonstellingen, praktische bezoekersinfo en snelle links in één duidelijk overzicht.',
+      'Ontdek de beste musea in Amsterdam, actuele tentoonstellingen en praktische tips voor kindvriendelijke en gratis musea in één overzicht.',
     heroTagline: 'Cultuurkompas',
-    heroTitle: 'Musea in Amsterdam: plan je museumdag',
+    heroTitle: 'Vind de beste musea in Amsterdam voor jouw dag',
     heroSubtitle:
-      'Ontdek musea in Amsterdam in één overzicht en zie snel wat er nu te zien is in de stad.',
+      'Vergelijk musea in Amsterdam, bekijk actuele tentoonstellingen en kies snel kindvriendelijke of gratis opties die bij je plannen passen.',
     homeSeoIntroHeading: 'Musea in Amsterdam ontdekken',
     homeSeoIntro:
-      'Zoek je musea in Amsterdam en weet je nog niet waar je wilt beginnen? Met MuseumBuddy vergelijk je in één overzicht musea op thema, sfeer en wat er nu te zien is. Of je nu vooral kunst, geschiedenis, fotografie, design of wetenschap zoekt: je krijgt direct een praktisch startpunt voor je museumdag. Gebruik zoeken en filters om gerichter te kiezen en klik daarna door naar de museumpagina voor openingstijden, locatiegegevens en links naar tickets of routeplanning.',
+      'Zoek je musea in Amsterdam en weet je nog niet waar je wilt beginnen? Met MuseumBuddy vergelijk je in één overzicht de beste musea in Amsterdam op thema, sfeer en wat er nu te zien is. Of je nu vooral kunst, geschiedenis, fotografie, design of wetenschap zoekt: je krijgt direct een praktisch startpunt voor je museumdag. Gebruik zoeken en filters om gerichter te kiezen en klik daarna door naar de museumpagina voor openingstijden, locatiegegevens en links naar tickets of routeplanning.',
     homeSeoFooterHeading: 'Plan je volgende museumbezoek in Amsterdam',
     homeSeoFooter:
       'Gebruik deze pagina als centraal overzicht om musea in Amsterdam efficiënt te vergelijken, zeker als je beperkte tijd hebt in de stad. Je kunt snel favorieten selecteren, praktische details checken en in een paar klikken van inspiratie naar planning gaan. Wil je vooral kiezen op basis van wat er nu loopt? Ga dan door naar het tentoonstellingsoverzicht en koppel elke tentoonstelling direct aan het juiste museum voor een soepelere dagindeling.',
+    homeSeoLinksIntro: 'Populaire museumgidsen:',
+    homeSeoLinkExhibitions: 'Tentoonstellingen in Amsterdam',
+    homeSeoLinkKidFriendly: 'Kindvriendelijke musea in Amsterdam',
+    homeSeoLinkFree: 'Gratis musea in Amsterdam',
+    homeSeoLinkRijksmuseum: 'Rijksmuseum',
+    homeSeoLinkVanGogh: 'Van Gogh Museum',
     heroDiscoverMuseums: 'Ontdek musea',
     heroViewExhibitions: 'Bekijk tentoonstellingen in Amsterdam',
     exhibitionsPageTitle: 'Tentoonstellingen in Amsterdam: actueel overzicht | MuseumBuddy',

--- a/pages/index.js
+++ b/pages/index.js
@@ -1088,6 +1088,14 @@ export default function Home({ initialMuseums = [], initialError = null }) {
               : 'View all exhibitions in Amsterdam'
           }</Link>.
         </p>
+        <p className="page-subtitle">
+          {t('homeSeoLinksIntro')}{' '}
+          <Link href="/tentoonstellingen">{t('homeSeoLinkExhibitions')}</Link>,{' '}
+          <Link href="/kindvriendelijke-musea-amsterdam">{t('homeSeoLinkKidFriendly')}</Link>,{' '}
+          <Link href="/gratis-musea-amsterdam">{t('homeSeoLinkFree')}</Link>,{' '}
+          <Link href="/museum/rijksmuseum-amsterdam">{t('homeSeoLinkRijksmuseum')}</Link>,{' '}
+          <Link href="/museum/van-gogh-museum-amsterdam">{t('homeSeoLinkVanGogh')}</Link>.
+        </p>
       </section>
     </>
   );


### PR DESCRIPTION
### Motivation
- Increase the homepage relevance for search queries around museums in Amsterdam (e.g. “museums in Amsterdam”, “best museums in Amsterdam”, “exhibitions in Amsterdam”, family/kid-friendly and free museums) while preserving the current UX and tone. 
- Surface more targeted keywords in visible metadata and hero copy so search engines understand the page intent without keyword-stuffing. 
- Strengthen internal linking from the homepage to high-value SEO landing and detail pages to improve discoverability and internal page authority.

### Description
- Updated translation copy (EN + NL) in `lib/translations.js` to modify the homepage title (`homeTitle`), meta description (`homeDescription`), hero H1 (`heroTitle`), hero subtitle (`heroSubtitle`) and the long-form intro (`homeSeoIntro`) to better target Amsterdam museum intents. 
- Added new translation keys for a small internal-link cluster: `homeSeoLinksIntro`, `homeSeoLinkExhibitions`, `homeSeoLinkKidFriendly`, `homeSeoLinkFree`, `homeSeoLinkRijksmuseum`, and `homeSeoLinkVanGogh`. 
- Inserted a short link cluster in the homepage SEO content block in `pages/index.js` that links to `/tentoonstellingen`, `/kindvriendelijke-musea-amsterdam`, `/gratis-musea-amsterdam`, and two high-intent museum detail pages (`/museum/rijksmuseum-amsterdam`, `/museum/van-gogh-museum-amsterdam`) without changing layout or component structure. 
- Kept all UX, layout, and component boundaries intact; this is a copy + internal-linking change only (no CSS/structural changes).

### Testing
- Ran unit/logic tests with `npm test`, and all automated tests passed (`Ticket CTA copy tests passed`, `Kid-friendly filter tests passed`, `Nearby filter results remain visible`, `Museum search parsing tests passed`).
- Built the site with `npm run build`, which completed successfully and statically generated pages (production build completed, pages compiled). 
- No automated test failures or build errors were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c163d576cc8326862900e0be19c127)