### PR TITLE
Improve SEO snippets for museum guide pages

### DIFF
--- a/lib/translations.js
+++ b/lib/translations.js
@@ -21,12 +21,12 @@ const translations = {
     homeSeoLinkVanGogh: 'Van Gogh Museum',
     heroDiscoverMuseums: 'Discover museums',
     heroViewExhibitions: 'View exhibitions in Amsterdam',
-    exhibitionsPageTitle: 'Exhibitions Amsterdam: museum exhibitions overview | MuseumBuddy',
+    exhibitionsPageTitle: 'Amsterdam museum agenda: exhibitions now | MuseumBuddy',
     exhibitionsPageDescription:
-      'Discover exhibitions and expos in Amsterdam, filter by museum and type, and use museum pages to verify opening hours and visit details.',
-    exhibitionsPageHeading: 'Exhibitions in Amsterdam',
+      'See exhibitions in Amsterdam now: filter by museum or theme, compare current shows, and click through for opening hours and ticket details.',
+    exhibitionsPageHeading: 'Exhibitions in Amsterdam now',
     exhibitionsPageSubtitle:
-      'Find exhibitions and exposities in Amsterdam, filter quickly, and open museum pages for practical visit details.',
+      'Use this Amsterdam museum agenda to find current exhibitions, filter quickly, and open museum pages for practical visit details.',
     exhibitionsBackHome: 'Back to homepage',
     exhibitionsSeoIntroHeading: 'Museum exhibitions in Amsterdam: practical overview',
     exhibitionsSeoIntro:
@@ -277,12 +277,12 @@ const translations = {
     homeSeoLinkVanGogh: 'Van Gogh Museum',
     heroDiscoverMuseums: 'Ontdek musea',
     heroViewExhibitions: 'Bekijk tentoonstellingen in Amsterdam',
-    exhibitionsPageTitle: 'Tentoonstellingen Amsterdam: exposities overzicht | MuseumBuddy',
+    exhibitionsPageTitle: 'Museumagenda Amsterdam: exposities nu | MuseumBuddy',
     exhibitionsPageDescription:
-      'Ontdek tentoonstellingen en exposities in Amsterdam, filter op museum en type, en controleer praktische bezoekinformatie op de museumpagina.',
-    exhibitionsPageHeading: 'Tentoonstellingen in Amsterdam',
+      'Bekijk tentoonstellingen en exposities die nu in Amsterdam lopen. Filter op museum of thema en klik door voor openingstijden en tickets.',
+    exhibitionsPageHeading: 'Tentoonstellingen in Amsterdam nu',
     exhibitionsPageSubtitle:
-      'Vind tentoonstellingen en exposities in Amsterdam, filter gericht en klik door naar musea voor praktische details.',
+      'Gebruik deze museumagenda voor Amsterdam om actuele tentoonstellingen en exposities snel te vergelijken.',
     exhibitionsBackHome: 'Terug naar homepage',
     exhibitionsSeoIntroHeading: 'Tentoonstellingen en exposities in Amsterdam overzichtelijk vergelijken',
     exhibitionsSeoIntro:

--- a/pages/beste-musea-amsterdam.js
+++ b/pages/beste-musea-amsterdam.js
@@ -131,9 +131,9 @@ function MuseumCardCompact({ slug, compact = false }) {
 }
 
 export default function BestMuseumsAmsterdamPage() {
-  const title = 'Beste musea in Amsterdam | MuseumBuddy';
+  const title = 'Beste musea Amsterdam: topkeuzes en verborgen parels | MuseumBuddy';
   const description =
-    'Discover the best museums in Amsterdam. From famous highlights like the Rijksmuseum to hidden gems. Find the perfect museum for your visit.';
+    'Vergelijk de beste musea in Amsterdam: Rijksmuseum, Van Gogh, Anne Frank Huis, moderne kunst, fotografie, wetenschap en verborgen parels voor je bezoek.';
 
   const structuredData = {
     '@context': 'https://schema.org',

--- a/pages/kindvriendelijke-musea-amsterdam.js
+++ b/pages/kindvriendelijke-musea-amsterdam.js
@@ -20,16 +20,16 @@ export default function KidFriendlyMuseumsLandingPage() {
   const { lang } = useLanguage();
   const title =
     lang === 'en'
-      ? 'Our curated selection of kid-friendly museums in Amsterdam | MuseumBuddy'
-      : 'Onze selectie kindvriendelijke musea in Amsterdam | MuseumBuddy';
+      ? 'Kid-friendly museums Amsterdam: hands-on family picks | MuseumBuddy'
+      : 'Kindvriendelijke musea Amsterdam: interactieve gezinstips | MuseumBuddy';
   const description =
     lang === 'en'
-      ? "Discover MuseumBuddy's curated selection of kid-friendly museums in Amsterdam, chosen for interactive and family-friendly experiences."
-      : "Ontdek MuseumBuddy's selectie kindvriendelijke musea in Amsterdam, gekozen op interactieve en gezinsvriendelijke museumervaringen.";
+      ? 'Find kid-friendly museums in Amsterdam, including hands-on children’s museum picks such as NEMO, Micropia, maritime stories, street art and cats.'
+      : 'Vind kindvriendelijke musea in Amsterdam, met interactieve gezinstips zoals NEMO, Micropia, maritieme verhalen, street art en katten.';
   const heading =
     lang === 'en'
-      ? 'Our curated selection of kid-friendly museums in Amsterdam'
-      : 'Onze selectie kindvriendelijke musea in Amsterdam';
+      ? 'Kid-friendly museums in Amsterdam'
+      : 'Kindvriendelijke musea in Amsterdam';
   const intro =
     lang === 'en'
       ? `Looking for kid-friendly museums in Amsterdam? This page is a curated editorial selection by MuseumBuddy, not a complete overview of every family museum in the city. We focus on places that can work especially well for families because they offer interactive elements, clear storytelling, visual experiences, or themes that often appeal to children. Each museum in this selection is included because we believe it can provide a strong starting point for a family museum day in Amsterdam.\n\nFamilies differ in age, interests, and attention span, so a museum that is great for one child may be less suitable for another. We therefore recommend checking the museum's own website for current exhibitions, opening hours, ticket conditions, and any age-specific activities before you visit. Use this page as a practical shortlist you can trust: carefully chosen options, transparent positioning, and realistic expectations for planning a museum outing with children.`
@@ -39,22 +39,63 @@ export default function KidFriendlyMuseumsLandingPage() {
     .filter((museum) => KID_FRIENDLY_SET.has((museum.slug || '').toLowerCase()))
     .map(toCardMuseum);
 
-  const structuredData = {
-    '@context': 'https://schema.org',
-    '@type': 'CollectionPage',
-    name: heading,
-    description,
-    mainEntity: {
-      '@type': 'ItemList',
-      numberOfItems: museums.length,
-      itemListElement: museums.map((museum, index) => ({
-        '@type': 'ListItem',
-        position: index + 1,
-        url: `https://museumbuddy.nl/museum/${museum.slug}`,
-        name: museum.naam,
+  const faqItems =
+    lang === 'en'
+      ? [
+          {
+            question: 'Which hands-on children’s museum in Amsterdam is a good first pick?',
+            answer:
+              'NEMO Science Museum is usually the clearest hands-on first pick because it focuses on interactive science exhibits. Micropia and Het Scheepvaartmuseum can also work well for curious children.',
+          },
+          {
+            question: 'Are all museums on this page suitable for every age?',
+            answer:
+              'No. The selection is a practical shortlist, but ages, interests and attention span differ per family. Always check current activities, tickets and opening hours before visiting.',
+          },
+        ]
+      : [
+          {
+            question: 'Welk interactief kindermuseum in Amsterdam is een goede eerste keuze?',
+            answer:
+              'NEMO Science Museum is meestal de duidelijkste hands-on keuze door de interactieve wetenschapsexposities. Ook Micropia en Het Scheepvaartmuseum kunnen goed werken voor nieuwsgierige kinderen.',
+          },
+          {
+            question: 'Zijn alle musea op deze pagina geschikt voor elke leeftijd?',
+            answer:
+              'Nee. De selectie is een praktische shortlist, maar leeftijden, interesses en aandachtsspanne verschillen per gezin. Controleer altijd actuele activiteiten, tickets en openingstijden voor je bezoek.',
+          },
+        ];
+
+  const structuredData = [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'CollectionPage',
+      name: heading,
+      description,
+      mainEntity: {
+        '@type': 'ItemList',
+        numberOfItems: museums.length,
+        itemListElement: museums.map((museum, index) => ({
+          '@type': 'ListItem',
+          position: index + 1,
+          url: `https://museumbuddy.nl/museum/${museum.slug}`,
+          name: museum.naam,
+        })),
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: faqItems.map((item) => ({
+        '@type': 'Question',
+        name: item.question,
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: item.answer,
+        },
       })),
     },
-  };
+  ];
 
   return (
     <>
@@ -71,6 +112,17 @@ export default function KidFriendlyMuseumsLandingPage() {
           <p key={paragraph} className="page-subtitle">
             {paragraph}
           </p>
+        ))}
+      </section>
+      <section className="museum-guide-section" aria-labelledby="family-faq-heading">
+        <h2 id="family-faq-heading">
+          {lang === 'en' ? 'Quick answers for families' : 'Snelle antwoorden voor gezinnen'}
+        </h2>
+        {faqItems.map((item) => (
+          <details key={item.question} className="guide-faq-item">
+            <summary>{item.question}</summary>
+            <p>{item.answer}</p>
+          </details>
         ))}
       </section>
       <p className="count">{museums.length} musea</p>

--- a/pages/moderne-kunst-musea-amsterdam.js
+++ b/pages/moderne-kunst-musea-amsterdam.js
@@ -45,9 +45,9 @@ function ModernArtMuseumCard({ slug, why }) {
 }
 
 export default function ModernArtMuseumsAmsterdamPage() {
-  const title = 'Moderne kunst musea in Amsterdam | Praktische gids';
+  const title = 'Moderne kunst Amsterdam: musea voor modern masters | MuseumBuddy';
   const description =
-    'Ontdek musea met moderne kunst in Amsterdam. Vergelijk Stedelijk, Moco, Nxt, STRAAT en Eye Filmmuseum en klik door naar detailpagina’s.';
+    'Vergelijk moderne kunst musea in Amsterdam: Stedelijk, Moco, Nxt, STRAAT en Eye. Praktische gids voor modern masters, street art en digitale kunst.';
 
   const structuredData = {
     '@context': 'https://schema.org',


### PR DESCRIPTION
### Motivation
- Increase organic click-through-rate by making page titles and meta descriptions match high-intent queries like “museumagenda Amsterdam”, “exposities nu” and family-focused queries such as “kid-friendly museums Amsterdam”.
- Provide clearer, intent-focused SERP copy to surface relevant phrases early in the title/H1/description for both Dutch and English audiences.
- Improve discoverability by adding FAQ content and structured data for family queries so search engines can show richer results and users get quick answers.

### Description
- Retargeted the exhibitions copy in `lib/translations.js` to emphasize “Amsterdam museum agenda”, “exhibitions now” and related query phrasing and updated the page heading and subtitle. 
- Rewrote meta/title/description text for the kid-friendly landing page in `pages/kindvriendelijke-musea-amsterdam.js`, added `faqItems`, exposed a visible FAQ section and included `FAQPage` structured data alongside the existing `CollectionPage` structured data. 
- Updated the best-musea guide in `pages/beste-musea-amsterdam.js` to a more specific title and description that include recognizable anchors like Rijksmuseum and Van Gogh. 
- Sharpened the modern-art guide in `pages/moderne-kunst-musea-amsterdam.js` with a more targeted title and description for modern/immersive art queries. 
- Sitemap regeneration was attempted by the SEO generator but the generated `public/sitemap.xml` was not committed (it was reverted) so only content/meta changes were committed. 

### Testing
- Ran `git diff --check` with no problems reported. 
- Ran `npm test` and all automated tests passed (`ticketCta`, `kidFriendlyFilter`, `nearbyFilter`, `museumSearch`).
- Ran `npm run build` and the Next.js production build completed successfully though it reported non-critical warnings about missing `sharp`, an oversized page data warning for `/tentoonstellingen`, and an outdated `browserslist` DB. 
- Attempted to install/run `playwright` for screenshots but the registry returned a `403`, so visual checks were not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c01b416f88326bacab14b7ad26ed0)