### PR TITLE
Update homepage hero subtitle to remove unsupported claims

### DIFF
--- a/lib/translations.js
+++ b/lib/translations.js
@@ -6,7 +6,7 @@ const translations = {
     heroTagline: 'Culture compass',
     heroTitle: 'Find the best museums in Amsterdam for your day',
     heroSubtitle:
-      'Compare museums in Amsterdam, see current exhibitions, and quickly pick family-friendly or free options that match your plans.',
+      'Compare museums in Amsterdam, explore current exhibitions, and find the ones that match your interests.',
     homeSeoIntroHeading: 'Discover museums in Amsterdam',
     homeSeoIntro:
       'Looking for museums in Amsterdam and not sure where to start? MuseumBuddy gives you one practical overview to compare the best museums in Amsterdam by theme, atmosphere, and what is currently on view. Whether you prefer art, history, photography, design, or science, you can quickly see which museum fits your day. Use search and filters to narrow your options, then open each museum page for opening hours, location details, and direct links for tickets or route planning.',
@@ -208,7 +208,7 @@ const translations = {
     heroTagline: 'Cultuurkompas',
     heroTitle: 'Vind de beste musea in Amsterdam voor jouw dag',
     heroSubtitle:
-      'Vergelijk musea in Amsterdam, bekijk actuele tentoonstellingen en kies snel kindvriendelijke of gratis opties die bij je plannen passen.',
+      'Vergelijk musea in Amsterdam, ontdek actuele tentoonstellingen en vind wat het beste bij jouw plannen past.',
     homeSeoIntroHeading: 'Musea in Amsterdam ontdekken',
     homeSeoIntro:
       'Zoek je musea in Amsterdam en weet je nog niet waar je wilt beginnen? Met MuseumBuddy vergelijk je in één overzicht de beste musea in Amsterdam op thema, sfeer en wat er nu te zien is. Of je nu vooral kunst, geschiedenis, fotografie, design of wetenschap zoekt: je krijgt direct een praktisch startpunt voor je museumdag. Gebruik zoeken en filters om gerichter te kiezen en klik daarna door naar de museumpagina voor openingstijden, locatiegegevens en links naar tickets of routeplanning.',


### PR DESCRIPTION
### Motivation
- The homepage hero copy referenced “family-friendly” and “free” options that the current homepage does not reliably provide, creating a mismatch between user expectations and site functionality.
- The change aims to make the message product-accurate while preserving SEO relevance for searches like "museums in Amsterdam".

### Description
- Replaced the `heroSubtitle` translation strings in `lib/translations.js` for `en` and `nl` with clearer, accurate lines that focus on comparing museums and exploring exhibitions. 
- New English subtitle is `"Compare museums in Amsterdam, explore current exhibitions, and find the ones that match your interests."` and the new Dutch subtitle is `"Vergelijk musea in Amsterdam, ontdek actuele tentoonstellingen en vind wat het beste bij jouw plannen past."`.
- No layout or component changes were made and the homepage still renders the subtitle via `t('heroSubtitle')` in `pages/index.js`.

### Testing
- Verified the updated strings are present by inspecting `lib/translations.js` with `sed -n` which showed the new `heroSubtitle` lines.
- Searched references with `rg -n 'heroSubtitle' lib/translations.js pages/index.js` to confirm the homepage uses the translation key and that the edited file is the only translation change.
- Performed the scripted replacement using a small Python edit script and confirmed the file write completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c16dc7c24883269b83aea5b6aa4e23)