### PR TITLE
Add breadcrumb schema to museum detail pages

### DIFF
--- a/pages/museum/[slug].js
+++ b/pages/museum/[slug].js
@@ -932,6 +932,7 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
   const seoDescription = buildSeoMetaDescription(displayName, summary || t('museumDescription', { name: displayName }));
   const seoTitle = `${displayName} in Amsterdam | MuseumBuddy`;
   const canonical = `/museum/${slug}`;
+  const museumOverviewPath = '/beste-musea-amsterdam';
   const mapQueryParts = [displayName, ...locationLines];
   if (!locationLines.length) {
     mapQueryParts.push(resolvedMuseum.address, resolvedMuseum.city, resolvedMuseum.province);
@@ -992,14 +993,14 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
           {
             '@type': 'ListItem',
             position: 1,
-            name: 'MuseumBuddy',
+            name: 'Home',
             item: SITE_URL,
           },
           {
             '@type': 'ListItem',
             position: 2,
-            name: t('breadcrumbMuseums'),
-            item: SITE_URL,
+            name: lang === 'nl' ? 'Musea Amsterdam' : 'Museums Amsterdam',
+            item: `${SITE_URL}${museumOverviewPath}`,
           },
           {
             '@type': 'ListItem',
@@ -1014,8 +1015,10 @@ export default function MuseumDetailPage({ museum, expositions, error }) {
       canonical,
       displayName,
       heroImageUrl,
+      lang,
       locationLines.length,
       mapDirectionsUrl,
+      museumOverviewPath,
       resolvedMuseum.address,
       resolvedMuseum.city,
       resolvedMuseum.email,


### PR DESCRIPTION
### Motivation
- Improve structured data so search engines better understand site hierarchy and potentially show breadcrumbs in SERPs by adding an explicit `BreadcrumbList` alongside the existing `Museum` schema on museum detail pages.

### Description
- Update `pages/museum/[slug].js` to add `const museumOverviewPath = '/beste-musea-amsterdam'`, replace the first breadcrumb label with `Home`, and emit a three-item `BreadcrumbList` with `Home` → localized `Musea/Museums Amsterdam` (linking to `${SITE_URL}${museumOverviewPath}`) → current museum, and add `lang` and `museumOverviewPath` to the `useMemo` dependency array.

### Testing
- Ran `npm test` (which executes `node tests/ticketCta.test.cjs`, `node tests/kidFriendlyFilter.test.cjs`, `node tests/nearbyFilter.test.cjs`, and `node tests/museumSearch.test.cjs`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a312cccd4208326ba564ae1d53395af)