### PR TITLE
Add SEO guide page for Eye Filmmuseum Amsterdam

### DIFF
--- a/pages/eye-filmmuseum-amsterdam.js
+++ b/pages/eye-filmmuseum-amsterdam.js
@@ -142,17 +142,17 @@ export default function EyeFilmmuseumAmsterdamPage() {
 
       <section className="museum-guide-section">
         <h2>Meer categorieën om verder te vergelijken</h2>
-        <ul>
-          <li>
-            <Link href="/beste-musea-amsterdam">Musea in Amsterdam</Link>
-          </li>
-          <li>
-            <Link href="/kindvriendelijke-musea-amsterdam">Beste musea bij slecht weer</Link>
-          </li>
-          <li>
-            <Link href="/museum/stedelijk-museum-amsterdam">Musea met moderne kunst</Link>
-          </li>
-        </ul>
+        <div className="museum-guide-link-grid">
+          <Link href="/beste-musea-amsterdam" className="museum-guide-link-button">
+            Beste Musea in Amsterdam <span aria-hidden="true">→</span>
+          </Link>
+          <Link href="/kindvriendelijke-musea-amsterdam" className="museum-guide-link-button">
+            Kindvriendelijke musea in Amsterdam <span aria-hidden="true">→</span>
+          </Link>
+          <Link href="/moderne-kunst-musea-amsterdam" className="museum-guide-link-button">
+            Musea met moderne kunst <span aria-hidden="true">→</span>
+          </Link>
+        </div>
       </section>
     </>
   );

