### PR TITLE
Strengthen internal linking to /beste-musea-amsterdam on key pages

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1087,7 +1087,14 @@ export default function Home({ initialMuseums = [], initialError = null }) {
       </section>
       <section className="page-intro" aria-label="SEO content">
         <h2 className="page-subtitle">{t('homeSeoIntroHeading')}</h2>
-        <p className="page-subtitle">{t('homeSeoIntro')}</p>
+        <p className="page-subtitle">
+          {t('homeSeoIntro')}{' '}
+          <Link href="/beste-musea-amsterdam">
+            {lang === 'nl'
+              ? 'Bekijk ook onze selectie van de beste musea in Amsterdam'
+              : 'Also explore our selection of the best museums in Amsterdam'}
+          </Link>.
+        </p>
         <h2 className="page-subtitle">{t('homeSeoFooterHeading')}</h2>
         <p className="page-subtitle">
           {t('homeSeoFooter')}{' '}

--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -1152,6 +1152,28 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
                   ))}
                 </p>
               ) : null}
+
+              <h2>{lang === 'nl' ? 'Andere musea ontdekken?' : 'Discover other museums?'}</h2>
+              <p className="page-subtitle">
+                <Link href="/beste-musea-amsterdam">
+                  {lang === 'nl'
+                    ? 'Bekijk onze selectie van de beste musea in Amsterdam'
+                    : 'Explore our selection of the best museums in Amsterdam'}
+                </Link>
+                {relatedMuseums.length > 0 ? (
+                  <>
+                    {' '}
+                    ·{' '}
+                    {relatedMuseums.slice(0, 2).map((item, index) => (
+                      <Fragment key={`cross-link-${item.slug}`}>
+                        {index > 0 ? ', ' : ''}
+                        <Link href={`/museum/${item.slug}`}>{item.name}</Link>
+                      </Fragment>
+                    ))}
+                  </>
+                ) : null}
+                .
+              </p>
             </section>
             <div className="museum-tablist" role="tablist" aria-label={t('museumTabsLabel')}>
               {tabDefinitions.map((tab, index) => {

--- a/pages/tentoonstellingen.js
+++ b/pages/tentoonstellingen.js
@@ -934,6 +934,19 @@ export default function ExhibitionsPage({ exhibitions = [], error = null }) {
           {t('exhibitionsPageHeading')}
         </h1>
         <p className="page-subtitle">{t('exhibitionsPageSubtitle')}</p>
+        <p className="page-subtitle">
+          {lang === 'nl' ? (
+            <>
+              Weet je nog niet welk museum bij je past? Bekijk onze selectie van de{' '}
+              <Link href="/beste-musea-amsterdam">beste musea in Amsterdam</Link>.
+            </>
+          ) : (
+            <>
+              Not sure which museum fits you best? Explore our selection of the{' '}
+              <Link href="/beste-musea-amsterdam">best museums in Amsterdam</Link>.
+            </>
+          )}
+        </p>
         <Button href="/" variant="secondary" size="sm">
           {t('exhibitionsBackHome')}
         </Button>


### PR DESCRIPTION
### Motivation
- Improve discoverability and internal SEO authority for the curated Amsterdam museums page by adding natural contextual links from high-value pages. 
- Target the homepage, the exhibitions listing, and individual museum detail pages because those templates receive the most user traffic and are logical entry points. 
- Keep changes lightweight and user-first so links feel helpful rather than spammy.

### Description
- Added a sentence-level internal link to `/beste-musea-amsterdam` in the homepage SEO intro paragraph using natural Dutch copy; implemented in `pages/index.js`. 
- Added a short guidance paragraph linking to `/beste-musea-amsterdam` near the top of the exhibitions page; implemented in `pages/tentoonstellingen.js`. 
- Added a minimal cross-link block on museum detail pages titled “Andere musea ontdekken?” that links to `/beste-musea-amsterdam` and optionally shows up to two related museum links; implemented in `pages/museum/[slug].js`. 
- No backend logic, layout redesigns, or styling-breaking changes were made, and all links use the existing Next.js `Link` component and language handling.

### Testing
- Ran the repository test suite with `npm test` and all automated tests passed. 
- Attempted `npm run lint` but the project does not expose a `lint` script, so linting was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c286d208808326a4f76f56779adf53)