### PR TITLE
Add featured hero button for "Beste Musea in Amsterdam"

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -942,8 +942,10 @@ export default function Home({ initialMuseums = [], initialError = null }) {
         <a
           href="https://www.museumbuddy.nl/beste-musea-amsterdam"
           className="hero-featured-link"
+          aria-label="Bekijk de gids: Beste Musea in Amsterdam"
         >
-          Beste Musea in Amsterdam
+          <span className="hero-featured-link__eyebrow">Gids</span>
+          <span className="hero-featured-link__label">Beste Musea in Amsterdam</span>
         </a>
         <div className="hero-content">
           <span className="hero-tagline">{t('heroTagline')}</span>

--- a/pages/index.js
+++ b/pages/index.js
@@ -939,14 +939,6 @@ export default function Home({ initialMuseums = [], initialError = null }) {
         }}
       />
       <section className="hero">
-        <a
-          href="https://www.museumbuddy.nl/beste-musea-amsterdam"
-          className="hero-featured-link"
-          aria-label="Bekijk de gids: Beste Musea in Amsterdam"
-        >
-          <span className="hero-featured-link__eyebrow">Gids</span>
-          <span className="hero-featured-link__label">Beste Musea in Amsterdam</span>
-        </a>
         <div className="hero-content">
           <span className="hero-tagline">{t('heroTagline')}</span>
           <h1 className="hero-title">{t('heroTitle')}</h1>
@@ -980,6 +972,13 @@ export default function Home({ initialMuseums = [], initialError = null }) {
           </div>
         </div>
         <form className="hero-card hero-search" onSubmit={(e) => e.preventDefault()}>
+          <a
+            href="https://www.museumbuddy.nl/beste-musea-amsterdam"
+            className="hero-featured-link"
+            aria-label="Bekijk de gids: Beste Musea in Amsterdam"
+          >
+            Beste Musea in Amsterdam
+          </a>
           <input
             type="search"
             className="input hero-input"

--- a/pages/index.js
+++ b/pages/index.js
@@ -939,6 +939,12 @@ export default function Home({ initialMuseums = [], initialError = null }) {
         }}
       />
       <section className="hero">
+        <a
+          href="https://www.museumbuddy.nl/beste-musea-amsterdam"
+          className="hero-featured-link"
+        >
+          Beste Musea in Amsterdam
+        </a>
         <div className="hero-content">
           <span className="hero-tagline">{t('heroTagline')}</span>
           <h1 className="hero-title">{t('heroTitle')}</h1>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1204,20 +1204,22 @@ img { max-width: 100%; height: auto; display: block; }
 
 .hero-featured-link {
   position: absolute;
-  top: clamp(var(--space-16), 2.4vw, var(--space-24));
-  right: clamp(var(--space-16), 3vw, var(--space-32));
+  top: clamp(-102px, -9vw, -72px);
+  right: clamp(0px, 0.8vw, 12px);
   z-index: 3;
-  display: grid;
-  gap: 4px;
-  justify-items: start;
-  width: min(280px, 36vw);
-  min-width: 200px;
-  padding: clamp(12px, 1.6vw, 16px) clamp(16px, 2.1vw, 22px);
-  border-radius: 28px;
+  display: inline-flex;
+  align-items: center;
+  width: min(250px, 90%);
+  padding: clamp(16px, 1.8vw, 20px) clamp(20px, 2.4vw, 28px);
+  border-radius: 30px;
   border: 1px solid rgba(147, 197, 253, 0.55);
   background: linear-gradient(145deg, rgba(59, 130, 246, 0.97) 0%, rgba(37, 99, 235, 0.95) 72%);
   color: #f8fafc;
   text-decoration: none;
+  font-size: clamp(1.05rem, 1.25vw, 1.18rem);
+  line-height: 1.25;
+  font-weight: 800;
+  letter-spacing: -0.01em;
   box-shadow: 0 16px 34px rgba(8, 47, 73, 0.42);
   transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease, border-color 0.15s ease;
 }
@@ -1232,22 +1234,6 @@ img { max-width: 100%; height: auto; display: block; }
 .hero-featured-link:focus-visible {
   outline: 2px solid rgba(255, 255, 255, 0.9);
   outline-offset: 2px;
-}
-
-.hero-featured-link__eyebrow {
-  font-size: 0.68rem;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: rgba(219, 234, 254, 0.92);
-}
-
-.hero-featured-link__label {
-  font-size: clamp(1.05rem, 1.4vw, 1.18rem);
-  line-height: 1.2;
-  font-weight: 800;
-  letter-spacing: -0.01em;
-  text-wrap: balance;
 }
 
 .hero > * { position: relative; z-index: 1; }
