### PR TITLE
Add Ons Lieve Heer hero image and photo credit on ticket landing page

### DIFF
--- a/components/TicketLandingTemplate.js
+++ b/components/TicketLandingTemplate.js
@@ -82,7 +82,7 @@ export default function TicketLandingTemplate({
     <>
       <SEO title={title} description={description} canonical={canonical} structuredData={structuredData} />
 
-      <section className="ticket-landing__hero">
+      <section className={`ticket-landing__hero${hasHeroImage ? ' ticket-landing__hero--with-image' : ''}`}>
         {hasHeroImage ? (
           <div className="ticket-landing__hero-media">
             <Image
@@ -94,37 +94,40 @@ export default function TicketLandingTemplate({
               priority
               style={{ objectFit: 'cover' }}
             />
+            <div className="ticket-landing__hero-media-overlay" aria-hidden="true" />
           </div>
         ) : null}
-        <h1>{h1}</h1>
-        <p>{intro}</p>
-        <div className="ticket-landing__hero-actions">
-          {renderPartnerButton(primaryCtaLabel)}
-          {detailPageHref ? (
-            <Link href={detailPageHref} className="ticket-landing__secondary-link">
-              {detailPageLabel}
-            </Link>
+        <div className={`ticket-landing__hero-content${hasHeroImage ? ' ticket-landing__hero-content--overlay' : ''}`}>
+          <h1>{h1}</h1>
+          <p>{intro}</p>
+          <div className="ticket-landing__hero-actions">
+            {renderPartnerButton(primaryCtaLabel)}
+            {detailPageHref ? (
+              <Link href={detailPageHref} className="ticket-landing__secondary-link">
+                {detailPageLabel}
+              </Link>
+            ) : null}
+          </div>
+          <p className="ticket-landing__legal-note">
+            {disclosureLabel}: als je via deze knop boekt, kan MuseumBuddy een kleine commissie ontvangen. Dit kost jou niets extra&apos;s.
+          </p>
+          {hasHeroImageCredit ? (
+            <p className="ticket-landing__hero-credit image-credit">
+              {creditSegments.map((segment, index) => (
+                <Fragment key={`ticket-hero-credit-${segment.key}-${index}`}>
+                  {index > 0 ? <span className="image-credit-divider">•</span> : null}
+                  {segment.url ? (
+                    <a className="image-credit-link" href={segment.url} target="_blank" rel="noreferrer">
+                      {segment.label}
+                    </a>
+                  ) : (
+                    <span className="image-credit-part">{segment.label}</span>
+                  )}
+                </Fragment>
+              ))}
+            </p>
           ) : null}
         </div>
-        <p className="ticket-landing__legal-note">
-          {disclosureLabel}: als je via deze knop boekt, kan MuseumBuddy een kleine commissie ontvangen. Dit kost jou niets extra&apos;s.
-        </p>
-        {hasHeroImageCredit ? (
-          <p className="ticket-landing__hero-credit image-credit">
-            {creditSegments.map((segment, index) => (
-              <Fragment key={`ticket-hero-credit-${segment.key}-${index}`}>
-                {index > 0 ? <span className="image-credit-divider">•</span> : null}
-                {segment.url ? (
-                  <a className="image-credit-link" href={segment.url} target="_blank" rel="noreferrer">
-                    {segment.label}
-                  </a>
-                ) : (
-                  <span className="image-credit-part">{segment.label}</span>
-                )}
-              </Fragment>
-            ))}
-          </p>
-        ) : null}
       </section>
 
       <PracticalSummary items={practicalItems} />

--- a/components/TicketLandingTemplate.js
+++ b/components/TicketLandingTemplate.js
@@ -1,3 +1,5 @@
+import { Fragment } from 'react';
+import Image from 'next/image';
 import Link from 'next/link';
 import SEO from './SEO';
 
@@ -45,6 +47,9 @@ export default function TicketLandingTemplate({
   ticketSectionText,
   affiliateNote,
   structuredData,
+  heroImageSrc,
+  heroImageAlt,
+  heroImageCreditSegments,
 }) {
   const ticketRel = 'sponsored noopener noreferrer';
   const partnerLabel = 'Partner';
@@ -69,11 +74,28 @@ export default function TicketLandingTemplate({
     </a>
   );
 
+  const hasHeroImage = Boolean(heroImageSrc);
+  const creditSegments = Array.isArray(heroImageCreditSegments) ? heroImageCreditSegments : [];
+  const hasHeroImageCredit = creditSegments.length > 0;
+
   return (
     <>
       <SEO title={title} description={description} canonical={canonical} structuredData={structuredData} />
 
       <section className="ticket-landing__hero">
+        {hasHeroImage ? (
+          <div className="ticket-landing__hero-media">
+            <Image
+              src={heroImageSrc}
+              alt={heroImageAlt || ''}
+              fill
+              className="ticket-landing__hero-image"
+              sizes="(max-width: 900px) 100vw, 900px"
+              priority
+              style={{ objectFit: 'cover' }}
+            />
+          </div>
+        ) : null}
         <h1>{h1}</h1>
         <p>{intro}</p>
         <div className="ticket-landing__hero-actions">
@@ -87,6 +109,22 @@ export default function TicketLandingTemplate({
         <p className="ticket-landing__legal-note">
           {disclosureLabel}: als je via deze knop boekt, kan MuseumBuddy een kleine commissie ontvangen. Dit kost jou niets extra&apos;s.
         </p>
+        {hasHeroImageCredit ? (
+          <p className="ticket-landing__hero-credit image-credit">
+            {creditSegments.map((segment, index) => (
+              <Fragment key={`ticket-hero-credit-${segment.key}-${index}`}>
+                {index > 0 ? <span className="image-credit-divider">•</span> : null}
+                {segment.url ? (
+                  <a className="image-credit-link" href={segment.url} target="_blank" rel="noreferrer">
+                    {segment.label}
+                  </a>
+                ) : (
+                  <span className="image-credit-part">{segment.label}</span>
+                )}
+              </Fragment>
+            ))}
+          </p>
+        ) : null}
       </section>
 
       <PracticalSummary items={practicalItems} />

--- a/pages/ons-lieve-heer-op-solder-tickets.js
+++ b/pages/ons-lieve-heer-op-solder-tickets.js
@@ -1,8 +1,14 @@
 import TicketLandingTemplate from '../components/TicketLandingTemplate';
+import formatImageCredit from '../lib/formatImageCredit';
+import museumImageCredits from '../lib/museumImageCredits';
+import museumImages from '../lib/museumImages';
 import museumTicketUrls from '../lib/museumTicketUrls';
 
 const DETAIL_PAGE_URL = '/museum/ons-lieve-heer-op-solder-amsterdam';
+const MUSEUM_SLUG = 'ons-lieve-heer-op-solder-amsterdam';
 const TICKET_URL = museumTicketUrls['ons-lieve-heer-op-solder-amsterdam'];
+const HERO_IMAGE = museumImages[MUSEUM_SLUG];
+const HERO_IMAGE_CREDIT = formatImageCredit(museumImageCredits[MUSEUM_SLUG]);
 
 const practicalItems = [
   { label: 'Prijsindicatie', value: '± €16–€18 p.p.' },
@@ -72,6 +78,9 @@ export default function OnsLieveHeerOpSolderTicketsPage() {
       ticketSectionText="Wil je je bezoek plannen? Via onze partner kun je actuele ticketopties bekijken en direct controleren welke momenten nog beschikbaar zijn."
       affiliateNote="Controleer bij de partner altijd de actuele voorwaarden en ticketdetails voordat je afrondt."
       structuredData={structuredData}
+      heroImageSrc={HERO_IMAGE}
+      heroImageAlt="Museum Ons’ Lieve Heer op Solder in Amsterdam"
+      heroImageCreditSegments={HERO_IMAGE_CREDIT?.segments}
     />
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4478,6 +4478,10 @@ button.hero-quick-link {
   box-shadow: var(--ds-shadow-sm);
 }
 
+.ticket-landing__hero {
+  position: relative;
+}
+
 .ticket-landing__hero h1 {
   margin: 0 0 12px;
   font-size: clamp(1.65rem, 4.8vw, 2.35rem);
@@ -4495,6 +4499,43 @@ button.hero-quick-link {
 
 .ticket-landing__hero-image {
   object-position: center;
+}
+
+.ticket-landing__hero-media-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(6, 18, 34, 0.38) 0%, rgba(6, 18, 34, 0.68) 100%);
+}
+
+.ticket-landing__hero-content {
+  position: relative;
+}
+
+.ticket-landing__hero--with-image {
+  overflow: hidden;
+}
+
+.ticket-landing__hero--with-image .ticket-landing__hero-content--overlay {
+  position: absolute;
+  inset: auto clamp(16px, 3vw, 24px) clamp(14px, 2.8vw, 22px);
+  z-index: 1;
+}
+
+.ticket-landing__hero--with-image h1,
+.ticket-landing__hero--with-image p,
+.ticket-landing__hero--with-image .ticket-landing__secondary-link,
+.ticket-landing__hero--with-image .ticket-landing__hero-credit {
+  color: #fff;
+}
+
+.ticket-landing__hero--with-image .ticket-landing__legal-note {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.ticket-landing__hero--with-image .ticket-landing__hero-credit .image-credit-link,
+.ticket-landing__hero--with-image .ticket-landing__hero-credit .image-credit-part,
+.ticket-landing__hero--with-image .ticket-landing__hero-credit .image-credit-divider {
+  color: inherit;
 }
 
 .ticket-landing__hero p,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4513,23 +4513,46 @@ button.hero-quick-link {
 
 .ticket-landing__hero--with-image {
   overflow: hidden;
+  padding: 0;
+  border: 1px solid color-mix(in srgb, var(--panel-border) 78%, transparent);
+  background: transparent;
 }
 
 .ticket-landing__hero--with-image .ticket-landing__hero-content--overlay {
   position: absolute;
-  inset: auto clamp(16px, 3vw, 24px) clamp(14px, 2.8vw, 22px);
-  z-index: 1;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: clamp(20px, 4vw, 34px);
+}
+
+.ticket-landing__hero--with-image .ticket-landing__hero-media {
+  aspect-ratio: 16 / 8;
+  margin-bottom: 0;
 }
 
 .ticket-landing__hero--with-image h1,
-.ticket-landing__hero--with-image p,
+.ticket-landing__hero--with-image .ticket-landing__hero-content--overlay > p,
 .ticket-landing__hero--with-image .ticket-landing__secondary-link,
-.ticket-landing__hero--with-image .ticket-landing__hero-credit {
-  color: #fff;
+.ticket-landing__hero--with-image .ticket-landing__hero-credit,
+.ticket-landing__hero--with-image .ticket-landing__legal-note {
+  color: #fff !important;
+  text-shadow: 0 2px 16px rgba(2, 6, 23, 0.6);
+}
+
+.ticket-landing__hero--with-image h1,
+ .ticket-landing__hero--with-image .ticket-landing__hero-content--overlay > p {
+  max-width: 900px;
 }
 
 .ticket-landing__hero--with-image .ticket-landing__legal-note {
-  color: rgba(255, 255, 255, 0.9);
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: rgba(255, 255, 255, 0.96) !important;
+  max-width: 900px;
 }
 
 .ticket-landing__hero--with-image .ticket-landing__hero-credit .image-credit-link,
@@ -4642,6 +4665,15 @@ button.hero-quick-link {
   font-size: 0.7rem;
 }
 
+.ticket-landing__hero--with-image .ticket-landing__hero-credit {
+  margin-top: 0;
+  font-size: 0.8rem;
+}
+
+.ticket-landing__hero--with-image .ticket-landing__hero-actions {
+  margin-top: 2px;
+}
+
 .ticket-landing__links {
   margin: 0;
   padding-left: 18px;
@@ -4655,6 +4687,30 @@ button.hero-quick-link {
   color: var(--ds-color-primary);
   text-decoration: underline;
   text-underline-offset: 3px;
+}
+
+@media (max-width: 767px) {
+  .ticket-landing__hero--with-image .ticket-landing__hero-media {
+    aspect-ratio: 4 / 5;
+  }
+
+  .ticket-landing__hero--with-image h1 {
+    font-size: clamp(1.55rem, 6vw, 2rem);
+    margin-bottom: 8px;
+  }
+
+  .ticket-landing__hero--with-image .ticket-landing__hero-content--overlay > p {
+    font-size: 1rem;
+    line-height: 1.45;
+  }
+
+  .ticket-landing__hero--with-image .ticket-landing__hero-actions {
+    margin-top: 4px;
+  }
+
+  .ticket-landing__hero--with-image .ticket-landing__hero-credit {
+    font-size: 0.72rem;
+  }
 }
 
 @media (min-width: 768px) {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4484,6 +4484,19 @@ button.hero-quick-link {
   line-height: 1.2;
 }
 
+.ticket-landing__hero-media {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 7;
+  overflow: hidden;
+  border-radius: 12px;
+  margin-bottom: 14px;
+}
+
+.ticket-landing__hero-image {
+  object-position: center;
+}
+
 .ticket-landing__hero p,
 .ticket-landing__section p {
   margin: 0;
@@ -4581,6 +4594,11 @@ button.hero-quick-link {
   font-size: 0.78rem;
   line-height: 1.5;
   color: color-mix(in srgb, var(--muted) 92%, var(--text) 8%);
+}
+
+.ticket-landing__hero-credit {
+  margin-top: 8px;
+  font-size: 0.7rem;
 }
 
 .ticket-landing__links {


### PR DESCRIPTION
### Motivation
- Provide the same museum hero photo and properly formatted photocredit on the Ons’ Lieve Heer op Solder ticket landing page so it matches the museum detail page and includes the required credit text.

### Description
- Updated `components/TicketLandingTemplate.js` to accept `heroImageSrc`, `heroImageAlt` and `heroImageCreditSegments` props, render an optional hero using `next/image`, and render inline credit segments in the hero area using the existing `image-credit` markup.
- Wired the Ons’ Lieve Heer ticket page (`pages/ons-lieve-heer-op-solder-tickets.js`) to reuse the museum image and credit by importing `museumImages`, `museumImageCredits` and `formatImageCredit` and passing `HERO_IMAGE` and the formatted `segments` into the template.
- Added CSS rules in `styles/globals.css` for `.ticket-landing__hero-media`, `.ticket-landing__hero-image` and `.ticket-landing__hero-credit` to control hero aspect ratio, positioning and small credit typography.

### Testing
- Ran the project test suite with `npm test`, which executes `tests/ticketCta.test.cjs`, `tests/kidFriendlyFilter.test.cjs`, `tests/nearbyFilter.test.cjs` and `tests/museumSearch.test.cjs`, and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de21da9a4c83269f799ac9886300a4)