### PR TITLE
Remove extra hero action buttons on homepage

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -403,13 +403,6 @@ export default function Home({ initialMuseums = [], initialError = null }) {
     return params.toString();
   }, []);
 
-  const handleQuickShowExhibitions = useCallback(() => {
-    skipNextUrlSync.current = true;
-    setActiveFilters((prev) => ({ ...DEFAULT_FILTERS, ...prev, exhibitions: true }));
-    setSheetFilters((prev) => ({ ...DEFAULT_FILTERS, ...prev, exhibitions: true }));
-    setFiltersSheetOpen(false);
-  }, [setActiveFilters, setSheetFilters, setFiltersSheetOpen]);
-
   useEffect(() => {
     if (!activeFilters.nearby) return;
     if (userLocation) return;
@@ -976,15 +969,6 @@ export default function Home({ initialMuseums = [], initialError = null }) {
             >
               {t('heroViewExhibitions')}
             </Button>
-            <Button
-              href="/beste-musea-amsterdam"
-              size="lg"
-              variant="secondary"
-              className="hero-cta-button hero-cta-button--secondary"
-              prefetch
-            >
-              {lang === 'nl' ? 'Beste musea in Amsterdam' : 'Best museums in Amsterdam'}
-            </Button>
           </div>
         </div>
         <form className="hero-card hero-search" onSubmit={(e) => e.preventDefault()}>
@@ -1016,14 +1000,6 @@ export default function Home({ initialMuseums = [], initialError = null }) {
                 <path d="M10 20h4" />
               </svg>
               <span>{t('filtersButton')}</span>
-            </button>
-            <button
-              type="button"
-              className="hero-quick-link hero-quick-link--primary"
-              onClick={handleQuickShowExhibitions}
-              aria-pressed={activeFilters.exhibitions}
-            >
-              {t('exhibitions')}
             </button>
             {(query ||
               activeFilters.exhibitions ||


### PR DESCRIPTION
### Motivation
- Simplify the homepage hero by removing secondary CTAs that duplicate navigation and reduce visual clutter.
- Remove a quick-action that toggled the exhibitions filter from the hero search to streamline the search UI.

### Description
- Deleted the secondary hero CTA linking to `/beste-musea-amsterdam` from the hero action group in `pages/index.js`.
- Removed the exhibitions quick-action button from the hero search action row in `pages/index.js`.
- Removed the now-unused `handleQuickShowExhibitions` callback from the component logic in `pages/index.js`.

### Testing
- Ran the full test script with `npm test`, which executes `tests/ticketCta.test.cjs`, `tests/kidFriendlyFilter.test.cjs`, `tests/nearbyFilter.test.cjs`, and `tests/museumSearch.test.cjs`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd053ecbf48326b808add55c6cfa5a)