@@ -1329,6 +1315,7 @@ img { max-width: 100%; height: auto; display: block; }
   backdrop-filter: blur(12px);
 }
 .hero-search {
+  position: relative;
   display: grid;
   gap: var(--space-16);
   max-width: 460px;
@@ -1676,8 +1663,8 @@ button.hero-quick-link {
   .hero::before { background-position: center 46%; }
   .hero-featured-link {
     position: static;
-    justify-self: end;
-    width: min(100%, 320px);
+    justify-self: start;
+    width: min(100%, 280px);
   }
   .hero-card { padding: var(--space-16); }
   .hero-content {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1204,34 +1204,50 @@ img { max-width: 100%; height: auto; display: block; }
 
 .hero-featured-link {
   position: absolute;
-  top: clamp(var(--space-16), 2.2vw, var(--space-24));
-  right: clamp(var(--space-16), 2.6vw, var(--space-24));
+  top: clamp(var(--space-16), 2.4vw, var(--space-24));
+  right: clamp(var(--space-16), 3vw, var(--space-32));
   z-index: 3;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px 16px;
-  border-radius: 999px;
-  border: 1px solid rgba(248, 250, 252, 0.4);
-  background: linear-gradient(135deg, rgba(14, 116, 144, 0.9) 0%, rgba(37, 99, 235, 0.92) 100%);
+  display: grid;
+  gap: 4px;
+  justify-items: start;
+  width: min(280px, 36vw);
+  min-width: 200px;
+  padding: clamp(12px, 1.6vw, 16px) clamp(16px, 2.1vw, 22px);
+  border-radius: 28px;
+  border: 1px solid rgba(147, 197, 253, 0.55);
+  background: linear-gradient(145deg, rgba(59, 130, 246, 0.97) 0%, rgba(37, 99, 235, 0.95) 72%);
   color: #f8fafc;
   text-decoration: none;
-  font-size: 0.83rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.32);
-  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+  box-shadow: 0 16px 34px rgba(8, 47, 73, 0.42);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease, border-color 0.15s ease;
 }
 
 .hero-featured-link:hover {
   transform: translateY(-1px);
-  filter: brightness(1.05);
-  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.38);
+  filter: brightness(1.06);
+  border-color: rgba(191, 219, 254, 0.75);
+  box-shadow: 0 20px 38px rgba(8, 47, 73, 0.5);
 }
 
 .hero-featured-link:focus-visible {
   outline: 2px solid rgba(255, 255, 255, 0.9);
   outline-offset: 2px;
+}
+
+.hero-featured-link__eyebrow {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(219, 234, 254, 0.92);
+}
+
+.hero-featured-link__label {
+  font-size: clamp(1.05rem, 1.4vw, 1.18rem);
+  line-height: 1.2;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  text-wrap: balance;
 }
 
 .hero > * { position: relative; z-index: 1; }
@@ -1661,6 +1677,7 @@ button.hero-quick-link {
   .hero-featured-link {
     position: static;
     justify-self: end;
+    width: min(100%, 320px);
   }
   .hero-card { padding: var(--space-16); }
   .hero-content {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1202,6 +1202,38 @@ img { max-width: 100%; height: auto; display: block; }
   }
 }
 
+.hero-featured-link {
+  position: absolute;
+  top: clamp(var(--space-16), 2.2vw, var(--space-24));
+  right: clamp(var(--space-16), 2.6vw, var(--space-24));
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(248, 250, 252, 0.4);
+  background: linear-gradient(135deg, rgba(14, 116, 144, 0.9) 0%, rgba(37, 99, 235, 0.92) 100%);
+  color: #f8fafc;
+  text-decoration: none;
+  font-size: 0.83rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.32);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+}
+
+.hero-featured-link:hover {
+  transform: translateY(-1px);
+  filter: brightness(1.05);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.38);
+}
+
+.hero-featured-link:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.9);
+  outline-offset: 2px;
+}
+
 .hero > * { position: relative; z-index: 1; }
 .hero-content {
   display: flex;
@@ -1626,6 +1658,10 @@ button.hero-quick-link {
     border-radius: var(--radius-md);
   }
   .hero::before { background-position: center 46%; }
+  .hero-featured-link {
+    position: static;
+    justify-self: end;
+  }
   .hero-card { padding: var(--space-16); }
   .hero-content {
     align-items: center;


### PR DESCRIPTION
### Motivation
- Provide a prominent, attractive CTA in the homepage hero that links users to the editorial page for the best museums in Amsterdam (`https://www.museumbuddy.nl/beste-musea-amsterdam`).
- Position the CTA visually above the search card so it appears top-right in the hero without interfering with the existing hero CTAs.

### Description
- Added an anchor in the homepage hero at `pages/index.js` with the label `Beste Musea in Amsterdam` and class `hero-featured-link` placed before the hero content so it floats above the search card. 
- Implemented styles in `styles/globals.css` for `.hero-featured-link` including gradient background, pill shape, hover and `:focus-visible` states for accessibility and visual polish. 
- Made the button absolutely positioned on larger screens and added a responsive fallback (for `@media (max-width: 600px)`) to avoid overlap by switching it to static layout.
- Kept existing hero layout and CTAs unchanged so behavior for other buttons (discover / exhibitions / search) is preserved.

### Testing
- Ran the test suite with `npm test`, which executed `node tests/ticketCta.test.cjs`, `node tests/kidFriendlyFilter.test.cjs`, `node tests/nearbyFilter.test.cjs`, and `node tests/museumSearch.test.cjs` and completed successfully.
- Individual test outputs included: "Ticket CTA copy tests passed.", "Kid-friendly filter tests passed.", "Nearby filter results remain visible.", and "Museum search parsing tests passed.".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5be5d86c83269bea9541b045ac4e)