### PR TITLE
Maak tentoonstellingen terugknop consistent met museumdetail

### DIFF
--- a/pages/tentoonstellingen.js
+++ b/pages/tentoonstellingen.js
@@ -947,9 +947,22 @@ export default function ExhibitionsPage({ exhibitions = [], error = null }) {
             </>
           )}
         </p>
-        <Button href="/" variant="secondary" size="sm">
-          {t('exhibitionsBackHome')}
-        </Button>
+        <Link href="/" className="museum-backlink">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+            width="20"
+            height="20"
+          >
+            <path d="M15 18l-6-6 6-6" />
+          </svg>
+          <span>{t('breadcrumbMuseums')}</span>
+        </Link>
         <h2 className="page-subtitle">{t('exhibitionsSeoIntroHeading')}</h2>
         <p className="page-subtitle">{t('exhibitionsSeoIntro')}</p>
       </section>


### PR DESCRIPTION
### Motivation
- Zorg voor visuele en tekstuele consistentie door de “Terug naar homepage” knop op de tentoonstellingenpagina gelijk te maken aan de pill-vormige teruglink op de museumdetailpagina.

### Description
- Vervangen van de `Button` op `pages/tentoonstellingen.js` door een `Link` met de `museum-backlink` klasse, hergebruik van dezelfde pijl-SVG en het label `breadcrumbMuseums` zodat stijl en copy overeenkomen met de museumdetailpagina.

### Testing
- Er is `npm test` uitgevoerd (uitvoertaken: `tests/ticketCta.test.cjs`, `tests/kidFriendlyFilter.test.cjs`, `tests/nearbyFilter.test.cjs`, `tests/museumSearch.test.cjs`) en alle tests zijn geslaagd.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3a27bff708326a2ad549f713e29f0)