### PR TITLE
Improve spacing below exhibitions back button

### DIFF
--- a/pages/tentoonstellingen.js
+++ b/pages/tentoonstellingen.js
@@ -1010,7 +1010,7 @@ export default function ExhibitionsPage({ exhibitions = [], error = null }) {
             </>
           )}
         </p>
-        <Link href="/" className="museum-backlink">
+        <Link href="/" className="museum-backlink exhibitions-backlink">
           <svg
             viewBox="0 0 24 24"
             fill="none"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1994,6 +1994,9 @@ button.hero-quick-link {
   outline: 2px solid var(--accent);
   outline-offset: 3px;
 }
+.exhibitions-backlink {
+  margin-bottom: var(--space-16);
+}
 .museum-primary-action-bar {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;


### PR DESCRIPTION
### Motivation
- The SEO intro heading and paragraph on the exhibitions page were too close to the back-to-museums button, so the text needs extra vertical spacing below that button.

### Description
- Add a page-specific class `exhibitions-backlink` to the back link in `pages/tentoonstellingen.js` and apply `.exhibitions-backlink { margin-bottom: var(--space-16); }` in `styles/globals.css` to create the gap.

### Testing
- Ran `npm test` (which runs the `ticketCta`, `kidFriendlyFilter`, `nearbyFilter`, and `museumSearch` tests) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd06b5bb388326b28bd6b7ed36e7f9)