### PR TITLE
docs: add GitHub webhook secret rotation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,33 @@ To run the app locally:
 
 These variables are required for the application to connect to Supabase and should also be added to your Vercel project settings for both build and runtime.
 
+## GitHub webhook secret rotation (incident Jan 2026)
+
+GitHub reported that for a subset of deliveries between **September 11, 2025** and **January 26, 2026**, a webhook secret could appear in the `X-Github-Encoded-Secret` header.
+If your repository webhook was in scope, treat the secret as compromised and rotate it immediately.
+
+### Steps for this repository
+
+1. Open repository settings:
+   - `https://github.com/pantsidou-dotcom/MuseumBuddyApp/settings/hooks`
+2. Locate webhook ID `573139046`.
+3. Generate a new secret locally:
+   ```bash
+   openssl rand -hex 32
+   ```
+4. Edit the webhook and replace the secret with the generated value.
+5. Save and re-send a recent delivery to confirm signature validation still passes.
+
+### Receiver hardening checklist
+
+- Verify incoming signatures using `X-Hub-Signature-256` and a constant-time comparison.
+- Remove `X-Github-Encoded-Secret` from request/header logs if your ingestion pipeline stored it.
+- Purge historical logs containing leaked secrets from the affected date window.
+
+GitHub docs:
+- Edit webhook: https://docs.github.com/en/webhooks/using-webhooks/editing-webhooks
+- Validate deliveries: https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
+
 ## Deduplicate musea table
 
 A helper script is available to remove duplicate `museum_id` entries from the Supabase `musea` table and enforce a `UNIQUE` constraint.


### PR DESCRIPTION
### Motivation
- Add an in-repo runbook so repository owners can quickly rotate and verify webhook secrets after GitHub's Jan 2026 header exposure for the affected webhook (`573139046`).

### Description
- Updated `README.md` to add a "GitHub webhook secret rotation (incident Jan 2026)" section that documents the incident window, provides repository-specific remediation steps (link to settings, webhook ID `573139046`, and `openssl rand -hex 32` to generate a new secret), includes a receiver hardening checklist (verify `X-Hub-Signature-256`, remove the `X-Github-Encoded-Secret` from logs, purge historical logs), and links to the relevant GitHub docs.

### Testing
- Ran `npm test`, which executed the project's test suite and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de8bdf892c8326b019ec9edf62d87d)