--- a/pages/eye-filmmuseum-amsterdam.js
+++ b/pages/eye-filmmuseum-amsterdam.js
@@ -142,14 +142,14 @@ export default function EyeFilmmuseumAmsterdamPage() {
 
       <section className="museum-guide-section">
         <h2>Meer categorieën om verder te vergelijken</h2>
-        <div className="museum-guide-link-grid">
-          <Link href="/beste-musea-amsterdam" className="museum-guide-link-button">
+        <div className="museum-guide-actions">
+          <Link href="/beste-musea-amsterdam" className="ticket-button museum-guide-action-link">
             Beste Musea in Amsterdam <span aria-hidden="true">→</span>
           </Link>
-          <Link href="/kindvriendelijke-musea-amsterdam" className="museum-guide-link-button">
+          <Link href="/kindvriendelijke-musea-amsterdam" className="ticket-button museum-guide-action-link">
             Kindvriendelijke musea in Amsterdam <span aria-hidden="true">→</span>
           </Link>
-          <Link href="/moderne-kunst-musea-amsterdam" className="museum-guide-link-button">
+          <Link href="/moderne-kunst-musea-amsterdam" className="ticket-button museum-guide-action-link">
             Musea met moderne kunst <span aria-hidden="true">→</span>
           </Link>
         </div>

--- a/pages/eye-filmmuseum-amsterdam.js
+++ b/pages/eye-filmmuseum-amsterdam.js
@@ -1,0 +1,159 @@
+import Link from 'next/link';
+import SEO from '../components/SEO';
+import { getStaticMuseumBySlug } from '../lib/staticMuseums';
+
+const RELATED_MUSEUMS = [
+  {
+    slug: 'stedelijk-museum-amsterdam',
+    reason:
+      'Sterke match als je van visuele cultuur en moderne kunst houdt. Je combineert hier kunst, design en vernieuwende tentoonstellingen.',
+  },
+  {
+    slug: 'nxt-museum-amsterdam',
+    reason:
+      'Interessant voor bezoekers die film, licht en digitale installaties waarderen. De beleving is vaak immersief en experimenteel.',
+  },
+  {
+    slug: 'moco-museum-amsterdam',
+    reason:
+      'Populair bij wie hedendaagse kunst zoekt die toegankelijk en visueel sterk is. Fijn als je naast Eye nog iets moderns wilt zien.',
+  },
+  {
+    slug: 'rijksmuseum-amsterdam',
+    reason:
+      'Goede aanvulling wanneer je je dag wilt verbreden met Nederlandse kunst- en cultuurgeschiedenis in een groot museum.',
+  },
+  {
+    slug: 'van-gogh-museum-amsterdam',
+    reason:
+      'Ideaal als je vooral geïnteresseerd bent in beeldtaal, kleur en artistieke ontwikkeling binnen één sterke collectie.',
+  },
+  {
+    slug: 'foam-fotografiemuseum-amsterdam',
+    reason:
+      'Past bij dezelfde doelgroep die visuele verhalen waardeert. FOAM is compact en daardoor makkelijk te combineren met andere stops.',
+  },
+];
+
+const practicalInfo = [
+  { label: 'Locatie', value: 'IJpromenade 1, Amsterdam-Noord (tegenover Amsterdam Centraal)' },
+  { label: 'Gemiddelde bezoektijd', value: 'Ongeveer 1,5 tot 2,5 uur' },
+  { label: 'Soort museum', value: 'Film, cultuur en moderne beeldtaal' },
+  {
+    label: 'Geschikt voor',
+    value: 'Filmliefhebbers, architectuurliefhebbers, solo-bezoekers en een regenachtige dag in Amsterdam',
+  },
+];
+
+function RelatedMuseumCard({ slug, reason }) {
+  const museum = getStaticMuseumBySlug(slug);
+  if (!museum) return null;
+
+  return (
+    <li className="guide-hub-item">
+      <Link href={`/museum/${museum.slug}`} className="guide-hub-item__link" aria-label={`Bekijk ${museum.naam}`}>
+        <h3 className="guide-hub-item__title">{museum.naam}</h3>
+        <p className="guide-hub-item__description">
+          {museum.samenvatting} {reason}
+        </p>
+        <span className="guide-hub-item__button" aria-hidden="true">
+          bekijk museum <span aria-hidden="true">→</span>
+        </span>
+      </Link>
+    </li>
+  );
+}
+
+export default function EyeFilmmuseumAmsterdamPage() {
+  const title = 'Eye Filmmuseum Amsterdam – praktische info en tips | MuseumBuddy';
+  const description =
+    'Eye Filmmuseum in Amsterdam bezoeken? Lees praktische info, tips en ontdek andere musea die goed passen bij film- en cultuurliefhebbers.';
+
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'TouristAttraction',
+    name: 'Eye Filmmuseum',
+    description,
+    url: 'https://museumbuddy.nl/eye-filmmuseum-amsterdam',
+    address: {
+      '@type': 'PostalAddress',
+      streetAddress: 'IJpromenade 1',
+      addressLocality: 'Amsterdam',
+      addressCountry: 'NL',
+    },
+  };
+
+  return (
+    <>
+      <SEO
+        title={title}
+        description={description}
+        canonical="/eye-filmmuseum-amsterdam"
+        robots="index,follow"
+        structuredData={structuredData}
+      />
+
+      <section className="page-intro">
+        <h1 className="page-title">Eye Filmmuseum Amsterdam – praktische info en tips</h1>
+        <p className="page-subtitle">
+          Wil je Eye Filmmuseum bezoeken en snel weten of het bij je past? Op deze pagina vind je de belangrijkste
+          praktische informatie, plus slimme doorkliktips naar vergelijkbare musea in Amsterdam.
+        </p>
+      </section>
+
+      <section className="museum-guide-section">
+        <h2>Praktische info</h2>
+        <ul className="museum-guide-practical-list">
+          {practicalInfo.map((item) => (
+            <li key={item.label} className="museum-guide-practical-item">
+              <span className="museum-guide-practical-label">{item.label}</span>
+              <span className="museum-guide-practical-value">{item.value}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="museum-guide-section">
+        <h2>Waarom Eye Filmmuseum bijzonder is</h2>
+        <p>
+          Eye Filmmuseum combineert architectuur, filmgeschiedenis en actuele filmcultuur op één plek. Je bezoekt er
+          niet alleen tentoonstellingen over cinema en makers, maar ook presentaties waarin beeld, geluid en verhaal op
+          een moderne manier samenkomen.
+        </p>
+        <p>
+          Bezoekers kiezen Eye vaak omdat het meer is dan een klassiek museumbezoek: je kunt collectie, tijdelijke
+          exposities en filmprogramma&apos;s combineren in één dagdeel. Daardoor is het aantrekkelijk voor zowel
+          doorgewinterde filmfans als bezoekers die gewoon een cultureel en inspirerend binnenprogramma zoeken.
+        </p>
+      </section>
+
+      <section className="museum-guide-section">
+        <h2>Andere musea die je misschien ook interessant vindt</h2>
+        <p className="museum-guide-section-intro">
+          Zoek je vergelijkbare beleving of wil je je museumdag uitbreiden? Deze musea sluiten goed aan bij bezoekers
+          die ook Eye Filmmuseum overwegen.
+        </p>
+        <ul className="guide-hub-list" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+          {RELATED_MUSEUMS.map((museum) => (
+            <RelatedMuseumCard key={museum.slug} slug={museum.slug} reason={museum.reason} />
+          ))}
+        </ul>
+      </section>
+
+      <section className="museum-guide-section">
+        <h2>Meer categorieën om verder te vergelijken</h2>
+        <ul>
+          <li>
+            <Link href="/beste-musea-amsterdam">Musea in Amsterdam</Link>
+          </li>
+          <li>
+            <Link href="/kindvriendelijke-musea-amsterdam">Beste musea bij slecht weer</Link>
+          </li>
+          <li>
+            <Link href="/museum/stedelijk-museum-amsterdam">Musea met moderne kunst</Link>
+          </li>
+        </ul>
+      </section>
+    </>
+  );
+}

--- a/pages/moderne-kunst-musea-amsterdam.js
+++ b/pages/moderne-kunst-musea-amsterdam.js
@@ -89,14 +89,14 @@ export default function ModernArtMuseumsAmsterdamPage() {
 
       <section className="museum-guide-section">
         <h2>Verder vergelijken</h2>
-        <div className="museum-guide-link-grid">
-          <Link href="/beste-musea-amsterdam" className="museum-guide-link-button">
+        <div className="museum-guide-actions">
+          <Link href="/beste-musea-amsterdam" className="ticket-button museum-guide-action-link">
             Beste Musea in Amsterdam <span aria-hidden="true">→</span>
           </Link>
-          <Link href="/eye-filmmuseum-amsterdam" className="museum-guide-link-button">
+          <Link href="/eye-filmmuseum-amsterdam" className="ticket-button museum-guide-action-link">
             Eye Filmmuseum praktische gids <span aria-hidden="true">→</span>
           </Link>
-          <Link href="/museumgidsen-amsterdam" className="museum-guide-link-button">
+          <Link href="/museumgidsen-amsterdam" className="ticket-button museum-guide-action-link">
             Alle museumgidsen <span aria-hidden="true">→</span>
           </Link>
         </div>

--- a/pages/moderne-kunst-musea-amsterdam.js
+++ b/pages/moderne-kunst-musea-amsterdam.js
@@ -1,0 +1,106 @@
+import Link from 'next/link';
+import SEO from '../components/SEO';
+import { getStaticMuseumBySlug } from '../lib/staticMuseums';
+
+const MODERN_ART_MUSEUMS = [
+  {
+    slug: 'stedelijk-museum-amsterdam',
+    why: 'Een van de belangrijkste musea voor moderne en hedendaagse kunst in Nederland, met sterke vaste collectie en wisselende exposities.',
+  },
+  {
+    slug: 'moco-museum-amsterdam',
+    why: 'Populair voor toegankelijke moderne kunst en bekende namen uit street art en hedendaagse beeldcultuur.',
+  },
+  {
+    slug: 'nxt-museum-amsterdam',
+    why: 'Focus op digitale en immersieve installaties, ideaal voor bezoekers die moderne kunst als ervaring willen meemaken.',
+  },
+  {
+    slug: 'straat-museum-amsterdam',
+    why: 'Groot museum voor street art en graffiti met monumentale werken van internationale makers.',
+  },
+  {
+    slug: 'eye-filmmuseum-amsterdam',
+    why: 'Interessante overlap tussen film, visuele cultuur en moderne artistieke presentatievormen.',
+  },
+];
+
+function ModernArtMuseumCard({ slug, why }) {
+  const museum = getStaticMuseumBySlug(slug);
+  if (!museum) return null;
+
+  return (
+    <li className="guide-hub-item">
+      <Link href={`/museum/${museum.slug}`} className="guide-hub-item__link" aria-label={`Bekijk ${museum.naam}`}>
+        <h3 className="guide-hub-item__title">{museum.naam}</h3>
+        <p className="guide-hub-item__description">
+          {museum.samenvatting} {why}
+        </p>
+        <span className="guide-hub-item__button" aria-hidden="true">
+          bekijk museum <span aria-hidden="true">→</span>
+        </span>
+      </Link>
+    </li>
+  );
+}
+
+export default function ModernArtMuseumsAmsterdamPage() {
+  const title = 'Moderne kunst musea in Amsterdam | Praktische gids';
+  const description =
+    'Ontdek musea met moderne kunst in Amsterdam. Vergelijk Stedelijk, Moco, Nxt, STRAAT en Eye Filmmuseum en klik door naar detailpagina’s.';
+
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: 'Moderne kunst musea in Amsterdam',
+    description,
+    url: 'https://museumbuddy.nl/moderne-kunst-musea-amsterdam',
+  };
+
+  return (
+    <>
+      <SEO
+        title={title}
+        description={description}
+        canonical="/moderne-kunst-musea-amsterdam"
+        robots="index,follow"
+        structuredData={structuredData}
+      />
+
+      <section className="page-intro">
+        <h1 className="page-title">Moderne kunst musea in Amsterdam</h1>
+        <p className="page-subtitle">
+          Zoek je musea met moderne kunst in Amsterdam? Hieronder vind je een praktische selectie met verschillende
+          stijlen: van klassiek moderne kunst tot digitale installaties en street art.
+        </p>
+      </section>
+
+      <section className="museum-guide-section">
+        <h2>Aanraders voor moderne kunst</h2>
+        <p className="museum-guide-section-intro">
+          Klik door naar de detailpagina per museum om openingstijden, context en praktische informatie te bekijken.
+        </p>
+        <ul className="guide-hub-list" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+          {MODERN_ART_MUSEUMS.map((museum) => (
+            <ModernArtMuseumCard key={museum.slug} slug={museum.slug} why={museum.why} />
+          ))}
+        </ul>
+      </section>
+
+      <section className="museum-guide-section">
+        <h2>Verder vergelijken</h2>
+        <div className="museum-guide-link-grid">
+          <Link href="/beste-musea-amsterdam" className="museum-guide-link-button">
+            Beste Musea in Amsterdam <span aria-hidden="true">→</span>
+          </Link>
+          <Link href="/eye-filmmuseum-amsterdam" className="museum-guide-link-button">
+            Eye Filmmuseum praktische gids <span aria-hidden="true">→</span>
+          </Link>
+          <Link href="/museumgidsen-amsterdam" className="museum-guide-link-button">
+            Alle museumgidsen <span aria-hidden="true">→</span>
+          </Link>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/pages/museumgidsen-amsterdam.js
+++ b/pages/museumgidsen-amsterdam.js
@@ -13,6 +13,11 @@ const guidePages = [
     description: 'Praktische informatie, openingstijden en ticketbeschikbaarheid voor een rustig bezoek.',
   },
   {
+    href: '/moderne-kunst-musea-amsterdam',
+    title: 'Moderne kunst musea in Amsterdam',
+    description: 'Vergelijk musea voor moderne kunst met duidelijke doorkliks naar de detailpagina’s.',
+  },
+  {
     href: '/beste-musea-amsterdam',
     title: 'Beste musea in Amsterdam',
     description: 'Onze redactionele selectie met musea die vaak als eerste keuze worden bekeken.',

--- a/pages/museumgidsen-amsterdam.js
+++ b/pages/museumgidsen-amsterdam.js
@@ -3,6 +3,11 @@ import SEO from '../components/SEO';
 
 const guidePages = [
   {
+    href: '/eye-filmmuseum-amsterdam',
+    title: 'Eye Filmmuseum Amsterdam gids',
+    description: 'Praktische info en rustige doorverwijzingen naar vergelijkbare musea in Amsterdam.',
+  },
+  {
     href: '/ons-lieve-heer-op-solder-tickets',
     title: "Ons' Lieve Heer op Solder tickets",
     description: 'Praktische informatie, openingstijden en ticketbeschikbaarheid voor een rustig bezoek.',

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4796,3 +4796,49 @@ button.hero-quick-link {
   background: var(--ds-color-primary-strong);
   border-color: color-mix(in srgb, var(--ds-color-primary-strong) 70%, transparent);
 }
+
+.museum-guide-section {
+  margin-bottom: 2rem;
+}
+
+.museum-guide-section h2 {
+  margin-bottom: 0.75rem;
+}
+
+.museum-guide-section-intro {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.museum-guide-practical-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.museum-guide-practical-item {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid color-mix(in srgb, var(--panel-border) 82%, transparent);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface) 96%, transparent);
+}
+
+.museum-guide-practical-label {
+  font-size: 0.88rem;
+  color: var(--ds-color-text-muted);
+}
+
+.museum-guide-practical-value {
+  color: var(--ds-color-text-strong);
+  font-weight: 600;
+}
+
+@media (min-width: 768px) {
+  .museum-guide-practical-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4842,3 +4842,38 @@ button.hero-quick-link {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
+
+.museum-guide-link-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.museum-guide-link-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--ds-color-primary) 40%, var(--panel-border));
+  background: color-mix(in srgb, var(--ds-color-primary) 12%, var(--surface));
+  color: var(--ds-color-text-strong);
+  text-decoration: none;
+  font-weight: 600;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.museum-guide-link-button:hover,
+.museum-guide-link-button:focus-visible {
+  background: color-mix(in srgb, var(--ds-color-primary) 18%, var(--surface));
+  border-color: color-mix(in srgb, var(--ds-color-primary) 64%, var(--panel-border));
+  transform: translateY(-1px);
+  outline: none;
+}
+
+@media (min-width: 768px) {
+  .museum-guide-link-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4843,37 +4843,18 @@ button.hero-quick-link {
   }
 }
 
-.museum-guide-link-grid {
-  display: grid;
+.museum-guide-actions {
+  display: flex;
+  flex-wrap: wrap;
   gap: 0.75rem;
 }
 
-.museum-guide-link-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.6rem;
-  width: 100%;
-  padding: 0.85rem 1rem;
-  border-radius: 12px;
-  border: 1px solid color-mix(in srgb, var(--ds-color-primary) 40%, var(--panel-border));
-  background: color-mix(in srgb, var(--ds-color-primary) 12%, var(--surface));
-  color: var(--ds-color-text-strong);
-  text-decoration: none;
-  font-weight: 600;
-  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
-}
-
-.museum-guide-link-button:hover,
-.museum-guide-link-button:focus-visible {
-  background: color-mix(in srgb, var(--ds-color-primary) 18%, var(--surface));
-  border-color: color-mix(in srgb, var(--ds-color-primary) 64%, var(--panel-border));
-  transform: translateY(-1px);
-  outline: none;
+.museum-guide-action-link {
+  min-width: 210px;
 }
 
 @media (min-width: 768px) {
-  .museum-guide-link-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+  .museum-guide-action-link {
+    min-width: 240px;
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a dedicated, informational SEO landing page for queries like "eye filmmuseum" and "filmmuseum amsterdam" that focuses on helpful guidance rather than ticket sales.
- Surface practical, scanable visitor information and encourage internal navigation to other museums where tickets are available.
- Keep changes lightweight and consistent with the existing design system and site structure.

### Description
- Added a new guide page `pages/eye-filmmuseum-amsterdam.js` with the requested structure including an H1, short intro (no ticket CTA), practical info, content about what makes Eye special, a section with 6 related museum cards linking to internal detail pages, and category links.
- Registered the new guide in the hub by updating `pages/museumgidsen-amsterdam.js` so the page is discoverable via existing internal navigation.
- Added minimal, reusable styles in `styles/globals.css` for the guide sections and compact practical-info blocks, reusing the project’s existing card/link styles and the `SEO` component with canonical and structured data.

### Testing
- Ran the project test suite with `npm test` which runs `tests/ticketCta.test.cjs`, `tests/kidFriendlyFilter.test.cjs`, `tests/nearbyFilter.test.cjs`, and `tests/museumSearch.test.cjs`, and all tests passed.
- Verified no regressions in automated tests after adding the page and CSS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4055977083268f1dbd034c5c29b3)