### PR TITLE
Simplify exhibition recommendation flows and compact kid-friendly cards

### DIFF
--- a/lib/translations.js
+++ b/lib/translations.js
@@ -42,6 +42,9 @@ const translations = {
     exhibitionsTopHeading: 'Top exhibition picks in Amsterdam',
     exhibitionsTopDescription:
       'Editorial picks from exhibitions that are currently visible on MuseumBuddy. Each card gives quick context on theme and planning, then links you straight to the right museum page.',
+    exhibitionsTopFeaturedLabel: 'Start here',
+    exhibitionsTopAlternativesLabel: 'Or consider one of these',
+    exhibitionsTopBrowseAll: 'Browse all exhibitions',
     exhibitionsTopEmpty:
       'No top picks are available right now. Use the full exhibitions list below.',
     exhibitionsTopReasonDate:
@@ -298,6 +301,9 @@ const translations = {
     exhibitionsTopHeading: 'Topselectie tentoonstellingen in Amsterdam',
     exhibitionsTopDescription:
       'Redactionele aanraders uit tentoonstellingen die nu zichtbaar zijn op MuseumBuddy. Elke kaart geeft je direct inhoudelijke context en een snelle route naar de juiste museumpagina.',
+    exhibitionsTopFeaturedLabel: 'Begin hier',
+    exhibitionsTopAlternativesLabel: 'Of kies een van deze',
+    exhibitionsTopBrowseAll: 'Bekijk alle tentoonstellingen',
     exhibitionsTopEmpty:
       'Er zijn nu geen topselecties beschikbaar. Gebruik de volledige lijst hieronder.',
     exhibitionsTopReasonDate:

--- a/pages/museumgids/kindvriendelijke-musea-amsterdam.js
+++ b/pages/museumgids/kindvriendelijke-musea-amsterdam.js
@@ -38,6 +38,7 @@ const pageCopy = {
     practical: 'Praktisch:',
     price: 'Prijsinformatie:',
     source: 'Gecontroleerd:',
+    moreDetails: 'Waarom deze keuze?',
     officialSource: 'officiële bron',
     availability: 'Controleer tickets en beschikbaarheid',
     situations: 'Welk museum past bij jullie dag?',
@@ -76,6 +77,7 @@ const pageCopy = {
     practical: 'Practical:',
     price: 'Child price info:',
     source: 'Checked:',
+    moreDetails: 'Why this pick?',
     officialSource: 'official source',
     availability: 'Check tickets and availability',
     situations: 'Which museum fits your day?',
@@ -169,6 +171,38 @@ function DetailLink({ profile, section, children }) {
   );
 }
 
+function FamilyRecommendationCard({ profile, cp, lang, t, featured = false }) {
+  const creditSegments = getCreditSegments(profile.slug, t);
+
+  return (
+    <article id={profile.slug} className={`family-guide__museum${featured ? ' family-guide__museum--featured' : ''}`}>
+      <div className="family-guide__image">
+        <Image src={museumImages[profile.slug]} alt={profile.imageAlt} width={720} height={420} />
+        {creditSegments.length ? <p className="image-credit family-guide__image-credit">{creditSegments.map((segment, index) => <span key={`${profile.slug}-credit-${segment.key}-${index}`}>{index > 0 ? <span aria-hidden="true" className="image-credit-divider">•</span> : null}{segment.url ? <a className="image-credit-link" href={segment.url} target="_blank" rel="noreferrer">{segment.label}</a> : <span className="image-credit-part">{segment.label}</span>}</span>)}</p> : null}
+      </div>
+      <div className="family-guide__museum-body">
+        <p className="family-guide__badge">{getProfileText(profile, lang, 'label')}</p>
+        <h3>{getProfileText(profile, lang, 'name')}</h3>
+        <p className="family-guide__reason">{getProfileText(profile, lang, 'reason')}</p>
+        <dl className="family-guide__at-a-glance">
+          <div><dt>{cp.age}</dt><dd>{getProfileText(profile, lang, 'age')}</dd></div>
+          <div><dt>{cp.duration}</dt><dd>{profile.typicalVisitDurationMin}–{profile.typicalVisitDurationMax} min</dd></div>
+        </dl>
+        <details className="family-guide__details">
+          <summary>{cp.moreDetails}</summary>
+          <p><strong>{cp.conclusion}</strong> {getProfileText(profile, lang, 'rank')}.</p>
+          <h4>{cp.why}</h4><p>{getProfileText(profile, lang, 'why')}</p>
+          <ul>{getProfileText(profile, lang, 'activities').map((activity) => <li key={activity}>{activity}</li>)}</ul>
+          <p><strong>{cp.practical}</strong> {getProfileText(profile, lang, 'practical')}</p>
+          <p><strong>{cp.price}</strong> {getProfileText(profile, lang, 'price')}</p>
+          <p><strong>{cp.source}</strong> {checkedDate} {cp.via} <a href={profile.familySourceUrl} rel="noopener noreferrer" target="_blank">{cp.officialSource}</a>.</p>
+        </details>
+        <div className="family-guide__actions"><TicketCta profile={profile} section="main_card" children={cp.availability} badgeText={cp.partnerlink} /><DetailLink profile={profile} section="main_card">{cp.details}</DetailLink><p className="ticket-button__note family-guide__card-affiliate-note"><span className="ticket-button__note-text"><span className="ticket-button__note-line">{t('ticketsAffiliateIntro')}</span><span className="ticket-button__note-line ticket-button__note-disclosure">{t('ticketsAffiliateDisclosure')} {t('ticketsAffiliatePricesMayVary')}</span></span></p></div>
+      </div>
+    </article>
+  );
+}
+
 export default function FamilyFriendlyMuseumsAmsterdamPage() {
   const { lang, t } = useLanguage();
   const cp = pageCopy[lang] || pageCopy.nl;
@@ -196,10 +230,12 @@ export default function FamilyFriendlyMuseumsAmsterdamPage() {
           <p className="family-guide__method">{cp.method}</p>
         </section>
 
-        <section className="museum-guide-section" aria-labelledby="main-recommendations"><h2 id="main-recommendations">{cp.main}</h2>{mainProfiles.map((profile) => {
-          const creditSegments = getCreditSegments(profile.slug, t);
-          return <article key={profile.slug} id={profile.slug} className="family-guide__museum"><div className="family-guide__image"><Image src={museumImages[profile.slug]} alt={profile.imageAlt} width={720} height={420} />{creditSegments.length ? <p className="image-credit family-guide__image-credit">{creditSegments.map((segment, index) => <span key={`${profile.slug}-credit-${segment.key}-${index}`}>{index > 0 ? <span aria-hidden="true" className="image-credit-divider">•</span> : null}{segment.url ? <a className="image-credit-link" href={segment.url} target="_blank" rel="noreferrer">{segment.label}</a> : <span className="image-credit-part">{segment.label}</span>}</span>)}</p> : null}</div><div className="family-guide__museum-body"><p className="family-guide__badge">{getProfileText(profile, lang, 'label')}</p><h3>{getProfileText(profile, lang, 'name')}</h3><p><strong>{cp.conclusion}</strong> {getProfileText(profile, lang, 'rank')}.</p><h4>{cp.why}</h4><p>{getProfileText(profile, lang, 'why')}</p><ul>{getProfileText(profile, lang, 'activities').map((activity) => <li key={activity}>{activity}</li>)}</ul><p><strong>{cp.age}</strong> {getProfileText(profile, lang, 'age')}</p><p><strong>{cp.duration}</strong> {profile.typicalVisitDurationMin}–{profile.typicalVisitDurationMax} min</p><p><strong>{cp.practical}</strong> {getProfileText(profile, lang, 'practical')}</p><p><strong>{cp.price}</strong> {getProfileText(profile, lang, 'price')}</p><p><strong>{cp.source}</strong> {checkedDate} {cp.via} <a href={profile.familySourceUrl} rel="noopener noreferrer" target="_blank">{cp.officialSource}</a>.</p><div className="family-guide__actions"><TicketCta profile={profile} section="main_card" children={cp.availability} badgeText={cp.partnerlink} /><DetailLink profile={profile} section="main_card">{cp.details}</DetailLink><p className="ticket-button__note family-guide__card-affiliate-note"><span className="ticket-button__note-text"><span className="ticket-button__note-line">{t('ticketsAffiliateIntro')}</span><span className="ticket-button__note-line ticket-button__note-disclosure">{t('ticketsAffiliateDisclosure')} {t('ticketsAffiliatePricesMayVary')}</span></span></p></div></div></article>;
-        })}</section>
+        <section className="museum-guide-section" aria-labelledby="main-recommendations">
+          <h2 id="main-recommendations">{cp.main}</h2>
+          <div className="family-guide__recommendations">
+            {mainProfiles.map((profile, index) => <FamilyRecommendationCard key={profile.slug} profile={profile} cp={cp} lang={lang} t={t} featured={index === 0} />)}
+          </div>
+        </section>
 
         <section className="museum-guide-section" aria-labelledby="situations"><h2 id="situations">{cp.situations}</h2><ul className="family-guide__situations">{cp.situationsList.map((item) => <li key={item}>{item}</li>)}</ul></section>
 

--- a/pages/tentoonstellingen.js
+++ b/pages/tentoonstellingen.js
@@ -166,7 +166,7 @@ function buildTopPickSummary(card, t, language) {
   });
 }
 
-function TopExhibitionCard({ item, t }) {
+function TopExhibitionCard({ item, t, featured = false }) {
   const museumName = item?.museumName || museumNames[item?.slug] || item?.slug;
   const detailUrl = item?.slug ? `/museum/${item.slug}` : '/tentoonstellingen';
   const exhibitionListUrl = item?.slug
@@ -178,7 +178,7 @@ function TopExhibitionCard({ item, t }) {
   });
 
   return (
-    <article className="top-exhibition-card">
+    <article className={`top-exhibition-card${featured ? ' top-exhibition-card--featured' : ''}`}>
       <Link href={detailUrl} className="top-exhibition-card__media-link" aria-label={`${item?.title} — ${museumName}`}>
         <div className="top-exhibition-card__media">
           <Image
@@ -195,6 +195,7 @@ function TopExhibitionCard({ item, t }) {
           <Link href={detailUrl}>{item?.title}</Link>
         </h3>
         <p className="top-exhibition-card__museum">{museumName}</p>
+        {featured ? <p className="top-exhibition-card__prompt">{t('exhibitionsTopFeaturedLabel')}</p> : null}
         {item?.summary ? <p className="top-exhibition-card__summary">{item.summary}</p> : null}
         <p className="top-exhibition-card__links">
           <Link href={detailUrl}>{t('exhibitionsTopViewMuseum')}</Link>
@@ -1024,7 +1025,7 @@ export default function ExhibitionsPage({ exhibitions = [], error = null }) {
         <h2 className="page-subtitle">{t('exhibitionsSeoIntroHeading')}</h2>
         <p className="page-subtitle">{t('exhibitionsSeoIntro')}</p>
       </section>
-      <section className="page-intro" aria-labelledby="top-exhibitions-heading">
+      <section className="page-intro exhibitions-recommendation" aria-labelledby="top-exhibitions-heading">
         <h2 id="top-exhibitions-heading" className="page-subtitle">
           {t('exhibitionsTopHeading')}
         </h2>
@@ -1032,16 +1033,27 @@ export default function ExhibitionsPage({ exhibitions = [], error = null }) {
         {topExhibitionPicks.length === 0 ? (
           <p className="page-subtitle">{t('exhibitionsTopEmpty')}</p>
         ) : (
-          <ul className="top-exhibition-grid" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-            {topExhibitionPicks.map((item) => (
-              <li key={`top-${item.exhibitionId || item.slug}-${item.title}`}>
-                <TopExhibitionCard item={item} t={t} />
-              </li>
-            ))}
-          </ul>
+          <div className="exhibitions-recommendation__content">
+            <TopExhibitionCard item={topExhibitionPicks[0]} t={t} featured />
+            {topExhibitionPicks.length > 1 ? (
+              <div className="exhibitions-recommendation__alternatives">
+                <p className="exhibitions-recommendation__alternatives-label">{t('exhibitionsTopAlternativesLabel')}</p>
+                <ul className="top-exhibition-grid" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                  {topExhibitionPicks.slice(1).map((item) => (
+                    <li key={`top-${item.exhibitionId || item.slug}-${item.title}`}>
+                      <TopExhibitionCard item={item} t={t} />
+                    </li>
+                  ))}
+                </ul>
+                <a className="exhibitions-recommendation__browse" href="#all-exhibitions">
+                  {t('exhibitionsTopBrowseAll')}
+                </a>
+              </div>
+            ) : null}
+          </div>
         )}
       </section>
-      <p className="count">
+      <p id="all-exhibitions" className="count" tabIndex="-1">
         {visibleCards.length} {t('exhibitions')}
       </p>
       <div className="filters-inline" ref={filtersContainerRef}>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1722,9 +1722,38 @@ button.hero-quick-link {
 @media (min-width: 640px){ .grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 @media (min-width: 1024px){ .grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
 
-.top-exhibition-grid { display: grid; gap: 12px; }
-@media (min-width: 640px){ .top-exhibition-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
-@media (min-width: 1100px){ .top-exhibition-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); } }
+.exhibitions-recommendation__content {
+  display: grid;
+  gap: 16px;
+}
+
+.exhibitions-recommendation__alternatives {
+  display: grid;
+  align-content: start;
+  gap: 10px;
+}
+
+.exhibitions-recommendation__alternatives-label,
+.top-exhibition-card__prompt {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.exhibitions-recommendation__browse {
+  width: fit-content;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.top-exhibition-grid { display: grid; gap: 10px; }
+@media (min-width: 640px){ .top-exhibition-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
+@media (min-width: 900px){
+  .exhibitions-recommendation__content { grid-template-columns: minmax(0, 1.1fr) minmax(360px, 0.9fr); gap: 24px; }
+}
 
 .top-exhibition-card {
   background: var(--surface);
@@ -1776,6 +1805,28 @@ button.hero-quick-link {
 .top-exhibition-card__links {
   margin: 2px 0 0;
   font-size: 0.82rem;
+}
+
+.top-exhibition-card--featured {
+  border-color: color-mix(in srgb, var(--accent) 36%, var(--card-border));
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.12);
+}
+
+.top-exhibition-card--featured .top-exhibition-card__media {
+  aspect-ratio: 16 / 8;
+}
+
+.top-exhibition-card--featured .top-exhibition-card__body {
+  padding: 16px;
+  gap: 8px;
+}
+
+.top-exhibition-card--featured .top-exhibition-card__title {
+  font-size: 1.22rem;
+}
+
+.top-exhibition-card--featured .top-exhibition-card__summary {
+  -webkit-line-clamp: 3;
 }
 
 .card {
@@ -4915,6 +4966,94 @@ button.hero-quick-link {
   padding: 1rem;
 }
 
+.family-guide__recommendations {
+  display: grid;
+  gap: 0.75rem;
+}
+
+/* The first recommendation answers the default question; the remaining facts are
+   available on demand so comparing options does not become a long reading task. */
+.family-guide__museum {
+  grid-template-columns: 132px minmax(0, 1fr);
+  gap: 0.9rem;
+  margin: 0;
+  padding: 0.75rem;
+}
+
+.family-guide__museum--featured {
+  border-color: color-mix(in srgb, var(--accent) 34%, var(--panel-border));
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.1);
+}
+
+.family-guide__image img {
+  aspect-ratio: 1 / 1;
+}
+
+.family-guide__museum-body {
+  min-width: 0;
+}
+
+.family-guide__museum h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.family-guide__reason {
+  margin: 0.3rem 0 !important;
+  line-height: 1.4;
+}
+
+.family-guide__at-a-glance {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 1rem;
+  margin: 0.45rem 0;
+  font-size: 0.88rem;
+}
+
+.family-guide__at-a-glance div {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.family-guide__at-a-glance dt {
+  color: var(--ds-color-text-muted, var(--muted));
+}
+
+.family-guide__at-a-glance dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.family-guide__details {
+  margin-top: 0.45rem;
+  font-size: 0.9rem;
+}
+
+.family-guide__details summary {
+  color: var(--accent);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.family-guide__details > :not(summary) {
+  margin-block: 0.45rem;
+}
+
+.family-guide__details h4 {
+  margin-bottom: 0;
+  font-size: 0.9rem;
+}
+
+.family-guide__actions {
+  margin-top: 0.6rem;
+}
+
+.family-guide__actions .ticket-button {
+  padding: 0.55rem 0.75rem;
+  font-size: 0.88rem;
+}
+
 .family-guide__image {
   position: relative;
 }
@@ -4991,6 +5130,10 @@ button.hero-quick-link {
 
   .family-guide__museum {
     grid-template-columns: 1fr;
+  }
+
+  .family-guide__image img {
+    aspect-ratio: 16 / 7;
   }
 
 


### PR DESCRIPTION
### Motivation

- Reduce choice overload on the Exhibitions page while keeping all existing content and actions available.  
- Surface one clear editorial recommendation first and make additional options feel secondary to guide fast decisions.  
- Reuse the Kid-Friendly Guide interaction pattern but make its recommendations more compact via an at-a-glance card plus progressive disclosure.

### Description

- Promote a single featured exhibition and show remaining editorial picks as compact alternatives, with a direct anchor to the full list; implemented in `pages/tentoonstellingen.js` by adding a `featured` flag to `TopExhibitionCard` and restructuring the top-picks layout.  
- Add bilingual labels for the new hierarchy in `lib/translations.js` (`exhibitionsTopFeaturedLabel`, `exhibitionsTopAlternativesLabel`, `exhibitionsTopBrowseAll`).  
- Refactor the Kid-Friendly Guide into compact recommendation cards using a new `FamilyRecommendationCard` component that surfaces key facts (reason, age fit, visit length) and hides longer rationale/details behind a `<details>` element in `pages/museumgids/kindvriendelijke-musea-amsterdam.js`.  
- Add responsive CSS to support the new hierarchy and emphasize a single lead recommendation while keeping the full information density accessible in `styles/globals.css`.

### Testing

- Ran `npm test`, which executes the unit checks for ticket CTA, kid-friendly filters, nearby filters, museum search parsing, exhibition lifecycle, discovery pages SEO and family guide; all tests passed.  
- Ran `npm run build` (Next.js production build) which completed with non-blocking warnings (optional `sharp` recommendation for image optimization).  
- Started `npm run dev` for local verification but the dev server experienced a runtime network/DNS fetch error (`getaddrinfo EAI_AGAIN`) that prevented a full visual sanity-check of the live page in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a634f21dfa48326a0dffd0ecfcbb7ed)