### PR TITLE
Rewrite /gratis-musea-amsterdam into honest editorial guide

### DIFF
--- a/pages/gratis-musea-amsterdam.js
+++ b/pages/gratis-musea-amsterdam.js
@@ -4,9 +4,10 @@ import MuseumCard from '../components/MuseumCard';
 import { useLanguage } from '../components/LanguageContext';
 import museumImages from '../lib/museumImages';
 import museumImageCredits from '../lib/museumImageCredits';
-import { getStaticMuseums } from '../lib/staticMuseums';
+import { getStaticMuseumBySlug } from '../lib/staticMuseums';
 
 function toCardMuseum(museum) {
+  if (!museum) return null;
   return {
     ...museum,
     image: museumImages[museum.slug] || museum.afbeelding_url || museum.image_url || null,
@@ -14,42 +15,31 @@ function toCardMuseum(museum) {
   };
 }
 
-function isFreeMuseum(museum) {
-  return Boolean(museum?.gratis_toegankelijk);
-}
+const FEATURED_SLUGS = ['rijksmuseum-amsterdam', 'ons-lieve-heer-op-solder-amsterdam'];
 
 export default function FreeMuseumsLandingPage() {
   const { lang } = useLanguage();
+
   const title =
     lang === 'en'
-      ? 'Free museums in Amsterdam | MuseumBuddy'
-      : 'Gratis musea in Amsterdam | MuseumBuddy';
+      ? 'Free museums in Amsterdam: what is truly free? | MuseumBuddy'
+      : 'Gratis musea in Amsterdam: wat is écht gratis? | MuseumBuddy';
   const description =
     lang === 'en'
-      ? 'Find museums in Amsterdam with free admission where available.'
-      : 'Vind musea in Amsterdam met gratis toegang waar beschikbaar.';
-  const heading = lang === 'en' ? 'Free museums in Amsterdam' : 'Gratis musea in Amsterdam';
-  const intro =
-    lang === 'en'
-      ? 'A practical list of museums in Amsterdam that are marked as free to visit.'
-      : 'Een praktisch overzicht van musea in Amsterdam die als gratis toegankelijk zijn gemarkeerd.';
+      ? 'Honest guide to free museum options in Amsterdam: truly free places, free moments, and ways to save with museum passes.'
+      : 'Eerlijke gids over gratis musea in Amsterdam: wat echt gratis is, wanneer toegang soms gratis is en hoe je slim bespaart met museumpassen.';
+  const heading =
+    lang === 'en' ? 'Free museums in Amsterdam: what is truly free?' : 'Gratis musea in Amsterdam: wat is écht gratis?';
 
-  const museums = getStaticMuseums().filter(isFreeMuseum).map(toCardMuseum);
+  const featuredMuseums = FEATURED_SLUGS.map((slug) => toCardMuseum(getStaticMuseumBySlug(slug))).filter(Boolean);
+
   const structuredData = {
     '@context': 'https://schema.org',
-    '@type': 'CollectionPage',
-    name: heading,
+    '@type': 'Article',
+    headline: heading,
     description,
-    mainEntity: {
-      '@type': 'ItemList',
-      numberOfItems: museums.length,
-      itemListElement: museums.map((museum, index) => ({
-        '@type': 'ListItem',
-        position: index + 1,
-        url: `https://museumbuddy.nl/museum/${museum.slug}`,
-        name: museum.naam,
-      })),
-    },
+    inLanguage: lang === 'en' ? 'en' : 'nl',
+    mainEntityOfPage: 'https://museumbuddy.nl/gratis-musea-amsterdam',
   };
 
   return (
@@ -57,35 +47,118 @@ export default function FreeMuseumsLandingPage() {
       <SEO
         title={title}
         description={description}
-        robots="noindex,follow"
+        robots="index,follow"
         canonical="/gratis-musea-amsterdam"
         image="/images/og-home.svg"
         structuredData={structuredData}
       />
+
       <section className="page-intro">
         <h1 className="page-title">{heading}</h1>
-        <p className="page-subtitle">{intro}</p>
-      </section>
-      <p className="count">{museums.length} musea</p>
-      {museums.length ? (
-        <ul className="grid" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-          {museums.map((museum, index) => (
-            <li key={museum.slug}>
-              <MuseumCard museum={museum} priority={index < 3} />
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p>
-          {lang === 'en'
-            ? 'No free museums are marked in the current data yet. You can still browse all museums.'
-            : 'Er zijn in de huidige dataset nog geen gratis musea gemarkeerd. Je kunt wel alle musea bekijken.'}{' '}
-          <Link href="/">
-            {lang === 'en' ? 'View all museums' : 'Bekijk alle musea'}
-          </Link>
-          .
+        <p className="page-subtitle">
+          Amsterdam staat bekend om zijn musea, maar volledig gratis musea zijn zeldzaam. In deze gids leggen we
+          eerlijk uit wat in Amsterdam echt gratis is, wanneer gratis toegang alleen in specifieke situaties geldt en
+          hoe je je museumbezoek voordeliger plant.
         </p>
-      )}
+      </section>
+
+      <section style={{ marginBottom: '2rem' }}>
+        <p>
+          <strong>Belangrijk:</strong> gratis toegang verandert regelmatig. Controleer daarom altijd de actuele
+          voorwaarden op de officiële ticketpagina van de locatie voordat je gaat.
+        </p>
+
+        <h2>Welke musea of museumplekken in Amsterdam zijn echt gratis?</h2>
+        <p>
+          Er zijn maar weinig plekken die je als “altijd gratis museum” kunt zien. Wel zijn er culturele locaties en
+          museumonderdelen die gratis toegankelijk zijn:
+        </p>
+        <ul>
+          <li>
+            <strong>Stadsarchief Amsterdam</strong>: het gebouw is vrij toegankelijk, met gratis toegang tot onder meer
+            het Informatiecentrum, de Studiezaal Originelen, de Schatkamer en de Filmzaal. Let op: voor exposities in
+            de Tentoonstellingszaal geldt voor volwassenen wel een entreeprijs.
+          </li>
+          <li>
+            <strong>Rijksmuseumtuinen</strong>: de tuinen zijn volgens het Rijksmuseum dagelijks open. Dat maakt dit een
+            voorbeeld van gratis toegankelijke museumruimte, ook als het hoofdmuseum zelf betaald is.
+          </li>
+          <li>
+            <strong>OSCAM</strong>: hanteert een “Pay As You Like”-model met bedragen vanaf €1. Dat is laagdrempelig,
+            maar dus niet standaard volledig gratis.
+          </li>
+          <li>
+            <strong>Ons&apos; Lieve Heer op Solder</strong>: er is volgens het museum bijna elke eerste zondag van de
+            maand een mis in de zolderkerk. Dit betekent niet automatisch dat regulier museumbezoek dan gratis is;
+            controleer agenda en ticketvoorwaarden vooraf.
+          </li>
+        </ul>
+
+        <h2>Wanneer zijn musea gratis?</h2>
+        <p>
+          Veel musea zijn niet standaard gratis, maar wel in specifieke situaties. Denk bijvoorbeeld aan:
+        </p>
+        <ul>
+          <li>gratis toegang voor kinderen of jongeren (per museum verschillend);</li>
+          <li>gratis toegang op speciale dagen of bij specifieke publieksprogramma’s;</li>
+          <li>gratis toegang tot een deel van een locatie (zoals tuin, publieksruimte of activiteit).</li>
+        </ul>
+        <p>
+          Concrete voorbeelden: bij het Rijksmuseum is toegang t/m 18 jaar gratis. Bij Stadsarchief Amsterdam is de
+          Tentoonstellingszaal gratis voor 0-18 jaar (en enkele andere groepen). Bij Ons&apos; Lieve Heer op Solder is een
+          peuterticket (t/m 4 jaar) gratis.
+        </p>
+
+        <h2>Gratis of voordeliger met een pas</h2>
+        <p>
+          Niet alles is letterlijk gratis, maar met een pas kun je vaak veel besparen. Belangrijk: een pas kost zelf
+          geld, dus dit is <strong>korting of prepaid toegang</strong>, geen universele gratis entree.
+        </p>
+        <ul>
+          <li>
+            <strong>Museumkaart</strong>: geeft volgens Museum.nl onbeperkte toegang tot meer dan 500 musea in
+            Nederland.
+          </li>
+          <li>
+            <strong>I amsterdam City Card</strong>: geeft toegang tot meer dan 70 musea en topattracties in
+            Amsterdam en de Metropoolregio Amsterdam.
+          </li>
+          <li>
+            <strong>Andere regelingen</strong>: sommige musea bieden extra kortingen met bijvoorbeeld Stadspas,
+            studentenkaart of tijdelijke acties.
+          </li>
+        </ul>
+
+        <h2>Tips om Amsterdamse musea goedkoper te bezoeken</h2>
+        <ul>
+          <li>Check altijd de officiële ticketpagina van het museum.</li>
+          <li>Kijk expliciet naar kinder- en jeugdvoorwaarden.</li>
+          <li>Let op gratis publieksprogramma&apos;s, open dagen en tijdelijke acties.</li>
+          <li>Overweeg een pas als je meerdere musea op één trip wilt bezoeken.</li>
+          <li>Vergeet kleinere culturele plekken niet; daar zijn soms laagdrempelige tarieven.</li>
+        </ul>
+
+        <p>
+          Zoek je een museum dat past bij jouw dag in Amsterdam? Bekijk dan onze{' '}
+          <Link href="/tentoonstellingen">tentoonstellingenpagina</Link>, ga naar het{' '}
+          <Link href="/">volledige museumoverzicht</Link> of lees direct meer over{' '}
+          <Link href="/museum/rijksmuseum-amsterdam">het Rijksmuseum</Link> en{' '}
+          <Link href="/museum/ons-lieve-heer-op-solder-amsterdam">Ons&apos; Lieve Heer op Solder</Link>.
+        </p>
+      </section>
+
+      {featuredMuseums.length ? (
+        <>
+          <h2 style={{ marginBottom: '1rem' }}>Uitgelichte musea om voorwaarden te vergelijken</h2>
+          <ul className="grid" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+            {featuredMuseums.map((museum, index) => (
+              <li key={museum.slug}>
+                <MuseumCard museum={museum} priority={index < 2} />
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : null}
     </>
   );
 }


### PR DESCRIPTION
### Motivation
- The existing page presented itself as a product-style filter for “free museums” while the underlying static data did not reliably provide free results, creating a weak/empty UX and overstating capabilities. 
- The aim is to reposition the page as a trustworthy editorial guide that explains what is truly free, when free access can apply, and how visitors can save, while avoiding unverifiable blanket claims.

### Description
- Rewrote the page at `pages/gratis-musea-amsterdam.js` to replace the previous free-filter landing behavior with an editorial article-style guide (new H1, intro, sectioned guidance, and repeated advisory to verify official sources). 
- Replaced the old static free-filter logic (`getStaticMuseums().filter(gratis_toegankelijk)`) with curated featured museum cards using `getStaticMuseumBySlug` and a `FEATURED_SLUGS` list (`rijksmuseum-amsterdam`, `ons-lieve-heer-op-solder-amsterdam`) to avoid an empty-state mismatch while keeping existing card components. 
- Updated SEO and page metadata: new title/description targeting “gratis musea Amsterdam” without overpromising, `robots` set to `index,follow`, canonical preserved, and structured data changed from a `CollectionPage`/ItemList to an `Article` to match the editorial intent. 
- Added practical content sections and natural internal links to `/tentoonstellingen`, the main museum overview (`/`), and the two featured museum detail pages, while keeping all UI components and i18n structure unchanged.

### Testing
- Ran `npm test` (suite of local unit/smoke tests); all tests passed. 
- Built the site with `npm run build`; the production build completed successfully and static pages were generated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c16f9a44ec83269d8fa1236dfcbb22)